### PR TITLE
R138 security: XSS output-encoding + CSP, refresh-news fail-closed, admin DoS, supply-chain, tests + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,10 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
-      - name: Static checks (syntax, JSON/YAML, merge markers, secrets, assets)
+      - name: Static checks (syntax, JSON/YAML, merge markers, secrets, assets, action-pinning)
         run: npm run check:static
+      - name: Security-logic tests (Edge Function auth invariants + constant-time compare)
+        run: node --test tests/security-logic.mjs
 
   browser:
     name: Browser smoke + internal QA

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -31,7 +31,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@v1
+        # (#R138 SEC) third-party action pinned to a full commit SHA (supply-chain: a moveable tag could be
+        # repointed to malicious code). Dependabot (github-actions ecosystem) proposes SHA bumps. v1 = ab05898.
+        uses: supabase/setup-cli@ab058987d8d6c725971f6cf9d0b5c98467e30bd1
         with:
           version: 2.106.0
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -37,9 +37,10 @@ jobs:
         with:
           fetch-depth: 0          # need full history + tags to resolve an old ref
       - name: Resolve and check out the requested ref
+        env:
+          REF: ${{ inputs.ref }}          # (#R138 SEC) pass via env — NEVER interpolate ${{ inputs.* }} into the shell body (command injection)
         run: |
           set -euo pipefail
-          REF='${{ inputs.ref }}'
           if ! SHA=$(git rev-parse --verify "${REF}^{commit}" 2>/dev/null); then
             echo "::error::Ref '${REF}' does not resolve to a commit in this repository. Refusing to deploy."
             exit 1
@@ -48,12 +49,14 @@ jobs:
           git checkout --quiet "${SHA}"
           echo "ROLLBACK_SHA=${SHA}" >> "$GITHUB_ENV"
       - name: Assemble site (exact tree at the rolled-back commit)
+        env:
+          REF: ${{ inputs.ref }}          # (#R138 SEC) env, not inline interpolation
         run: |
           set -euo pipefail
           rm -rf _site && mkdir -p _site
           git archive "${ROLLBACK_SHA}" | tar -x -C _site
           printf '{ "sha": "%s", "ref": "%s", "runId": "%s", "builtAt": "%s", "rollback": true }\n' \
-            "${ROLLBACK_SHA}" "${{ inputs.ref }}" "${GITHUB_RUN_ID}" "$(date -u +%FT%TZ)" \
+            "${ROLLBACK_SHA}" "${REF}" "${GITHUB_RUN_ID}" "$(date -u +%FT%TZ)" \
             > _site/build-info.json
           cat _site/build-info.json
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,47 @@
+# IntMap security CI (#R138). Static application security testing (CodeQL) for the
+# inline app JS, the Edge Functions (Deno/TS) and the tooling. Findings surface in the
+# repo's Security → Code scanning tab and as PR annotations; they are advisory (they do
+# not block the merge unless the maintainer makes the check required in branch protection).
+#
+# The cheap regex/secret/action-pinning checks + Edge-Function auth-logic tests run in
+# ci.yml (every PR) — they are NOT duplicated here, to avoid double notifications.
+#
+# CodeQL is free for PUBLIC repositories (IntMap is public). On a private repo it needs
+# GitHub Advanced Security; see docs/SECURITY-TESTING.md.
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '17 3 * * 1'   # weekly, Monday 03:17 UTC — catches newly-published CodeQL queries
+  workflow_dispatch:
+
+# Least privilege. CodeQL needs security-events: write to upload its SARIF results.
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codeql:
+    name: CodeQL (JavaScript / TypeScript)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          # Covers index.html/admin.html inline scripts, supabase/functions/**/*.ts (Deno),
+          # and scripts/*.mjs. node_modules is auto-excluded.
+          languages: javascript-typescript
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
+      security-events: write   # upload the SARIF results to code scanning
+      actions: read            # CodeQL reads the workflow/run context
+      packages: read           # resolve any CodeQL packs
     steps:
       - uses: actions/checkout@v4
       - name: Initialize CodeQL

--- a/Architecture.md
+++ b/Architecture.md
@@ -1084,4 +1084,40 @@ supabase db diff --schema public             # driftゼロ確認
 ```
 本番適用は `docs/MIGRATIONS.md`（バックアップ→承認→`db push`）。詳細は `docs/{DATABASE,MIGRATIONS,RLS-TESTING,BACKUP-RESTORE,DATABASE-INCIDENT}.md`。
 
+## 17. セキュリティ基盤 (脅威モデル・XSS防御・Edge Function認証・CI) — R138
+
+セキュリティ監査＋修正の成果。**信頼境界＝サーバー（Supabase）**、ブラウザJSは非信頼。外部から来る値
+（コミュニティ投稿、ニュースRSS見出し、OSM/Nominatimの地名、OSM編集可能なウェブカメラURL、AI出力、URL
+hash）はすべて敵性入力として扱う。詳細は **`docs/SECURITY-ARCHITECTURE.md`**（脅威モデル・データフロー図・
+認証認可・公開値と秘密値の区別・残存リスク・本番手動設定）、報告方法は **`SECURITY.md`**、検査手順は
+**`docs/SECURITY-TESTING.md`**。
+
+### 17.1 XSS出力エンコード（第一防御）
+- 全アプリJSがインライン＋トークンが`localStorage`＝**XSS＝トークン窃取**なので、**各シンクでの正しい出力
+  エンコードが最優先の防御**。非信頼テキストは唯一の正規ヘルパー `window.IntMapSafe`（`<head>`最初の
+  scriptでグローバル定義）を通す。`.html(s)`＝`& < > " '` エスケープ（テキスト/属性両対応）、
+  `.url(s,{allowData})`＝http(s)/mailto/tel（＋rasterのdata:image・svg不可）のみ許可し
+  `javascript:`/`data:text/html`等は`''`。href/src/styleは`html(url(s))`。
+- 修正シンク＝コミュニティ（post.img・title/body・avatar_url）／ニュース6経路（title/publisher/name・
+  window.open scheme）／ウェブカメラpopup（OSM編集可能url→iframe/video/img/href）／地名検索カード
+  （Nominatim display_name/type/country）／USGS/POI。**AtlasのAI返答経路は監査の結果すでに安全**（エスケープ→
+  markdown整形の順・リンクは`https?:`強制）＝無変更。URL hash復元・GeoJSONインポート・エラー表示は監査の
+  結果安全。回帰＝`tests/security.spec.js`（実ブラウザで無害化確認）＋CodeQL。
+
+### 17.2 Edge Function認証
+- **ai-proxy**＝`verify_jwt`＋明示的ユーザー検証（未ログイン401）・プラン別1日上限を`increment_ai_usage`で
+  原子的消費・入力上限（prompt24000字/画像4枚）・鍵/prompt/JWTは非ログ。
+- **refresh-news**（R138で是正）＝**fail-closed**。`REFRESH_SECRET`未設定なら全リクエスト拒否（503・公開実行
+  しない）。秘密は`x-refresh-secret`**ヘッダのみ**（クエリ文字列不可＝ログ流出防止）・**定数時間比較**・POST
+  のみ。cronはヘッダで秘密送信（本番手動設定は`docs/SECURITY-ARCHITECTURE.md §9`）。
+
+### 17.3 CSP・ブラウザ・供給網
+- GitHub Pagesは応答ヘッダ設定不可＋インライン多用＋外部60+ホスト接続のため、nonce/connect-src許可リストは
+  非現実的。採用＝`<meta>` CSP（`object-src 'none'`/`base-uri 'self'`/`frame-src 'self' https: blob:`/
+  `worker-src 'self' blob:`/script-src許可リスト＋インライン許可）でアプリを壊さず注入`<script src=evil>`を
+  遮断。frame-ancestors/XFO/HSTS/Permissions-Policyはヘッダ専用＝不可→文書化（`§6`）。全`target=_blank`に
+  `rel=noopener`。DB側＝`feedback.rating` CHECK（管理画面DoS対策・migration `20260720120000`）。
+- CI＝**CodeQL**（`security.yml`）＋`check:static`に**第三者Action SHA固定**検査＋`tests/security-logic.mjs`
+  （Edge Function認証不変条件）＋pgTAP `03_security_test.sql`。`npm test`で全実行。
+
 *変更履歴の詳細は `DEV-NOTES.md`、守るべき原則は `CONSTITUTION.md` を参照。*

--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -5,6 +5,40 @@
 
 ---
 
+## R138 — セキュリティ監査・強化（XSS出力エンコード・Edge Function認証・CSP・CI・脅威モデル文書）(tag `#R138`)
+
+「業務委託書（セキュリティ強化）」対応。既存実装を**実調査**してから、現実に悪用可能な問題を優先修正。加算的・単一HTML/ビルド無し温存。作業ブランチ `sec/security-hardening-r138`（`origin/main`=R137 起点）。`npm test` 緑（静的88ファイル＋security-logic 10/10＋Playwright: security.spec 7 + smoke 8 = 全緑）。**方針＝一般論でツールを足すのでなく、コード/データフロー/再現条件を確認して実害ベースで優先**。
+
+**調査（並列サブエージェント5本で全攻撃面を実地監査）**: フロントXSS（`index.html` innerHTML 357箇所・esc ヘルパー約15種で強度バラバラ＝`[&<>"']`/`[&<>"]`/`[&<>]`混在）／Edge Functions（ai-proxy・refresh-news）／RLS baseline／admin.html／CI workflows／sw.js。**確定した実脆弱性**（すべて実データ経路で再現）:
+
+### P0/P1 — フロントエンド DOM/格納型 XSS（真因＝属性/テキスト文脈で出力エンコード漏れ）
+1. **コミュニティ `post.img` → `<img src>`**（無エスケープ・**フィード描画で自動発火**）。攻撃者は自分のJWTでSupabase RESTに任意`img`を直接insert可能→全閲覧者で `img="x" onerror=..."` 実行。
+2. コミュニティ投稿 `title`/`body` → ピンhoverツールチップ（無エスケープ）。
+3. 他ユーザー `profiles.avatar_url` → プロフィールカード `background:url('…')`（列grantで本人が任意設定可）。
+4. **ニュース6経路**（RSS `title`/`publisher`/`name`）＝カード・翻訳再描画・desktop 2ツールチップ・mobileポップアップ。RSS `<title>` は `.textContent` で実体参照デコード→`&lt;img&gt;`が生HTML化。#1/#2/#4 は無操作/hoverで発火。
+5. **ウェブカメラpopup**＝OSM編集可能な `url` が iframe(pano)/video/img/href に無エスケープ（誰でもOSMに `webcam=javascript:…` や `x"onload=…` を書ける）→自オリジンで実行。
+6. 地名検索カード＝Nominatim `display_name`/`type`/`country` 無エスケープ。
+- **修正＝唯一の正規サニタイザ `window.IntMapSafe`**（`<head>`最初のscriptでグローバル定義。`.html`＝`[&<>"']`／`.url`＝http(s)/mailto/tel＋rasterのdata:image のみ・`javascript:`等は`''`・tab難読化 `java\tscript:` も除去）を全該当シンクに適用。href/src/styleは`html(url(s))`。**AtlasのAI返答経路は監査で既に安全**（esc→markdown整形の順＝生`<`が先にエスケープ済・リンク`https?:`強制）＝無変更。**URL hash復元・GeoJSONインポート・エラー表示・bundled GeoJSON popupは監査で安全**。`window.open`4箇所＋POI1箇所にscheme guard・`target=_blank`1箇所に`rel=noopener`追加・`escForReader`に引用符エスケープ追加（未配線readerの属性文脈保険）。
+
+### P0 — refresh-news が **fail-open**（真因＝秘密未設定時に認証をスキップ）
+- 旧: `if(secret){…}` ＝ `REFRESH_SECRET` 未設定なら**誰でも**起動可（有料AI＋service_role DB書込を無制限に誘発）。加えて `got!==secret`（非定数時間）＋ `?secret=` クエリ（ログ流出）。
+- 修正: **fail-closed**（秘密未設定=全503・公開実行しない）＋**定数時間比較** `timingSafeEqual`＋**`x-refresh-secret` ヘッダのみ**（クエリ廃止）＋**POSTのみ**。フロントは呼ばない（cron専用）ので運用維持。**本番手動設定必須**（`REFRESH_SECRET`設定＋cronヘッダ送信＋再deploy）＝`docs/SECURITY-ARCHITECTURE.md §9`。
+
+### P2 — admin/CI（実害ベースで低〜中）
+- **admin.html feedback rating DoS**（未認証で悪用可）: `'★'.repeat(r.rating)` が `rating` 無制約（anon insert可）で `repeat(6→-1)` RangeError→**Feedbackタブ全体が描画不能**。修正＝クライアントclamp（0..5）＋**DB CHECK制約**（migration `20260720120000_security_hardening.sql`・`NOT VALID`＝既存不正行でも失敗しない）。`:265` の user_id を inline JS文字列→`data-uid`+委譲listenerへ（uuid型で非悪用だがDiD）。
+- **rollback.yml script injection**: `${{ inputs.ref }}` を shell本体へ直接展開→`env:`経由に変更。
+- **第三者Action `supabase/setup-cli@v1` を full SHA固定**（`ab05898…`・Dependabotが更新）。
+
+**追加した自動テスト**: `tests/security.spec.js`（実ブラウザで委託書の全XSSペイロードを`IntMapSafe`経由でDOM挿入→スクリプト非実行・活性要素0を検証・属性/テキスト両文脈・scheme遮断・**i18n（日/独/露/西/絵文字/キリル/アクセント/長地名）保持**・CSP存在）／`tests/security-logic.mjs`（`node:test`・定数時間比較のunit＋Edge Functionソースの不変条件回帰ガード＝refresh-news fail-closed/ヘッダのみ/POST・ai-proxy JWT必須/入力上限/秘密非ログ）／`supabase/tests/03_security_test.sql`（pgTAP・rating CHECK が6/0/-1拒否・1/5/null許可・`profiles_public`はPII非露出・public-readテーブルはanon書込不可・ai_usageはRPC専用）。
+
+**CI**: `.github/workflows/security.yml`（**CodeQL** JS/TS SAST・週次＋PR・public repoで無料）／`ci.yml`静的jobに `node --test tests/security-logic.mjs` 追加／`scripts/static-checks.mjs` に**第三者Action SHA固定検査**＋Anthropic鍵パターン追加。重複通知回避（CodeQLは`security.yml`のみ・regex系は`ci.yml`のみ）。
+
+**罠/教訓**: (1) `static-checks` の CSS `url()` 資産検査regexが JS `IntMapSafe.url(link)` を誤検知→`(?<![\w.$])`で識別子前置を除外（**セキュリティ検査の弱体化でなく偽陽性除去**・CSS `url()`は必ず非識別子前置）。加えて自分のコメント内 `url(s)`/`url('...')` も誤検知→コメント文言変更。(2) **Editツールで `  ﻿` を打つと実体文字が挿入される**（`\x00-\x20\xa0`は生ASCIIで通る）→正規表現の不可視文字はxxdでバイト確認必須。scheme難読化対策は TAB/LF/CR（=`\x00-\x20`内）で十分。(3) **公開anon key（`sb_publishable_…`）は秘密でない**＝RLS/権限/Edge認証で守る（削除禁止・委託書§2遵守）。(4) service_role/DBパスワード/秘密は一切表示せず・本番Edge Functionは**未deploy**（承認ゲート）・GitHub/Supabase設定は**未変更**（手動手順を最終報告に明記）。
+
+**文書**: `SECURITY.md`（脆弱性報告・公開値の区別）／`docs/SECURITY-ARCHITECTURE.md`（脅威モデル・信頼境界・データフロー図・認証認可・Edge Function一覧・service_role使用箇所・外部API・残存リスク・**本番手動設定**）／`docs/SECURITY-TESTING.md`／`docs/INCIDENT-RESPONSE.md`（セキュリティインシデント初動＝contain優先）／`Architecture.md §17`／本ノート。
+
+---
+
 ## R137 — モバイルUI微調整・順位表示・現在地マーカー・タイムマシン時刻タブ・Atlas重複除去 (tag `#R137`)
 
 ユーザー要望10件を実装。全て `index.html` の**追加/微修正のみ**（既存機能の削除なし・単一HTML/ビルド無し温存）。作業ブランチ `feat/mobile-ui-locate-timemachine-r137`（R136 の上に stacked）。`npm test` 緑（静的83ファイル＋Playwright 11/11・AtlasQA/RegionResolver/UIAudit）。地図描画はブラウザペイン `document.hidden` で WebGL 未init のため、DOM/計算スタイル/純関数をヘッドレス実測で検証（R129〜R136 と同じ方針）。**教訓（新）: `document.hidden` のブラウザペインでは CSS トランジションが進まない → 既存要素に `.active` を後付けして `getComputedStyle` すると遷移開始値（transparent）を読む。ルール検証は「その class を最初から持つ新規要素」を生成して読むのが正解**（`.mode-btn.active` の白背景を fresh 要素で確認）。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security Policy — IntMap
+
+IntMap is a static, client-side world-map web app (single `index.html`) backed by
+Supabase (Auth, Postgres + RLS, Edge Functions) and many public read-only data APIs.
+This document is the entry point for **reporting a vulnerability** and for the two facts
+people most often get wrong about this project.
+
+日本語: 脆弱性の報告方法と「公開前提の値」についてのまとめです。詳細な脅威モデルは
+[`docs/SECURITY-ARCHITECTURE.md`](docs/SECURITY-ARCHITECTURE.md) を参照してください。
+
+---
+
+## Reporting a vulnerability
+
+**Please report privately — do not open a public issue for a security bug.**
+
+1. Preferred: **GitHub → Security → "Report a vulnerability"** (Private Vulnerability
+   Reporting). This keeps the report private until a fix ships.
+2. If that is unavailable, open a **minimal** public issue that says only *"security report —
+   please enable private reporting / provide a contact"* with **no exploit details**.
+
+Please include: affected URL/file, a description, reproduction steps, and impact. Do **not**
+include third-party personal data or run destructive/mass tests against production.
+
+We aim to acknowledge within a few days and to fix P0/P1 issues promptly. Coordinated
+disclosure is appreciated.
+
+### In scope
+- Stored/DOM XSS in the app or admin console.
+- Auth / RLS / Edge-Function authorization bypass (reading or writing another user's data,
+  privilege escalation, AI-quota or plan tampering, unauthenticated abuse of a protected
+  Edge Function).
+- Secret exposure (a **real** secret — see "not a vulnerability" below).
+- SSRF / injection reachable from untrusted input.
+
+### Not a vulnerability (please don't report these)
+- **The Supabase publishable / anon key** (`sb_publishable_…`) in `index.html` / `admin.html`.
+  It is **designed to be public**; security is enforced by Row Level Security, column grants,
+  the SECURITY DEFINER RPCs, and the Edge-Function auth — not by hiding this key. See the
+  architecture doc. (A `service_role`/secret key committed anywhere **is** a vulnerability.)
+- Rate-limiting / cost of the **public** read-only data APIs IntMap calls (they are third-party).
+- Missing HTTP response headers that **GitHub Pages cannot set** (e.g. `X-Frame-Options`,
+  HSTS, `Permissions-Policy`, a header-form CSP). These are documented limitations with the
+  compensating in-page controls listed in `docs/SECURITY-ARCHITECTURE.md §CSP`.
+
+---
+
+## Supported versions
+IntMap ships continuously from `main` (there is no release train). Security fixes land on
+`main` and deploy from there. Only the current `main` is supported.
+
+---
+
+## How security is verified
+Every PR runs, in CI:
+- `npm run check:static` — syntax, committed-secret scan, SQL-PII guard, workflow least-
+  privilege + **third-party-action SHA-pinning** checks.
+- `node --test tests/security-logic.mjs` — Edge-Function auth invariants (refresh-news is
+  fail-closed / header-only / constant-time; ai-proxy requires a JWT + caps input) and the
+  constant-time compare.
+- `tests/security.spec.js` (Playwright) — XSS payloads are neutralised in a **real browser**
+  and i18n text still renders.
+- `.github/workflows/security.yml` — **CodeQL** (JavaScript/TypeScript) SAST.
+- `.github/workflows/db.yml` — **pgTAP** RLS / privilege / constraint tests against a
+  throwaway Postgres (`supabase/tests/*_test.sql`).
+
+Run locally: `npm test` (adds the browser suite). See
+[`docs/SECURITY-TESTING.md`](docs/SECURITY-TESTING.md).

--- a/admin.html
+++ b/admin.html
@@ -259,13 +259,15 @@
       $('fb-count').textContent=(data||[]).length;
       if(!data||!data.length){ tb.innerHTML='<tr><td colspan="7" class="muted">No feedback yet.</td></tr>'; return; }
       tb.innerHTML=data.map(r=>'<tr><td style="white-space:nowrap;">'+esc(new Date(r.created_at).toLocaleString())+'</td>'+
-        '<td style="white-space:nowrap;color:#ffcc00;">'+'★'.repeat(r.rating)+'<span style="opacity:0.3;">'+'★'.repeat(5-r.rating)+'</span></td>'+
+        /* (#R138 SEC) clamp rating 0..5 — feedback.rating is anon-insertable with no CHECK; an out-of-range value (e.g. 6, negative) made String.repeat throw a RangeError that aborted the WHOLE feedback render (admin-tab DoS). */
+        '<td style="white-space:nowrap;color:#ffcc00;">'+(rt=>'★'.repeat(rt)+'<span style="opacity:0.3;">'+'★'.repeat(5-rt)+'</span>')(Math.max(0,Math.min(5,r.rating|0)))+'</td>'+
         '<td style="max-width:420px;">'+esc(r.comment||'')+'</td>'+
         '<td>'+esc(r.lang||'')+'</td><td>'+esc(r.email||'')+'</td>'+
-        '<td style="font-family:monospace;font-size:11px;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:'+(r.user_id?'copy':'default')+';" title="'+esc(r.user_id||'(not logged in)')+'"'+(r.user_id?' onclick="navigator.clipboard&&navigator.clipboard.writeText(\''+esc(r.user_id)+'\')"':'')+'>'+esc(r.user_id||'—')+'</td>'+
+        '<td style="font-family:monospace;font-size:11px;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:'+(r.user_id?'copy':'default')+';" title="'+esc(r.user_id||'(not logged in)')+'"'+(r.user_id?' class="uid-copy" data-uid="'+esc(r.user_id)+'" onclick="window._copyUid(this)"':'')+'>'+esc(r.user_id||'—')+'</td>'+   /* (#R138 SEC) uid via data-attr + static onclick (no user data in an inline JS string) */
         '<td><button class="btn sec sm" onclick="window._fbDel('+r.id+')">Delete</button></td></tr>').join('');
     }catch(e){ tb.innerHTML='<tr><td colspan="7" class="muted">'+esc(e.message||String(e))+'</td></tr>'; }
   }
+  window._copyUid=function(el){ try{ const u=el&&el.getAttribute('data-uid'); if(u&&navigator.clipboard) navigator.clipboard.writeText(u); }catch(_){} };   /* (#R138 SEC) copies the uid from the data-attr; no user-controlled value is ever placed in an inline handler string */
   window._fbDel=async function(id){ if(!confirm('Delete this feedback row?')) return;
     try{ await sb.from('feedback').delete().eq('id',id); }catch(_){}
     loadFb(); };

--- a/docs/INCIDENT-RESPONSE.md
+++ b/docs/INCIDENT-RESPONSE.md
@@ -1,7 +1,58 @@
 # Incident response (production)
 
 A short runbook for when production is broken. Optimised for a solo maintainer: **restore
-service first, investigate second.**
+service first, investigate second.** For a **security** incident (below), the order flips:
+**contain first.**
+
+---
+
+## Security incident (suspected compromise / vulnerability exploited) — #R138
+
+Use this when the problem is a **security** one, not an outage: a secret may have leaked, an
+XSS is firing in the wild, a user is reading/writing another user's data, `refresh-news` is
+being abused, or an Edge Function is being hit maliciously. See the model in
+[`SECURITY-ARCHITECTURE.md`](SECURITY-ARCHITECTURE.md).
+
+**S0 — Classify (what kind?)**
+- **Secret leak** — a `service_role` key, a provider API key, `REFRESH_SECRET`, or DB password
+  appeared somewhere public/logged. *(The Supabase publishable/anon key `sb_publishable_…` is
+  **public by design** — do NOT emergency-rotate it; it changes nothing and breaks clients.)*
+- **XSS / data exposure in the app.**
+- **Auth / RLS bypass** — someone accessed data they shouldn't.
+- **Edge-Function abuse** — cost spike / DB churn from `ai-proxy` or `refresh-news`.
+
+**S1 — Contain (minutes, before investigating)**
+- **Leaked `service_role` / DB password** → **rotate immediately** in Supabase (Settings →
+  API / Database); this invalidates the old key. Re-set Edge-Function secrets. Assume anything
+  it could reach was reachable.
+- **Leaked provider AI key** → revoke/rotate it in the provider console; `supabase secrets set`
+  the new one.
+- **Leaked `REFRESH_SECRET`** → `supabase secrets set REFRESH_SECRET=<new>` and update the cron
+  header. (To take news refresh **fully offline** right now: **unset** `REFRESH_SECRET` — the
+  function is fail-closed and will refuse every request.)
+- **ai-proxy abused** → it already requires a JWT + per-user daily quota; to hard-stop, unset
+  the provider key (returns 502) or lower `PLAN_LIMITS`/redeploy; consider revoking the abusing
+  user's sessions (Supabase → Auth → Users).
+- **XSS confirmed live** → treat session tokens as compromised for anyone who viewed the
+  payload; ship the output-encoding fix (§4 of the architecture doc) and, if data was exposed,
+  consider forcing re-auth (rotate the JWT secret / sign out users).
+- **RLS bypass** → tighten the policy in a migration + add a pgTAP attack case; if a specific
+  grant is the hole, revoke it.
+
+**S2 — Eradicate** — land the real fix on a branch → `npm test` green (add the regression test:
+XSS payload, auth assertion, or pgTAP case that reproduces it) → PR → CI → merge → deploy.
+
+**S3 — Recover & disclose** — verify the fix in production; if user data was exposed, notify
+affected users; coordinate disclosure per [`SECURITY.md`](../SECURITY.md). **Never** post a
+secret value in the issue/PR/notes.
+
+**S4 — Record** — append to `DEV-NOTES.md`: what was exploited, root cause, blast radius, the
+fix, and the **test/check added** so it cannot recur silently.
+
+> A committed-secret leak also has a DB-specific runbook in
+> [`DATABASE-INCIDENT.md`](DATABASE-INCIDENT.md).
+
+---
 
 ## 0. Triage (30 seconds)
 

--- a/docs/SECURITY-ARCHITECTURE.md
+++ b/docs/SECURITY-ARCHITECTURE.md
@@ -1,0 +1,252 @@
+# IntMap — Security Architecture & Threat Model (#R138)
+
+Authoritative description of IntMap's attack surface, trust boundaries, authentication /
+authorization model, the public-vs-secret distinction, and the residual risks + manual
+production settings. Companion to [`SECURITY.md`](../SECURITY.md) (reporting) and
+[`SECURITY-TESTING.md`](SECURITY-TESTING.md) (how to run the checks). Keep this current when
+the data flow, an Edge Function, or the auth model changes.
+
+---
+
+## 1. What we protect (assets)
+
+| Asset | Where | Protected by |
+|---|---|---|
+| User account identity / session (JWT) | Supabase Auth; JWT in browser `localStorage` | Supabase Auth; **correct output-encoding** so XSS can't steal the token |
+| Per-user private data (`favorites`, `user_prefs`, `donations`/`feedback`/`bug_reports` PII, `ai_usage`) | Postgres | **RLS** + column grants + SECURITY DEFINER RPCs |
+| Admin capability (`profiles.is_admin`) | Postgres | RLS (`is_admin()`), no self-escalation (column grant) |
+| Provider API keys (AI, etc.) | Edge Function env (server only) | Never sent to the browser; never logged |
+| AI spend / quota | `ai_usage` + `ai-proxy` | JWT-gated proxy + atomic RPC; refresh-news fail-closed secret |
+| Integrity of what every visitor sees | `index.html` render paths | **XSS output-encoding** (`window.IntMapSafe`) + CSP |
+
+**Adversaries considered:** an anonymous internet user; a *logged-in* user attacking other
+users or the platform (the most important one — they hold a valid JWT and can write their own
+rows via the Supabase REST API, bypassing the UI); and an attacker who can edit **third-party
+data IntMap renders** (OpenStreetMap nodes, a news headline that reaches Google News RSS, a
+Nominatim place name). All three are assumed hostile.
+
+---
+
+## 2. Trust boundaries & data flow
+
+```mermaid
+flowchart LR
+  subgraph Browser["Browser (UNTRUSTED code path — anyone can run it)"]
+    UI["index.html / admin.html<br/>all app JS is INLINE"]
+  end
+  subgraph Untrusted["UNTRUSTED DATA SOURCES"]
+    OSM["OSM / Overpass / Nominatim<br/>(world-editable)"]
+    RSS["Google News RSS"]
+    APIs["60+ read-only data/tile APIs"]
+    AIout["AI model output<br/>(prompt-injectable)"]
+    HASH["URL hash / share link"]
+  end
+  subgraph Supabase["Supabase (TRUST BOUNDARY = server)"]
+    Auth["Auth (JWT)"]
+    PG[("Postgres + RLS")]
+    AIP["Edge fn: ai-proxy<br/>(verify_jwt, quota)"]
+    RN["Edge fn: refresh-news<br/>(no-verify-jwt, SECRET)"]
+  end
+  Providers["AI providers<br/>(server-held key)"]
+
+  UI -- "JWT (anon key + user token)" --> Auth
+  UI -- "RLS-scoped reads/writes (anon key)" --> PG
+  UI -- "JWT" --> AIP
+  AIP -- "server key" --> Providers
+  AIP -- "service_role: quota RPC" --> PG
+  cron["pg_cron"] -- "x-refresh-secret header" --> RN
+  RN -- "server key" --> Providers
+  RN -- "service_role: write news" --> PG
+  Untrusted -. "HOSTILE bytes rendered by UI" .-> UI
+```
+
+**The security rules that follow from this diagram:**
+1. **Everything crossing into `UI` from `Untrusted` is hostile** and must be output-encoded
+   before it touches the DOM (§4). The browser JS is not a trust boundary — an attacker can
+   read and replay any request the page makes.
+2. **Authorization lives on the server** (RLS, RPC EXECUTE grants, Edge-Function auth), never
+   in the client UI. The admin console's client-side gate is UX only; the real boundary is
+   RLS (proven by pgTAP).
+3. **Secrets live only server-side** (Edge-Function env). The browser holds only the
+   *publishable* anon key + the user's own JWT.
+
+---
+
+## 3. Authentication & authorization
+
+- **AuthN:** Supabase Auth (email + Google/Apple OAuth). The session JWT is stored by the
+  Supabase JS client in `localStorage` (its default; Supabase JS cannot use an httpOnly
+  cookie). Consequence: **an XSS = token theft**, which is exactly why §4 is the priority.
+- **AuthZ — data:** Postgres **Row Level Security** on all 15 tables + column-level UPDATE
+  grants so a user can only touch their own rows and **cannot** set `is_admin`/`is_pro`/
+  `plan`/`email` on their profile (no privilege escalation). See
+  [`DATABASE.md`](DATABASE.md) / [`RLS-TESTING.md`](RLS-TESTING.md); enforced baseline in
+  `supabase/migrations/20260718090000_baseline.sql`; attack cases in `supabase/tests/*_test.sql`.
+- **AuthZ — AI quota:** `ai_usage` is writable **only** by the SECURITY DEFINER RPCs
+  `increment_ai_usage` / `refund_ai_usage`, whose EXECUTE is granted to `service_role` only.
+  A user cannot inflate/deflate their own quota.
+- **AuthZ — admin:** `profiles.is_admin`, checked by the `is_admin()` SECURITY DEFINER
+  function (with `search_path=''`) inside the admin-only RLS policies. `admin.html`'s login
+  gate is convenience; a non-admin who loads it still gets **zero** rows from RLS.
+
+---
+
+## 4. Frontend XSS defense (the primary control)
+
+Because the app is a single inline no-build file and holds the session token in
+`localStorage`, **correct output-encoding at every sink is the primary XSS defense** (CSP is
+secondary — see §6). All untrusted text now routes through one canonical, dependency-free,
+globally-defined helper, `window.IntMapSafe` (defined in the first `<head>` script):
+
+- `IntMapSafe.html(s)` — escapes `& < > " '`; safe in HTML **text** and single/double-quoted
+  **attribute** contexts.
+- `IntMapSafe.url(s, {allowData})` — allows **only** `http(s)` / `mailto` / `tel` (+ raster
+  `data:image`, never SVG); `javascript:` / `data:text/html` / `vbscript:` / tab-obfuscated
+  schemes → `''`. For a URL in `href`/`src`/`style`, wrap as `html(url(s))` (scheme-check
+  then quote-escape).
+
+**Sinks hardened this round** (all were confirmed reachable from attacker-controlled data):
+
+| Surface | Field(s) | Trigger |
+|---|---|---|
+| Community feed | `community_posts.img` → `<img src>` | auto-fires on feed render (most severe) |
+| Community map pin | `title` / `body` tooltip | hover a malicious pin |
+| Profile card | another user's `avatar_url` → `background:url()` | view attacker's profile |
+| News | RSS `title` / `publisher` / `name` (6 sinks: card, translate re-render, 2 tooltips, mobile popup) | render / hover / tap |
+| News links | article `link` → `window.open` | http(s)-only guard |
+| Live-camera popup | OSM-editable `url` → iframe/video/img/`href` | open a malicious webcam |
+| Place search card | Nominatim `display_name` / `type` / `country` | search → click a result |
+| Earthquake / POI | USGS `place`, POI `url` | defense-in-depth |
+
+The **Atlas AI reply** pipeline was audited and found **already safe** (it escapes before
+markdown formatting and forces `https?:` on links) — unchanged. Bundled first-party GeoJSON
+popups (ecoregions, volcanoes) are trusted-source and out of scope. **URL hash / share
+restore, GeoJSON file import, and error rendering were audited and are safe** (hash values are
+consumed as numbers/dates/layer-ids, imported properties only feed MapLibre paint layers,
+error messages are escaped).
+
+Regression guards: `tests/security.spec.js` proves the payloads stay inert in a real browser;
+CodeQL runs the JS XSS queries.
+
+---
+
+## 5. Edge Functions & `service_role` usage
+
+| Function | `verify_jwt` | Auth | Uses `service_role` for | Provider key |
+|---|---|---|---|---|
+| `ai-proxy` | **true** | Supabase JWT (login required) → 401 | plan lookup + `increment/refund_ai_usage` RPC | server env only, never logged |
+| `refresh-news` | false (by design) | **fail-closed shared secret** (`x-refresh-secret` header, constant-time) | write `current_news`, read `geo_pins` | server env only |
+
+- **`ai-proxy`** verifies the user, resolves plan → daily limit, **atomically** consumes one
+  use, calls the provider with the server-held key, refunds on failure, and caps input
+  (`MAX_PROMPT=24000`, `MAX_IMAGES=4`). Errors are typed; **prompt / key / JWT are never
+  logged** (metadata only). CORS is `*` but that is safe: every request needs a valid user
+  JWT that a cross-origin site cannot obtain.
+- **`refresh-news`** (#R138) is **fail-closed**: `REFRESH_SECRET` **must** be set or every
+  request is refused (503) — it never runs publicly. The secret is read **only** from the
+  `x-refresh-secret` header (never a URL query, so it can't reach access logs) and compared in
+  **constant time**. Only `POST` triggers a run. This closes the previous fail-open design
+  where an unset secret let anyone trigger paid AI + `service_role` DB writes. `service_role`
+  bypasses RLS, so it is confined to these two server functions and never reaches the browser.
+
+---
+
+## 6. Browser security — CSP & the GitHub Pages limits
+
+IntMap is served by **GitHub Pages**, which **cannot set custom HTTP response headers**, and
+its app JS is **entirely inline** with no build step and fetches from **60+ external hosts**.
+So a nonce/hash `script-src` or a `connect-src` allowlist is impossible without a build the
+project forbids, and would break the app. The chosen posture:
+
+- **In-page CSP (`<meta http-equiv>`), tested to not break the app** — `object-src 'none'`
+  (no plugin XSS), `base-uri 'self'` (no `<base>` hijack), `frame-src 'self' https: blob:`
+  (blocks a `javascript:`/`data:` iframe), `worker-src 'self' blob:`, and a `script-src`
+  allowlist (self + the known CDNs + `'unsafe-inline'`/`'unsafe-eval'`, which are unavoidable
+  for an inline no-build app) that still blocks an injected `<script src=evil-host>`.
+  `connect-src`/`img-src`/`style-src` are intentionally left unrestricted so the data/tile
+  APIs keep working. `<meta name="referrer" content="strict-origin-when-cross-origin">`.
+- **Because `'unsafe-inline'` is unavoidable, output-encoding (§4) — not CSP — is the primary
+  XSS defense.** The CSP is defense-in-depth.
+- **Header-only controls GitHub Pages cannot provide** — `X-Frame-Options` / CSP
+  `frame-ancestors` (clickjacking), HSTS, `Permissions-Policy`, a header-form CSP. Documented
+  here as a residual limitation. Mitigations: IntMap performs no sensitive state-changing
+  action by click alone that clickjacking would meaningfully abuse; all `target="_blank"`
+  links carry `rel="noopener"` and every `window.open` passes `noopener` (no reverse
+  tabnabbing); GitHub Pages is HTTPS-only in practice. If the site is ever moved behind a host
+  that can set headers (e.g. Cloudflare), add `frame-ancestors 'self'` / `X-Frame-Options:
+  SAMEORIGIN` / HSTS there.
+
+---
+
+## 7. External data & privacy
+
+IntMap calls **60+ public, read-only** third-party APIs (map/satellite tiles, elevation/
+weather, routing, statistics, news, geocoding, market data, live cameras, AI providers). The
+**full, user-facing list with exactly what is sent** is in the in-app Privacy Policy
+(`index.html`, "第三者 / Third parties"). Security-relevant notes:
+
+- Some camera-list endpoints are fetched via **public CORS relays** (`corsproxy.io`,
+  `allorigins.win`, `codetabs.com`) — the relay sees the request; no personal data is sent.
+- **No PII in URL query strings**; error monitoring (Sentry, dormant) strips PII / tokens /
+  query strings and only reports IntMap's own exceptions.
+- Analytics: Google Analytics (gtag) + Microsoft Clarity load as third-party scripts
+  (allowlisted in the CSP).
+
+---
+
+## 8. Residual risks (accepted / tracked)
+
+1. **`'unsafe-inline'`/`'unsafe-eval'` in `script-src`** — unavoidable for an inline no-build
+   app; mitigated by output-encoding (§4). Eliminable only by a build step (out of scope).
+2. **JWT in `localStorage`** — Supabase JS default; mitigated by the XSS fixes. An httpOnly
+   cookie would need a different auth transport.
+3. **Header-only browser controls** not settable on GitHub Pages (§6).
+4. **Public CORS relays** for some camera lists (§7) — third-party sees the request.
+5. **AI content-sharing**: when the active provider is OpenAI, submitted text/outputs may be
+   used by OpenAI to improve its models (disclosed in-app); users are told not to submit
+   sensitive data.
+6. **The unwired in-app article reader** (`openArticleInSidebar`, no caller) uses a
+   `sandbox="allow-scripts allow-same-origin"` iframe; `escForReader` now quote-escapes so its
+   attribute sinks are safe, but if it is ever re-wired, drop `allow-same-origin`.
+
+---
+
+## 9. Manual production settings (operator — cannot be set from code)
+
+These are **not** applied by this PR. Apply them in the GitHub / Supabase dashboards. **Never
+put a real secret value in the repo, a PR, or a log.**
+
+### GitHub (repo → Settings)
+- **Code security**: enable **Secret scanning** + **Push protection**; enable **Private
+  vulnerability reporting**; confirm **Dependabot alerts** (config already in
+  `.github/dependabot.yml`); **CodeQL** runs from `security.yml` (free for this public repo).
+- **Branch protection / ruleset on `main`**: require PRs; require status checks **CI** (static
+  + browser) and **Database checks** (and optionally **Security / CodeQL**) to pass; no direct
+  pushes; keep **Actions default permissions = read** (workflows already set least privilege).
+
+### Supabase (project `vpekfwdpurzejrrmacac`)
+- **`refresh-news` — REQUIRED (this PR makes it fail-closed):**
+  1. `supabase secrets set REFRESH_SECRET=<a long random value>` (do not paste the value
+     anywhere in the repo).
+  2. Update the pg_cron job to send the **header** `x-refresh-secret: <REFRESH_SECRET>` when it
+     POSTs the function (header only — never `?secret=` in the URL). Example net.http_post
+     call shape (secret injected from a secure setting, not literal):
+     `select net.http_post(url:='https://<ref>.functions.supabase.co/refresh-news',
+      headers:=jsonb_build_object('Content-Type','application/json','x-refresh-secret', current_setting('app.refresh_secret')));`
+  3. Redeploy: `supabase functions deploy refresh-news --no-verify-jwt` (maintainer, gated).
+     Until the secret is set + cron updated, news refresh is intentionally **off** (fail-safe).
+- **Auth → URL Configuration**: confirm the production **Site URL** and **Redirect URLs** are
+  the real production origins only (no wildcard, no stray localhost) to prevent open-redirect
+  on OAuth.
+- **Postgres version**: confirm `supabase/config.toml` `db.major_version` matches production
+  (for faithful `db diff`).
+- **Migrations**: apply `20260720120000_security_hardening.sql` via the gated flow in
+  [`MIGRATIONS.md`](MIGRATIONS.md) (it is `NOT VALID` — safe against a pre-existing bad row;
+  `VALIDATE CONSTRAINT` after confirming clean).
+- **Backups**: register the backup secrets so `db-backup.yml` can run (see
+  [`BACKUP-RESTORE.md`](BACKUP-RESTORE.md)).
+
+---
+
+## 10. Reporting
+See [`SECURITY.md`](../SECURITY.md).

--- a/docs/SECURITY-TESTING.md
+++ b/docs/SECURITY-TESTING.md
@@ -1,0 +1,77 @@
+# IntMap — Security Testing (#R138)
+
+How to run the security checks, what each one proves, and how to add a case. Companion to
+[`SECURITY-ARCHITECTURE.md`](SECURITY-ARCHITECTURE.md) (threat model) and
+[`RLS-TESTING.md`](RLS-TESTING.md) (the DB harness in depth).
+
+---
+
+## Run everything
+
+```bash
+npm ci
+npm test          # = static-checks  →  security-logic (node --test)  →  Playwright (browser)
+```
+
+The DB / RLS tests need Postgres and run in CI (`.github/workflows/db.yml`); locally they need
+Docker + the Supabase CLI (`supabase db start && supabase db reset --local && supabase test db`).
+
+## Run one layer
+
+| Command | What it proves | Runtime |
+|---|---|---|
+| `npm run check:static` | no committed secrets, no SQL PII, workflows least-privilege, **third-party actions SHA-pinned**, valid JSON/YAML/JS/TS | Node only |
+| `npm run test:security` (`node --test tests/security-logic.mjs`) | refresh-news is fail-closed / header-only / constant-time; ai-proxy needs a JWT + caps input + never logs secrets | Node only |
+| `npx playwright test tests/security.spec.js` | XSS payloads stay **inert in a real browser**; `IntMapSafe.url` blocks bad schemes; i18n renders; CSP present | Chromium |
+| `supabase test db` (or `db.yml` in CI) | RLS + privilege + the `feedback.rating` CHECK (pgTAP) | Postgres |
+| CodeQL (`.github/workflows/security.yml`) | SAST for JS/TS (XSS, injection) → Security tab | CI |
+
+---
+
+## What each test file is
+
+- **`scripts/static-checks.mjs`** — fast, dependency-light gate. Secret patterns (incl. a
+  `service_role` JWT and provider keys), SQL-PII guard, destructive-migration detector,
+  workflow permissions + **`action-pinning`** (third-party `uses:` must be a full 40-hex SHA;
+  `actions/*` and `github/*` are GitHub-owned and may use tags), asset existence.
+- **`tests/security-logic.mjs`** (`node:test`) — unit-tests the constant-time compare, then
+  **reads the Edge-Function sources** and asserts their invariants so a future edit cannot
+  silently reintroduce a fail-open guard, a URL-query secret, an unauthenticated ai-proxy, or
+  an uncapped prompt/image. (No Deno runtime needed — this is the CI-friendly substitute.)
+- **`tests/security.spec.js`** (Playwright) — loads the app, feeds the commission's exact XSS
+  payloads through `IntMapSafe` **into the live DOM**, and asserts no script runs and no active
+  `<img onerror>`/`<svg onload>`/`<script>` is created, in text **and** attribute contexts;
+  checks scheme-blocking and i18n round-trip; checks the CSP meta.
+- **`supabase/tests/03_security_test.sql`** (pgTAP) — the `feedback.rating` CHECK rejects the
+  out-of-range DoS payload, `profiles_public` exposes no PII, public-read tables aren't
+  anon-writable, `ai_usage` is RPC-only. (00/01/02 cover structure / the RLS matrix / the RPCs.)
+
+---
+
+## Adding a case
+
+- **New XSS sink?** Route the untrusted value through `IntMapSafe.html()` (text/attr) or
+  `IntMapSafe.html(IntMapSafe.url(v,{allowData}))` (href/src/style). Add its payload/context to
+  `XSS_PAYLOADS` in `tests/security.spec.js` if it exercises a new context.
+- **New Edge-Function auth rule?** Add an assertion to `tests/security-logic.mjs` (unit or a
+  source regression guard).
+- **New RLS / constraint?** Add to `supabase/tests/03_security_test.sql` using the existing
+  pgTAP helpers (`throws_ok`/`lives_ok`/`ok`/`has_*_privilege`) — see 02 for the impersonation
+  pattern (`set local role` + `request.jwt.claims`). Don't rewrite 00/01/02; add cases.
+
+---
+
+## The commission payload set (kept in sync with `tests/security.spec.js`)
+
+```
+<script>window.__xss = true</script>
+<img src=x onerror="window.__xss = true">
+<svg onload="window.__xss = true">
+"><img src=x onerror=window.__xss=true>
+</style><script>window.__xss=true</script>
+x" onmouseover="window.__xss=true          (attribute breakout)
+x' onmouseover='window.__xss=true          (single-quote breakout)
+javascript:alert(1) · data:text/html,… · vbscript:… · java\tscript:…   (url() must return '')
+```
+Each must render as inert text; and 日本語 / Zürich / Москва / España / emoji / accents /
+long place names must survive `html()` unchanged.

--- a/index.html
+++ b/index.html
@@ -1,6 +1,18 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="light">
 <head>
+  <!-- (#R138 SECURITY) Content Security Policy — pragmatic, defence-in-depth. IntMap is a single no-build file whose
+       JS is ENTIRELY inline and which legitimately fetches from 60+ external hosts, so a nonce script-src or a
+       connect-src allowlist is impossible without a build step (which the project forbids) / would break the app.
+       The PRIMARY XSS defence is therefore correct output-encoding at every sink (window.IntMapSafe, below); this
+       CSP adds the layers that DON'T break an inline app: no plugins (object-src 'none'), no <base> hijack
+       (base-uri 'self'), only https/blob framed content (blocks a javascript:/data: iframe), workers only from
+       blob:, and a script-src that still blocks an injected <script src=evil-host>. 'unsafe-inline'/'unsafe-eval'
+       are unavoidable for an inline no-build app. connect-src/img-src/style-src are intentionally left
+       unrestricted so the 60+ data/tile/API hosts keep working. Header-only controls GitHub Pages cannot set
+       (frame-ancestors, X-Frame-Options, HSTS, Permissions-Policy) are documented in docs/SECURITY-ARCHITECTURE.md. -->
+  <meta http-equiv="Content-Security-Policy" content="object-src 'none'; base-uri 'self'; frame-src 'self' https: blob:; worker-src 'self' blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://unpkg.com https://cdn.jsdelivr.net https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://browser.sentry-cdn.com https://www.clarity.ms https://*.clarity.ms">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-57X5MX0ZPW"></script>
 <script>
 window.dataLayer = window.dataLayer || [];
@@ -34,6 +46,29 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
   (function(){ function push(kind,msg,extra){ try{ window.__imErrors.push({t:Date.now(),kind:kind,msg:String(msg||'').slice(0,400),extra:extra?String(extra).slice(0,300):''}); if(window.__imErrors.length>25) window.__imErrors.shift(); }catch(e){} }
     window.addEventListener('error',function(e){ push('error', e&&e.message, e&&e.filename?((e.filename||'').split('/').pop()+':'+e.lineno):''); });
     window.addEventListener('unhandledrejection',function(e){ var r=e&&e.reason; push('promise', (r&&(r.message||r))||'unhandledrejection'); });
+  })();
+  /* (#R138 SECURITY) Canonical output-encoding helpers — the single source of truth for neutralising
+     UNTRUSTED text before it reaches the DOM. Every value that originates outside our own code
+     (community posts/profiles, news RSS titles/publishers, OSM/Nominatim place names, OSM-editable
+     webcam URLs, GeoJSON properties, AI output, external-API bodies, the URL hash) is HOSTILE and must
+     pass through here. Tiny, dependency-free and defined FIRST so it is global to every later render
+     path (window.IntMapSafe survives IIFE scoping, unlike the ~15 local esc() closures it complements).
+       IntMapSafe.html(s)            → escape & < > " '  → safe in HTML TEXT and single/double-quoted ATTRS
+       IntMapSafe.url(s,{allowData}) → allow ONLY http(s)/mailto/tel (+ optional data:image, NEVER svg);
+                                       javascript:/vbscript:/data:text/html/… → '' (or opts.fallback)
+     For a URL going into an href/src/style attribute: run the scheme check first, THEN quote-escape. */
+  (function(){
+    var MAP={'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};
+    function html(s){ return String(s==null?'':s).replace(/[&<>"']/g,function(c){return MAP[c];}); }
+    function url(s,opt){
+      opt=opt||{}; s=String(s==null?'':s).trim();
+      /* strip whitespace/control chars before the scheme test so "java\tscript:" or a leading \x01 can't sneak a scheme through */
+      var probe=s.replace(/[\x00-\x20\xa0]+/g,'').toLowerCase();
+      if(/^(?:https?:|mailto:|tel:)/.test(probe)) return s;
+      if(opt.allowData && /^data:image\/(?!svg\b)[a-z0-9.+-]+[;,]/.test(probe)) return s;
+      return (opt.fallback!=null?opt.fallback:'');
+    }
+    window.IntMapSafe={ html:html, esc:html, url:url };
   })();
   /* (#R133) OPTIONAL error monitoring → Sentry. DORMANT unless a DSN is configured via
      window.INTMAP_SENTRY_DSN or <meta name="intmap-sentry-dsn" content="…">. Zero weight and
@@ -6996,10 +7031,10 @@ window.addEventListener('DOMContentLoaded', () => {
     const restAdmin=parts.slice(1,4).map(s=>s.trim()).filter(Boolean).join(', ');
     searchCardEl.innerHTML=`<button class="src-card-close" title="${t('close')}">✕</button>
       <div class="src-card">
-        <h4>📍 ${primary}</h4>
-        <div class="src-sub">${restAdmin||country||''}</div>
+        <h4>📍 ${IntMapSafe.html(primary)}</h4>
+        <div class="src-sub">${IntMapSafe.html(restAdmin||country||'')}</div>
         <div class="src-row"><span>${t('coords')}</span><b>${fmtLL(lng,lat)}</b></div>
-        ${type?`<div class="src-row"><span>${currentLang==='jp'?'種別':currentLang==='de'?'Typ':currentLang==='ru'?'Тип':currentLang==='es'?'Tipo':'Type'}</span><b>${type}</b></div>`:''}
+        ${type?`<div class="src-row"><span>${currentLang==='jp'?'種別':currentLang==='de'?'Typ':currentLang==='ru'?'Тип':currentLang==='es'?'Tipo':'Type'}</span><b>${IntMapSafe.html(type)}</b></div>`:''}
         <div class="src-row"><span>${t('elev')}</span><b id="src-elev">${currentLang==='jp'?'取得中...':currentLang==='de'?'Lädt…':currentLang==='ru'?'Загрузка…':currentLang==='es'?'Cargando…':'Loading...'}</b></div>
         <div class="src-actions">
           <button class="primary" id="src-copy">📋 ${t('ctxCopy')}</button>
@@ -9157,7 +9192,7 @@ window.addEventListener('DOMContentLoaded', () => {
         try{map.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:true});}catch(err){}
       }
       const el=ensureMapTooltip(); el.style.display='block';
-      el.innerHTML=`<div style="display:flex;justify-content:space-between;gap:8px;"><span style="color:var(--primary-color);font-weight:600;font-size:11px;">[${f.properties.name}]</span><span style="color:var(--text-muted);font-size:11px;font-weight:500;">${formatCustomDate(f.properties.pubDate)}</span></div><div style="line-height:1.4;font-weight:500;margin-top:4px;">${f.properties.title}</div><div style="color:var(--text-muted);margin-top:6px;font-size:11px;">${f.properties.publisher}</div>`;
+      el.innerHTML=`<div style="display:flex;justify-content:space-between;gap:8px;"><span style="color:var(--primary-color);font-weight:600;font-size:11px;">[${IntMapSafe.html(f.properties.name)}]</span><span style="color:var(--text-muted);font-size:11px;font-weight:500;">${formatCustomDate(f.properties.pubDate)}</span></div><div style="line-height:1.4;font-weight:500;margin-top:4px;">${IntMapSafe.html(f.properties.title)}</div><div style="color:var(--text-muted);margin-top:6px;font-size:11px;">${IntMapSafe.html(f.properties.publisher)}</div>`;   /* (#R138 SEC) news name/title/publisher come from external RSS → escape */
       positionTooltip(map.project(f.geometry.coordinates));
     });
     map.on('mouseleave','news-dots',()=>{
@@ -9176,8 +9211,8 @@ window.addEventListener('DOMContentLoaded', () => {
       const pop=back.querySelector('.m-news-pop'), link=pr.link||'';
       const readLbl=currentLang==='jp'?'記事を読む':currentLang==='de'?'Artikel lesen':currentLang==='ru'?'Читать статью':'Read article';
       const closeLbl=currentLang==='jp'?'閉じる':currentLang==='de'?'Schließen':currentLang==='ru'?'Закрыть':'Close';
-      pop.innerHTML=`<div class="mnp-head"><span class="mnp-loc">${pr.name?('['+pr.name+']'):''}</span><span class="mnp-date">${formatCustomDate(pr.pubDate)}</span></div><div class="mnp-title">${pr.title||''}</div><div class="mnp-pub">${pr.publisher||''}</div><div class="mnp-actions">${link?`<button class="mnp-read" type="button">${readLbl}</button>`:''}<button class="mnp-close" type="button">${closeLbl}</button></div>`;
-      const rb=pop.querySelector('.mnp-read'); if(rb) rb.onclick=()=>{ try{ window.open(link,'_blank','noopener'); }catch(_){} back.classList.remove('show'); };
+      pop.innerHTML=`<div class="mnp-head"><span class="mnp-loc">${pr.name?('['+IntMapSafe.html(pr.name)+']'):''}</span><span class="mnp-date">${formatCustomDate(pr.pubDate)}</span></div><div class="mnp-title">${IntMapSafe.html(pr.title||'')}</div><div class="mnp-pub">${IntMapSafe.html(pr.publisher||'')}</div><div class="mnp-actions">${link?`<button class="mnp-read" type="button">${readLbl}</button>`:''}<button class="mnp-close" type="button">${closeLbl}</button></div>`;   /* (#R138 SEC) escape external news fields */
+      const rb=pop.querySelector('.mnp-read'); if(rb) rb.onclick=()=>{ try{ const _u=IntMapSafe.url(link); if(_u) window.open(_u,'_blank','noopener'); }catch(_){} back.classList.remove('show'); };   /* (#R138 SEC) http(s) only — never open a javascript: link */
       const cb=pop.querySelector('.mnp-close'); if(cb) cb.onclick=()=>back.classList.remove('show');
       back.classList.add('show');
     }
@@ -9187,14 +9222,14 @@ window.addEventListener('DOMContentLoaded', () => {
       const p=e.features[0].properties;
       if(isMobile()){ _showMobileNewsPopup(p); return; }
       /* Desktop: open the article straight in the device's browser (the in-app mini-browser was removed) */
-      if(p.link) window.open(p.link,'_blank','noopener');
+      if(p.link){ const _u=IntMapSafe.url(p.link); if(_u) window.open(_u,'_blank','noopener'); }   /* (#R138 SEC) http(s)-only */
     });
     /* (#R37) The BAND (news-labels = the place-name pill) is the big, natural tap target — make it clickable
        too, not just the tiny dot ("地名ラベルを押しても反応しない"). */
-    map.on('click','news-labels',e=>{ if(!e.features.length) return; const p=e.features[0].properties; if(isMobile()){ _showMobileNewsPopup(p); return; } if(p.link) window.open(p.link,'_blank','noopener'); });
+    map.on('click','news-labels',e=>{ if(!e.features.length) return; const p=e.features[0].properties; if(isMobile()){ _showMobileNewsPopup(p); return; } if(p.link){ const _u=IntMapSafe.url(p.link); if(_u) window.open(_u,'_blank','noopener'); }   /* (#R138 SEC) http(s)-only */ });
     map.on('mousemove','news-labels',e=>{ if(!e.features.length) return; map.getCanvas().style.cursor='pointer'; const f=e.features[0];
       const el=ensureMapTooltip(); el.style.display='block';
-      el.innerHTML=`<div style="display:flex;justify-content:space-between;gap:8px;"><span style="color:var(--primary-color);font-weight:600;font-size:11px;">[${f.properties.name}]</span><span style="color:var(--text-muted);font-size:11px;font-weight:500;">${formatCustomDate(f.properties.pubDate)}</span></div><div style="line-height:1.4;font-weight:500;margin-top:4px;">${f.properties.title}</div><div style="color:var(--text-muted);margin-top:6px;font-size:11px;">${f.properties.publisher}</div>`;
+      el.innerHTML=`<div style="display:flex;justify-content:space-between;gap:8px;"><span style="color:var(--primary-color);font-weight:600;font-size:11px;">[${IntMapSafe.html(f.properties.name)}]</span><span style="color:var(--text-muted);font-size:11px;font-weight:500;">${formatCustomDate(f.properties.pubDate)}</span></div><div style="line-height:1.4;font-weight:500;margin-top:4px;">${IntMapSafe.html(f.properties.title)}</div><div style="color:var(--text-muted);margin-top:6px;font-size:11px;">${IntMapSafe.html(f.properties.publisher)}</div>`;   /* (#R138 SEC) news name/title/publisher come from external RSS → escape */
       positionTooltip(map.project(f.geometry.coordinates)); });
     map.on('mouseleave','news-labels',()=>{ map.getCanvas().style.cursor=''; if(mapTooltipEl) mapTooltipEl.style.display='none'; });
     /* (#R37) MOBILE crosshair → news popup, the same way the DESKTOP cursor reveals the pin under it
@@ -9673,9 +9708,9 @@ window.addEventListener('DOMContentLoaded', () => {
     if(a.titleTranslated && a.titleTranslated!==item.title){
       const lang=a.titleOrigLangLabel||a.titleOrigLang||'';
       const note=lang?(currentLang==='jp'?('（原文: '+lang+'）'):currentLang==='ru'?('(ориг.: '+lang+')'):('(orig: '+lang+')')):'';
-      return a.titleTranslated + (note?`<div class="news-origlang">${note}</div>`:'');
+      return IntMapSafe.html(a.titleTranslated) + (note?`<div class="news-origlang">${IntMapSafe.html(note)}</div>`:'');   /* (#R138 SEC) titleTranslated/lang are AI output → escape */
     }
-    return item.title;
+    return IntMapSafe.html(item.title);   /* (#R138 SEC) news title comes from external RSS → escape (this string is written to innerHTML by the card + rerenderNewsFeedTitles) */
   }
   /* (#R79b) In workspace mode the News window can be hidden (it is hidden by default now). When it is,
      news pins must NOT sit on the map ("ニュースウィンドウがオンになってないのに勝手にマップ上に現れる").
@@ -9773,15 +9808,15 @@ window.addEventListener('DOMContentLoaded', () => {
       else chipCls='loc-chip unmapped';
       const readLabel = currentLang==='jp'?'記事を読む ↗':currentLang==='de'?'Lesen ↗':currentLang==='ru'?'Читать ↗':currentLang==='es'?'Leer ↗':'Read ↗';
       card.innerHTML=`<button class="btn-bookmark ${bm?'active':''}">★</button>
-        <div class="news-head"><span class="${chipCls}">${item.analysis.name||(currentLang==='jp'?'場所不明':currentLang==='de'?'Ort unbekannt':currentLang==='ru'?'Место неизвестно':currentLang==='es'?'Ubicación desconocida':'Location unknown')}</span><small class="news-date">${formatCustomDate(item.pubDate)}</small></div>
+        <div class="news-head"><span class="${chipCls}">${IntMapSafe.html(item.analysis.name)||(currentLang==='jp'?'場所不明':currentLang==='de'?'Ort unbekannt':currentLang==='ru'?'Место неизвестно':currentLang==='es'?'Ubicación desconocida':'Location unknown')}</span><small class="news-date">${formatCustomDate(item.pubDate)}</small></div>
         <div class="news-title">${newsTitleHTML(item)}</div>
-        <div class="news-foot"><small class="news-pub">${item.publisher}</small><button class="btn-read">${readLabel}</button></div>`;
+        <div class="news-foot"><small class="news-pub">${IntMapSafe.html(item.publisher)}</small><button class="btn-read">${readLabel}</button></div>`;   /* (#R138 SEC) name/publisher from external RSS → escape (newsTitleHTML self-escapes) */
       card.querySelector('.btn-bookmark').onclick=async(e)=>{ e.stopPropagation();
         if(currentUser){ const on=await toggleFavorite(item.link,item.title); if(currentMode==='saved')startNews(); else card.querySelector('.btn-bookmark').classList.toggle('active',on); }
         else { /* guest: keep a local list until they log in */ if(bookmarks.includes(item.link))bookmarks=bookmarks.filter(b=>b!==item.link); else bookmarks.push(item.link); saveBookmarks(); if(currentMode==='saved')startNews(); else card.querySelector('.btn-bookmark').classList.toggle('active'); }
       };
       /* (#R11) Read article → open directly in the device's browser (reverted per request). */
-      card.querySelector('.btn-read').onclick=(e)=>{ e.stopPropagation(); window.open(item.link,'_blank','noopener'); };
+      card.querySelector('.btn-read').onclick=(e)=>{ e.stopPropagation(); const _u=IntMapSafe.url(item.link); if(_u) window.open(_u,'_blank','noopener'); };   /* (#R138 SEC) http(s)-only */
       /* Whole card → fly to the map location (replaces the old "Show on map" button) */
       card.onclick=()=>{ if(map&&item.analysis.loc) map.flyTo({center:item.analysis.loc,zoom:4,speed:1.0}); };
       item._cardEl=card; /* lets the translation pass update this title in place */
@@ -9801,7 +9836,7 @@ window.addEventListener('DOMContentLoaded', () => {
   function stripHTML(s){ const d=document.createElement('div'); d.innerHTML=s||''; return d.textContent||d.innerText||''; }
   /* ===== In-sidebar article reader (the sidebar becomes the reading zone) ===== */
   let readerOpen=false, readerCurrent=null;
-  function escForReader(s){ const d=document.createElement('div'); d.textContent=(s==null?'':String(s)); return d.innerHTML; }
+  function escForReader(s){ const d=document.createElement('div'); d.textContent=(s==null?'':String(s)); return d.innerHTML.replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }   /* (#R138 SEC) textContent escapes &<> but NOT quotes; this helper is used in attribute context (href/src) too, so quote-escape as well (prevents attribute breakout / srcdoc injection) */
   const READER_NOISE=new Set(['edit','[edit]','skip to content','watch live','sign in','log in','menu','advertisement','home','news','sport','business','technology','more','share','save','reuters','associated press','follow us','related topics','watch','listen']);
   function cleanReaderMarkdown(md){
     let firstImg=''; let text=md||'';
@@ -10292,7 +10327,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const _cimg=info.img||'';
       cards+=`<div class="wiki-card" id="card-${info.id}" onclick="flyToLoc(${info.loc[0]},${info.loc[1]})" onmouseenter="triggerLayerHover('${info.layerRef||''}',true); highlightDashMarker('${info.id}',true)" onmouseleave="triggerLayerHover('${info.layerRef||''}',false); highlightDashMarker('${info.id}',false)">
         <div class="wiki-card-img${_cimg?'':' wc-noimg'}" data-type="${info.type||''}"${_cimg?` style="background-image:url('${_cimg}');"`:''}><span class="wiki-card-badge">${dashBadgeLabel(info.badge)}</span></div>
-        <div class="wiki-card-content"><h4 class="wiki-card-title">${info.title[currentLang]||info.title.en}</h4><p class="wiki-card-body">${info.body[currentLang]||info.body.en}</p>${specsHTML}<div class="wiki-card-footer"><a href="${info.wiki[currentLang]||info.wiki.en}" target="_blank" class="wiki-link" onclick="event.stopPropagation()">${dict.readWiki}</a></div></div></div>`;
+        <div class="wiki-card-content"><h4 class="wiki-card-title">${info.title[currentLang]||info.title.en}</h4><p class="wiki-card-body">${info.body[currentLang]||info.body.en}</p>${specsHTML}<div class="wiki-card-footer"><a href="${IntMapSafe.html(IntMapSafe.url(info.wiki[currentLang]||info.wiki.en)||'#')}" target="_blank" rel="noopener" class="wiki-link" onclick="event.stopPropagation()">${dict.readWiki}</a></div></div></div>`;
     });
     cards+='</div>';
     /* (#R20) top-level Places | Events switch, then the existing category nav */
@@ -14920,7 +14955,7 @@ window.addEventListener('DOMContentLoaded', () => {
         }
         const el=ensureMapTooltip(); el.style.display='block';
         const p=f.properties;
-        el.innerHTML=`<div style="color:#34c759;font-weight:600;font-size:13px;">💬 ${p.title}</div><div style="line-height:1.4;margin-top:4px;color:var(--text-muted);font-size:11px;">${p.body||''}</div>`;
+        el.innerHTML=`<div style="color:#34c759;font-weight:600;font-size:13px;">💬 ${IntMapSafe.html(p.title)}</div><div style="line-height:1.4;margin-top:4px;color:var(--text-muted);font-size:11px;">${IntMapSafe.html(p.body||'')}</div>`;   /* (#R138 SEC) community post title/body are user-generated → escape (stored XSS on pin hover) */
         positionTooltip(e.point);
       });
       map.on('mouseleave','community-dots',()=>{
@@ -15014,7 +15049,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const jp=currentLang==='jp', mine=currentUser&&post.userId===currentUser.id;
     const canDel = currentUser && (mine || currentUser.isAdmin);
     const cat=commCatById(post.category||'general');
-    const imgHtml=post.img?`<img class="comm-post-img" src="${post.img}" data-id="${post.id}" alt="">`:'';
+    const imgHtml=post.img?`<img class="comm-post-img" src="${IntMapSafe.html(IntMapSafe.url(post.img,{allowData:true}))}" data-id="${post.id}" alt="">`:'';   /* (#R138 SEC) post.img is user-controlled (direct Supabase insert) → scheme-validate + quote-escape (stored XSS, auto-fires on feed render) */
     const edited=post.editedTs?` · <span class="comm-edited">${t('commEdited')}</span>`:'';
     const cmts=post.comments||[];
     return `<div class="comm-post" id="comm-post-${post.id}">
@@ -15841,7 +15876,7 @@ window.addEventListener('DOMContentLoaded', () => {
       else { const nm=(currentUser.name||currentUser.email.split('@')[0]), img=window.imGetAvatarImg();
         /* (#R30) name wrapped in .acct-name so mobile can show the avatar ONLY (the full name made the
            account / feedback / settings row wrap = "横一列に並ばず改行されてしまう"). */
-        b.innerHTML = (img?`<span class="acct-av" style="background:url('${img}') center/cover;"></span>`:`<span class="acct-av">${window.imGetAvatar()}</span>`)+'<span class="acct-name">'+escapeHtml(nm)+'</span>'; }
+        b.innerHTML = (img?`<span class="acct-av" style="background:url('${IntMapSafe.html(IntMapSafe.url(img,{allowData:true}))}') center/cover;"></span>`:`<span class="acct-av">${IntMapSafe.html(window.imGetAvatar())}</span>`)+'<span class="acct-name">'+escapeHtml(nm)+'</span>'; }   /* (#R138 SEC) validate+escape the stored avatar data-URL */
     }
     /* Sidebar EN/JP toggle shows only when logged OUT; logged-in users switch language in Settings. */
     const lt=document.querySelector('.lang-toggle'); if(lt) lt.style.display = currentUser ? 'none' : 'flex';
@@ -15860,7 +15895,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const data=r.data; if(data){ name=data.display_name||name; bio=data.bio||''; avatar=data.avatar_url||''; }
     }catch(_){} }
     let h=0; for(let i=0;i<name.length;i++) h=(h*31+name.charCodeAt(i))|0;
-    const ava = avatar?`<div style="width:66px;height:66px;border-radius:50%;background:url('${avatar}') center/cover;margin:0 auto 10px;"></div>`:`<div style="width:66px;height:66px;border-radius:50%;margin:0 auto 10px;display:flex;align-items:center;justify-content:center;font-size:27px;font-weight:700;color:#fff;background:hsl(${Math.abs(h)%360},58%,46%)">${escapeHtml((name[0]||'?').toUpperCase())}</div>`;
+    const ava = avatar?`<div style="width:66px;height:66px;border-radius:50%;background:url('${IntMapSafe.html(IntMapSafe.url(avatar,{allowData:true}))}') center/cover;margin:0 auto 10px;"></div>`:`<div style="width:66px;height:66px;border-radius:50%;margin:0 auto 10px;display:flex;align-items:center;justify-content:center;font-size:27px;font-weight:700;color:#fff;background:hsl(${Math.abs(h)%360},58%,46%)">${escapeHtml((name[0]||'?').toUpperCase())}</div>`;   /* (#R138 SEC) another user's avatar_url is attacker-controllable → scheme-validate + quote-escape (stored XSS via CSS background breakout) */
     m.innerHTML=`<div style="background:var(--card-bg);color:var(--text-main);border-radius:16px;box-shadow:var(--shadow);padding:24px;width:100%;max-width:320px;text-align:center;">${ava}<h2 style="margin:0 0 6px;font-size:18px;">${escapeHtml(name||'?')}</h2><p style="color:var(--text-muted);font-size:13px;line-height:1.55;white-space:pre-wrap;margin:0 0 16px;">${bio?escapeHtml(bio):(currentLang==='jp'?'自己紹介はまだありません。':currentLang==='de'?'Noch keine Bio.':currentLang==='ru'?'Пока без описания.':currentLang==='es'?'Aún sin biografía.':'No bio yet.')}</p><button id="pm-close" style="width:100%;background:var(--input-bg);color:var(--text-main);border:none;padding:10px;border-radius:9px;font-weight:600;cursor:pointer;">${currentLang==='jp'?'閉じる':currentLang==='de'?'Schließen':currentLang==='ru'?'Закрыть':currentLang==='es'?'Cerrar':'Close'}</button></div>`;
     m.querySelector('#pm-close').onclick=()=>{ m.style.display='none'; };
     m.style.display='flex';
@@ -27840,7 +27875,7 @@ window.addEventListener('DOMContentLoaded', () => {
         const vb=el&&el.querySelector('.poi-web');
         if(vb&&p.web){ let u=String(p.web); if(!/^https?:/i.test(u)) u='https://'+u; vb.onclick=()=>{ try{ window.open(u,'_blank','noopener'); }catch(_){} }; }
         const ab=el&&el.querySelector('.poi-art');
-        if(ab&&p.url){ ab.onclick=()=>{ try{ window.open(String(p.url),'_blank','noopener'); }catch(_){} }; }
+        if(ab&&p.url){ ab.onclick=()=>{ try{ const _u=IntMapSafe.url(String(p.url)); if(_u) window.open(_u,'_blank','noopener'); }catch(_){} }; }   /* (#R138 SEC) http(s)-only (matches the website-button guard) */
       }catch(_){} });
       map.on('mouseenter','nlq-poi-c',()=>{ try{ map.getCanvas().style.cursor='pointer'; }catch(_){} });
       return true; }catch(_){ return false; } }
@@ -31218,7 +31253,7 @@ window.addEventListener('DOMContentLoaded', () => {
         /* (#R32) className 'plc-popup' → themed dark/light bg + readable text. The default white maplibre popup
            inherited the page text color (near-white in dark mode) = white-on-white "ポップアップがダークモードで
            は見えない". */
-        new maplibregl.Popup({closeButton:true,className:'plc-popup'}).setLngLat(e.lngLat).setHTML('<div style="font-size:12.5px;line-height:1.5;color:var(--text-main);"><b style="color:#ff453a;">M '+(p.mag!=null?(+p.mag).toFixed(1):'?')+'</b><br>'+(p.place||'')+'<br><span style="color:var(--text-muted);">'+when+'</span></div>').addTo(map); }); map.on('mouseenter','eq-pt',()=>{ map.getCanvas().style.cursor='pointer'; }); map.on('mouseleave','eq-pt',()=>{ map.getCanvas().style.cursor=''; }); }catch(_){} }
+        new maplibregl.Popup({closeButton:true,className:'plc-popup'}).setLngLat(e.lngLat).setHTML('<div style="font-size:12.5px;line-height:1.5;color:var(--text-main);"><b style="color:#ff453a;">M '+(p.mag!=null?(+p.mag).toFixed(1):'?')+'</b><br>'+IntMapSafe.html(p.place||'')+'<br><span style="color:var(--text-muted);">'+when+'</span></div>').addTo(map); }); map.on('mouseenter','eq-pt',()=>{ map.getCanvas().style.cursor='pointer'; }); map.on('mouseleave','eq-pt',()=>{ map.getCanvas().style.cursor=''; }); }catch(_){} }
       try{ if(on&&window._registerLayerOpacity){ const el=window._registerLayerOpacity('eq',['Earthquakes (USGS)','地震（USGS）'],['eq-pt'],'bx-eq');
         if(el){ let ctl=el.querySelector('.bx-eqwin'); if(!ctl){ ctl=document.createElement('div'); ctl.className='bx-eqwin'; ctl.style.cssText='display:flex;gap:5px;flex-wrap:wrap;margin-top:6px;'; el.appendChild(ctl); }
           const opts=[['day',jp()?'24時間':'24h'],['week',jp()?'7日':'7d'],['month',jp()?'30日(M4.5+)':'30d M4.5+'],['year',jp()?'1年(M6+)':'1yr M6+']];
@@ -31377,9 +31412,9 @@ window.addEventListener('DOMContentLoaded', () => {
       const onerr="this.style.display='none';var n=this.parentNode.querySelector('.wc-off');if(n)n.style.display='block';";
       let media='';
       if(kind==='yt'){ const yt=ytId(url); media='<div style="position:relative;'+box+'height:170px;border-radius:11px;overflow:hidden;background:#000;"><iframe src="https://www.youtube-nocookie.com/embed/'+yt+'?autoplay=1&mute=1&playsinline=1&rel=0" width="100%" height="100%" style="border:0;position:absolute;inset:0;" allow="autoplay; encrypted-media; picture-in-picture" allowfullscreen referrerpolicy="strict-origin-when-cross-origin" loading="lazy"></iframe></div>'; }
-      else if(kind==='pano'){ media='<div style="position:relative;'+box+'height:175px;border-radius:11px;overflow:hidden;background:#000;"><iframe src="'+url+'" width="100%" height="100%" style="border:0;position:absolute;inset:0;" allowfullscreen referrerpolicy="no-referrer" loading="lazy"></iframe></div>'; }
-      else if(kind==='video'){ media='<div style="position:relative;'+box+'">'+'<video class="wc-live" src="'+url+'" autoplay muted loop playsinline style="'+box+'border-radius:11px;display:block;background:#000;" onerror="'+onerr+'"></video>'+offlineMsg+'</div>'; }
-      else { const base=(kind==='tfl')?String(p.img||''):url; const bust=base+(base.indexOf('?')>=0?'&':'?')+'_t='+Date.now(); media='<div style="position:relative;'+box+'">'+'<img class="wc-live" data-base="'+base.replace(/"/g,'&quot;')+'" src="'+bust+'" referrerpolicy="no-referrer" style="'+box+'border-radius:11px;display:block;background:#000;min-height:60px;" onerror="'+onerr+'">'+offlineMsg+'</div>'; }
+      else if(kind==='pano'){ media='<div style="position:relative;'+box+'height:175px;border-radius:11px;overflow:hidden;background:#000;"><iframe src="'+IntMapSafe.html(IntMapSafe.url(url))+'" width="100%" height="100%" style="border:0;position:absolute;inset:0;" allowfullscreen referrerpolicy="no-referrer" loading="lazy"></iframe></div>'; }   /* (#R138 SEC) OSM-editable webcam url → http(s)-only + escape (an unvalidated javascript: iframe src runs in our origin) */
+      else if(kind==='video'){ media='<div style="position:relative;'+box+'">'+'<video class="wc-live" src="'+IntMapSafe.html(IntMapSafe.url(url))+'" autoplay muted loop playsinline style="'+box+'border-radius:11px;display:block;background:#000;" onerror="'+onerr+'"></video>'+offlineMsg+'</div>'; }
+      else { const base=IntMapSafe.url((kind==='tfl')?String(p.img||''):url); const bust=base?(base+(base.indexOf('?')>=0?'&':'?')+'_t='+Date.now()):''; media='<div style="position:relative;'+box+'">'+'<img class="wc-live" data-base="'+IntMapSafe.html(base)+'" src="'+IntMapSafe.html(bust)+'" referrerpolicy="no-referrer" style="'+box+'border-radius:11px;display:block;background:#000;min-height:60px;" onerror="'+onerr+'">'+offlineMsg+'</div>'; }   /* (#R138 SEC) validate+escape webcam image url */
       const srcTxt=p.attr||(kind==='tfl'?'© Transport for London':'© OpenStreetMap');
       const refreshTxt=(kind!=='yt'&&kind!=='pano')?(LLw('↻ live','↻ ライブ','↻ live','↻ вживую','↻ en vivo')+' · '):'';
       /* (#R87) a station with several camera views (Finland weather stations) → switchable thumbnails; tapping one
@@ -31390,7 +31425,7 @@ window.addEventListener('DOMContentLoaded', () => {
         +' <span style="font-size:9px;font-weight:800;letter-spacing:.4px;background:#ff3b30;color:#fff;border-radius:4px;padding:1px 5px;">LIVE</span></div>'
         +media+gallery
         +'<div style="margin-top:7px;display:flex;justify-content:space-between;align-items:center;gap:8px;"><span style="font-size:10px;color:var(--text-muted);">'+refreshTxt+srcTxt+'</span>'
-        +'<a href="'+(url||p.video||p.img||'#')+'" target="_blank" rel="noopener" style="font-size:11.5px;font-weight:600;color:var(--primary-color);text-decoration:none;white-space:nowrap;">'+LLw('Source','ソース','Quelle','Источник','Fuente')+' ↗</a></div>';
+        +'<a href="'+IntMapSafe.html(IntMapSafe.url(url||p.video||p.img)||'#')+'" target="_blank" rel="noopener" style="font-size:11.5px;font-weight:600;color:var(--primary-color);text-decoration:none;white-space:nowrap;">'+LLw('Source','ソース','Quelle','Источник','Fuente')+' ↗</a></div>';   /* (#R138 SEC) http(s)-only + escape */
       if(popup) popup.remove();
       popup=new maplibregl.Popup({offset:14,closeButton:true,maxWidth:'330px',className:'plc-popup webcam-popup'}).setLngLat(c).setHTML(html).addTo(map);
       try{ popup.on('close',_stopRefresh); }catch(_){}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:smoke": "playwright test tests/smoke.spec.js",
     "test:qa": "playwright test tests/internal-qa.spec.js",
     "test:e2e": "playwright test",
-    "test": "node scripts/static-checks.mjs && playwright test",
+    "test:security": "node --test tests/security-logic.mjs",
+    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs && playwright test",
     "report": "playwright show-report"
   },
   "devDependencies": {

--- a/scripts/static-checks.mjs
+++ b/scripts/static-checks.mjs
@@ -73,6 +73,7 @@ const SECRET_PATTERNS = [
   { name: 'GitHub token', re: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/ },
   { name: 'Slack token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}/ },
   { name: 'OpenAI key', re: /\bsk-(?:proj-)?[A-Za-z0-9]{32,}/ },
+  { name: 'Anthropic key', re: /\bsk-ant-[A-Za-z0-9_-]{20,}/ },   // (#R138) ai-proxy provider key
 ];
 function jwtIsServiceRole(tok) {
   try {
@@ -175,6 +176,19 @@ for (const f of yamlFiles) {
     if (/pull_request_target/.test(t) && /actions\/checkout/.test(t)) {
       warn('workflow-security', `${f.rel}: uses pull_request_target with checkout — never build/run untrusted PR code with repo secrets`);
     }
+    // (#R138) Supply-chain: a THIRD-PARTY action pinned to a moveable tag can be repointed to
+    // malicious code. First-party actions/* and github/* are GitHub-owned (tags acceptable);
+    // everything else should be pinned to a full 40-hex commit SHA (Dependabot bumps them).
+    for (const m of t.matchAll(/(?:^|\s)uses:\s*([A-Za-z0-9._-]+)\/([A-Za-z0-9._\/-]+)@(\S+)/g)) {
+      const owner = m[1], ref = (m[3] || '').replace(/["']/g, '');
+      if (owner === 'actions' || owner === 'github') continue;         // GitHub-owned first-party
+      if (!/^[0-9a-f]{40}$/.test(ref)) {
+        warn('action-pinning', `${f.rel}: third-party action ${m[1]}/${m[2]}@${ref} is not SHA-pinned (supply-chain: pin to a full commit SHA)`);
+      }
+    }
+    // NOTE: expression-injection into run: blocks (${{ inputs.* }} → shell) is checked by CodeQL's
+    // dedicated Actions query (.github/workflows/security.yml) — a regex can't tell a run: body from a
+    // later step's env: block on this YAML, so it is not re-implemented here (avoids false positives).
   }
 }
 
@@ -185,7 +199,10 @@ for (const htmlName of ['index.html', 'admin.html']) {
   const t = read(f);
   const refs = new Set();
   for (const m of t.matchAll(/(?:src|href)\s*=\s*"([^"]+)"/g)) refs.add(m[1]);
-  for (const m of t.matchAll(/url\(\s*['"]?([^'")]+)['"]?\s*\)/g)) refs.add(m[1]);
+  // CSS url(...) asset refs ONLY. The negative lookbehind excludes JS method calls like
+  // `IntMapSafe.url(link)` / `foo.url(x)` — a CSS url() is always preceded by ':', ',', space
+  // or '(', never by an identifier char or '.', so no real CSS asset ref is missed. (#R138)
+  for (const m of t.matchAll(/(?<![\w.$])url\(\s*['"]?([^'")]+)['"]?\s*\)/g)) refs.add(m[1]);
   for (let r0 of refs) {
     r0 = r0.trim();
     if (!r0 || /^(https?:|data:|blob:|mailto:|tel:|#|\/\/|javascript:)/i.test(r0)) continue;

--- a/supabase/functions/refresh-news/index.ts
+++ b/supabase/functions/refresh-news/index.ts
@@ -20,7 +20,8 @@
 //    5. Prune anything older than 72 h (by pub_date) from the table.
 //
 //  Deploy:   supabase functions deploy refresh-news --no-verify-jwt
-//  Secrets:  supabase secrets set REFRESH_SECRET=<random>   (optional but recommended)
+//  Secrets:  supabase secrets set REFRESH_SECRET=<random>   (#R138 REQUIRED — fail-closed: with the secret
+//            unset the function refuses every request. The caller must send the x-refresh-secret header.)
 //            # AI geocoding reuses the SAME server-held key/provider as ai-proxy:
 //            supabase secrets set AI_PROVIDER=anthropic        (anthropic | openai | gemini)
 //            supabase secrets set ANTHROPIC_API_KEY=sk-ant-... (or OPENAI_API_KEY / GEMINI_API_KEY)
@@ -36,7 +37,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.4";
 const cors = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-refresh-secret",
-  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 
 // ---- Editions: the two primary UI languages. (Multi-language auto-translate
@@ -480,14 +481,40 @@ async function fetchEdition(topic: string, q: string): Promise<RawItem[]> {
   } catch { return []; }
 }
 
+// (#R138 SECURITY) Constant-time string comparison — avoids a timing side-channel that could let an
+// attacker recover REFRESH_SECRET byte-by-byte. Length difference is folded in without an early return.
+function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a), bb = enc.encode(b);
+  let diff = ab.length ^ bb.length;
+  const n = Math.max(ab.length, bb.length);
+  for (let i = 0; i < n; i++) diff |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+  return diff === 0;
+}
+
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
+  // (#R138 SECURITY) Only POST triggers a run. A GET could carry the secret in the URL (→ access logs)
+  // and makes this expensive job (Google-News fetch + paid AI geocoding + service-role DB writes) trivially
+  // triggerable by a link prefetch / crawler.
+  if (req.method !== "POST") return new Response(JSON.stringify({ error: "method_not_allowed" }), { status: 405, headers: { ...cors, "Content-Type": "application/json" } });
 
-  // Optional shared-secret guard (set REFRESH_SECRET to lock the endpoint down).
-  const secret = Deno.env.get("REFRESH_SECRET");
-  if (secret) {
-    const got = req.headers.get("x-refresh-secret") || new URL(req.url).searchParams.get("secret");
-    if (got !== secret) return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401, headers: { ...cors, "Content-Type": "application/json" } });
+  // (#R138 SECURITY) FAIL-CLOSED shared-secret auth. This function is deployed --no-verify-jwt so cron /
+  // GitHub Actions can call it without a user session; the shared secret is therefore the ONLY gate.
+  //   • REFRESH_SECRET MUST be set. If it is NOT, EVERY request is refused (503) — it never runs publicly.
+  //     (The old guard fail-OPEN: with the secret unset, ANYONE could trigger unlimited AI-cost + DB writes.)
+  //   • The secret is read ONLY from the `x-refresh-secret` HEADER — never a URL query string — so it can
+  //     never leak into an access log.
+  //   • Compared in CONSTANT TIME (no early-exit timing oracle).
+  // The caller (pg_cron via pg_net, or a GitHub Action) MUST send header `x-refresh-secret: <secret>`.
+  // Setup + the exact cron SQL are in docs/SECURITY-ARCHITECTURE.md.
+  const secret = Deno.env.get("REFRESH_SECRET") || "";
+  if (!secret) {
+    return new Response(JSON.stringify({ error: "not_configured", message: "refresh-news is disabled: REFRESH_SECRET is not set. Set it and have the caller send the x-refresh-secret header." }), { status: 503, headers: { ...cors, "Content-Type": "application/json" } });
+  }
+  const got = req.headers.get("x-refresh-secret") || "";
+  if (!got || !timingSafeEqual(got, secret)) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401, headers: { ...cors, "Content-Type": "application/json" } });
   }
 
   const url = Deno.env.get("SUPABASE_URL")!;

--- a/supabase/migrations/20260720120000_security_hardening.sql
+++ b/supabase/migrations/20260720120000_security_hardening.sql
@@ -1,0 +1,42 @@
+-- ============================================================================
+--  IntMap — SECURITY HARDENING migration (#R138)
+-- ----------------------------------------------------------------------------
+--  Additive, idempotent, NON-DESTRUCTIVE. Applied through the same manual, gated
+--  flow as the baseline (docs/MIGRATIONS.md) — never auto-applied on merge.
+--
+--  WHAT & WHY
+--    `feedback.rating` is a nullable integer that ANYONE (incl. anon) may insert
+--    (policy feedback_insert_any WITH CHECK (true)) and it had NO range constraint.
+--    The admin console renders it with String.prototype.repeat(rating); an
+--    out-of-range value (e.g. rating = 6, or negative) made repeat() throw a
+--    RangeError that aborted the ENTIRE feedback render — a one-row, unauthenticated
+--    denial-of-service against the admin Feedback tab. The client render is now
+--    clamped (admin.html, #R138); this constraint adds the matching guard at the
+--    database so a malformed value can never be stored in the first place.
+--
+--  NOT VALID: a pre-existing out-of-range row (e.g. one an attacker inserted before
+--    this fix) will NOT block the migration; the constraint is enforced on every
+--    NEW insert/update immediately. After confirming no bad rows remain you may run
+--    `alter table public.feedback validate constraint feedback_rating_range;`.
+-- ============================================================================
+
+begin;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'feedback_rating_range'
+      and conrelid = 'public.feedback'::regclass
+  ) then
+    alter table public.feedback
+      add constraint feedback_rating_range
+      check (rating is null or (rating between 1 and 5))
+      not valid;
+  end if;
+end $$;
+
+comment on constraint feedback_rating_range on public.feedback is
+  '(#R138) rating must be NULL or 1..5. Guards the admin-render RangeError DoS; enforced on new writes.';
+
+commit;

--- a/supabase/tests/03_security_test.sql
+++ b/supabase/tests/03_security_test.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+--  pgTAP · 03 security hardening (#R138) — attack cases ADDED on top of the
+--  00/01/02 suites (this file does not rewrite them). New coverage:
+--    • feedback.rating CHECK — the guard for the admin-console RangeError DoS
+--      (an anon-insertable out-of-range rating bricked the admin Feedback tab).
+--    • profiles_public leaks NOTHING sensitive (only id/display_name/bio/avatar_url).
+--    • the public-READ tables (current_news/geo_pins/dashboard_cards) are NOT
+--      writable by anon, and ai_usage is never directly writable (RPC-only).
+-- ============================================================================
+begin;
+select no_plan();
+
+-- ── feedback.rating CHECK constraint (guards the admin-render DoS) ───────────
+select ok(
+  exists(select 1 from pg_constraint
+         where conname = 'feedback_rating_range' and conrelid = 'public.feedback'::regclass),
+  'feedback_rating_range CHECK constraint exists');
+-- Out-of-range ratings are rejected at the DB (check_violation = 23514), so a
+-- malicious insert can never reach the admin renderer.
+select throws_ok($$ insert into public.feedback(rating) values (6)  $$, '23514', null, 'rating = 6 is rejected (the DoS payload)');
+select throws_ok($$ insert into public.feedback(rating) values (0)  $$, '23514', null, 'rating = 0 is rejected');
+select throws_ok($$ insert into public.feedback(rating) values (-1) $$, '23514', null, 'rating = -1 is rejected');
+select lives_ok($$  insert into public.feedback(rating) values (1)    $$, 'rating = 1 is accepted');
+select lives_ok($$  insert into public.feedback(rating) values (5)    $$, 'rating = 5 is accepted');
+select lives_ok($$  insert into public.feedback(rating) values (null) $$, 'rating = NULL is accepted (feedback need not be rated)');
+
+-- ── profiles_public exposes ONLY the four safe columns (no PII / no flags) ───
+select is(
+  (select count(*)::int from information_schema.columns
+   where table_schema = 'public' and table_name = 'profiles_public'),
+  4, 'profiles_public has exactly 4 columns');
+select ok(
+  not exists(select 1 from information_schema.columns
+             where table_schema = 'public' and table_name = 'profiles_public'
+               and column_name in ('email','is_admin','is_pro','plan','login_count')),
+  'profiles_public does NOT expose email/is_admin/is_pro/plan/login_count');
+
+-- ── public-READ tables are not writable by anon (writes = admin/service_role) ─
+select ok(not has_table_privilege('anon','public.current_news','insert'),      'anon cannot INSERT current_news');
+select ok(not has_table_privilege('anon','public.current_news','update'),      'anon cannot UPDATE current_news');
+select ok(not has_table_privilege('anon','public.current_news','delete'),      'anon cannot DELETE current_news');
+select ok(not has_table_privilege('anon','public.geo_pins','insert'),          'anon cannot INSERT geo_pins');
+select ok(not has_table_privilege('anon','public.dashboard_cards','insert'),   'anon cannot INSERT dashboard_cards');
+
+-- ── ai_usage is never directly writable — only the SECURITY DEFINER RPCs write it ─
+select ok(not has_table_privilege('authenticated','public.ai_usage','insert'), 'authenticated cannot INSERT ai_usage (quota tamper-proof)');
+select ok(not has_table_privilege('authenticated','public.ai_usage','update'), 'authenticated cannot UPDATE ai_usage');
+select ok(not has_table_privilege('authenticated','public.ai_usage','delete'), 'authenticated cannot DELETE ai_usage');
+
+select * from finish();
+rollback;

--- a/tests/security-logic.mjs
+++ b/tests/security-logic.mjs
@@ -1,0 +1,96 @@
+// ============================================================================
+//  IntMap — Edge Function security-logic tests (#R138). Pure Node (node:test),
+//  no Deno runtime required (CI has none). Two kinds of assertion:
+//    1. UNIT tests of the constant-time secret comparison used by refresh-news.
+//    2. SOURCE regression guards: the security-critical Edge Functions are read
+//       and asserted to still hold their invariants, so a future edit cannot
+//       silently reintroduce the fail-OPEN refresh-news guard, a URL-query secret,
+//       an unauthenticated ai-proxy, or an uncapped prompt/image input.
+//  Run: node --test tests/security-logic.mjs   (also part of `npm test`).
+// ============================================================================
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+const refreshNews = read('supabase/functions/refresh-news/index.ts');
+const aiProxy = read('supabase/functions/ai-proxy/index.ts');
+
+// ---- Mirror of refresh-news timingSafeEqual (kept in lock-step; unit-tested here) ----
+function timingSafeEqual(a, b) {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a), bb = enc.encode(b);
+  let diff = ab.length ^ bb.length;
+  const n = Math.max(ab.length, bb.length);
+  for (let i = 0; i < n; i++) diff |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+  return diff === 0;
+}
+
+test('timingSafeEqual: equal strings compare true', () => {
+  assert.equal(timingSafeEqual('s3cr3t-token', 's3cr3t-token'), true);
+  assert.equal(timingSafeEqual('', ''), true);
+});
+
+test('timingSafeEqual: any difference compares false', () => {
+  assert.equal(timingSafeEqual('s3cr3t-token', 's3cr3t-tokeX'), false); // last byte differs
+  assert.equal(timingSafeEqual('Xs3cr3t-token', 's3cr3t-token'), false); // length differs
+  assert.equal(timingSafeEqual('secret', ''), false);
+  assert.equal(timingSafeEqual('secret', 'secret ') , false);            // trailing space
+});
+
+test('timingSafeEqual: the mirror matches the source (same algorithm shape)', () => {
+  // The source must implement a constant-time compare (no early-return === on the secret).
+  assert.match(refreshNews, /function timingSafeEqual/);
+  assert.match(refreshNews, /diff \|=/);            // accumulates, no early break
+  assert.doesNotMatch(refreshNews, /got !== secret/); // the old timing-unsafe compare is gone
+});
+
+test('refresh-news is FAIL-CLOSED: unset REFRESH_SECRET refuses every request (503)', () => {
+  // With the secret unset the function must return 503 "not_configured" and never run.
+  assert.match(refreshNews, /const secret = Deno\.env\.get\("REFRESH_SECRET"\) \|\| ""/);
+  assert.match(refreshNews, /if \(!secret\)/);
+  assert.match(refreshNews, /not_configured/);
+  assert.match(refreshNews, /status: 503/);
+});
+
+test('refresh-news reads the secret ONLY from a header, never a URL query string', () => {
+  assert.match(refreshNews, /req\.headers\.get\("x-refresh-secret"\)/);
+  // The old query-string channel (leaks the secret into access logs) must be gone.
+  assert.doesNotMatch(refreshNews, /searchParams\.get\(\s*["']secret["']\s*\)/);
+});
+
+test('refresh-news only runs on POST (GET/others rejected)', () => {
+  assert.match(refreshNews, /req\.method !== "POST"/);
+  assert.match(refreshNews, /method_not_allowed/);
+});
+
+test('ai-proxy REQUIRES a valid JWT (login) before doing any work', () => {
+  assert.match(aiProxy, /auth\.getUser\(\)/);
+  assert.match(aiProxy, /if \(!user\) return json\(\{ error: "auth"/);
+});
+
+test('ai-proxy enforces the per-user daily quota via the SECURITY DEFINER RPC', () => {
+  assert.match(aiProxy, /increment_ai_usage/);
+  assert.match(aiProxy, /error: "limit"/);
+  assert.match(aiProxy, /}, 429\)/);           // over-quota → 429
+});
+
+test('ai-proxy caps prompt and image input (no unbounded request)', () => {
+  assert.match(aiProxy, /MAX_PROMPT = \d/);
+  assert.match(aiProxy, /MAX_IMAGES = \d/);
+  assert.match(aiProxy, /\.slice\(0, MAX_PROMPT\)/);
+  assert.match(aiProxy, /\.slice\(0, MAX_IMAGES\)/);
+});
+
+test('ai-proxy does not log the prompt / provider key / JWT', () => {
+  // Telemetry logging must be metadata-only. Assert the prompt variable is never passed to console.*.
+  const logCalls = [...aiProxy.matchAll(/console\.(?:error|log|warn|info)\(([^\n]*)/g)].map((m) => m[1]);
+  for (const c of logCalls) {
+    assert.doesNotMatch(c, /\bprompt\b/, `a console call references prompt: ${c}`);
+    assert.doesNotMatch(c, /\bkey\b/, `a console call references key: ${c}`);
+    assert.doesNotMatch(c, /authHeader|Authorization|jwt/i, `a console call references the JWT: ${c}`);
+  }
+});

--- a/tests/security.spec.js
+++ b/tests/security.spec.js
@@ -1,0 +1,151 @@
+// ============================================================================
+//  IntMap — SECURITY tests (#R138). Runs in a REAL browser (Chromium) so the
+//  assertions prove BROWSER behaviour, not just string shape:
+//    • window.IntMapSafe.html() neutralises every payload from the security
+//      commission (§6) — when its output is inserted into the live DOM, NO script
+//      runs and NO active element (<script>/<img onerror>/<svg onload>) is created.
+//    • window.IntMapSafe.url() blocks javascript:/data:text-html/vbscript: and
+//      allows only http(s)/mailto/tel (+ raster data:image, never SVG).
+//    • The SAME payloads, once neutralised, still DISPLAY correctly — and so do
+//      Japanese / German / Russian / Spanish / emoji / Cyrillic / accents / long
+//      place names (the commission's i18n requirement).
+//    • The pragmatic CSP meta is present (object-src 'none' + base-uri 'self').
+//  These map 1:1 to the sinks fixed in this round (community, news, webcam,
+//  place-search, profiles, popups) — every one now routes untrusted text through
+//  IntMapSafe, so proving IntMapSafe + real DOM parsing covers them all.
+// ============================================================================
+import { test, expect } from '@playwright/test';
+import { installHermeticRouting, collectPageDiagnostics } from './helpers/network.js';
+
+// The exact hostile inputs listed in the commission (§6) + a quote-breakout case.
+const XSS_PAYLOADS = [
+  '<script>window.__xss = true</script>',
+  '<img src=x onerror="window.__xss = true">',
+  '<svg onload="window.__xss = true">',
+  '"><img src=x onerror=window.__xss=true>',
+  '</style><script>window.__xss=true</script>',
+  'x" onmouseover="window.__xss=true',        // attribute-breakout attempt
+  "x' onmouseover='window.__xss=true",        // single-quote attribute-breakout
+];
+const URL_BLOCK = [
+  'javascript:alert(1)',
+  'data:text/html,<script>alert(1)</script>',
+  'JavaScript:alert(1)',
+  'java\tscript:alert(1)',
+  '  javascript:alert(1)',
+  'vbscript:msgbox(1)',
+  'data:image/svg+xml,<svg onload=alert(1)>',
+];
+const URL_ALLOW = [
+  'https://example.com/a?b=1#c',
+  'http://example.org/x',
+  'mailto:a@b.com',
+];
+// Must survive intact through html() (display correctness across languages).
+const I18N = [
+  '日本語のニュース見出し',
+  'Zürich Straße Größe',
+  'Москва — Санкт-Петербург',
+  'España, Peñíscola, ñ',
+  '🇯🇵🔥🌏 emoji headline',
+  'Kōbe · Ōsaka · Đà Nẵng · İstanbul',
+  'A very long place name '.repeat(8).trim(),
+];
+
+test.describe.configure({ mode: 'serial' });
+
+let page, diag;
+
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext();
+  await installHermeticRouting(context);
+  page = await context.newPage();
+  diag = collectPageDiagnostics(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 45_000 });
+  // IntMapSafe is defined in the FIRST head script, so it is ready almost immediately;
+  // still wait for it explicitly so a regression that removes/moves it fails loudly.
+  await page.waitForFunction(() => typeof window.IntMapSafe === 'object' && !!window.IntMapSafe.html, null, { timeout: 45_000 });
+});
+
+test.afterAll(async () => { await page?.context()?.close(); });
+
+test('IntMapSafe is defined globally with html() and url()', async () => {
+  const shape = await page.evaluate(() => ({
+    html: typeof window.IntMapSafe?.html,
+    url: typeof window.IntMapSafe?.url,
+    esc: typeof window.IntMapSafe?.esc,
+  }));
+  expect(shape).toEqual({ html: 'function', url: 'function', esc: 'function' });
+});
+
+test('escaped payloads never execute and never create an active element (real DOM)', async () => {
+  const result = await page.evaluate((payloads) => {
+    const out = [];
+    for (const p of payloads) {
+      window.__xss = false;
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      // Reproduce the fixed sinks: text context AND double/single-quoted attribute context.
+      host.innerHTML =
+        '<div>' + window.IntMapSafe.html(p) + '</div>' +
+        '<a title="' + window.IntMapSafe.html(p) + '">t</a>' +
+        "<span data-x='" + window.IntMapSafe.html(p) + "'>s</span>" +
+        '<div style="background:url(\'' + window.IntMapSafe.html(window.IntMapSafe.url(p, { allowData: true })) + '\')">b</div>';
+      // Force any lazy <img onerror>/<svg onload> to attempt to run.
+      void host.getBoundingClientRect();
+      out.push({ p, xss: window.__xss, imgs: host.querySelectorAll('img').length, svgs: host.querySelectorAll('svg').length, scripts: host.querySelectorAll('script').length });
+      host.remove();
+    }
+    // settle a tick so any async onerror would have fired
+    return new Promise((r) => setTimeout(() => r(out), 50));
+  }, XSS_PAYLOADS);
+  for (const r of result) {
+    expect(r.xss, `payload executed: ${r.p}`).toBe(false);
+    expect(r.imgs, `live <img> created for: ${r.p}`).toBe(0);
+    expect(r.svgs, `live <svg> created for: ${r.p}`).toBe(0);
+    expect(r.scripts, `live <script> created for: ${r.p}`).toBe(0);
+  }
+  // A final global check: nothing ever set the canary during the whole pass.
+  expect(await page.evaluate(() => window.__xss)).toBe(false);
+});
+
+test('IntMapSafe.url() blocks dangerous schemes', async () => {
+  const blocked = await page.evaluate((urls) => urls.map((u) => window.IntMapSafe.url(u)), URL_BLOCK);
+  for (let i = 0; i < URL_BLOCK.length; i++) {
+    expect(blocked[i], `scheme NOT blocked: ${URL_BLOCK[i]}`).toBe('');
+  }
+  // data:image/svg is blocked even with allowData; raster data:image is allowed.
+  const svgBlocked = await page.evaluate(() => window.IntMapSafe.url('data:image/svg+xml;base64,x', { allowData: true }));
+  expect(svgBlocked).toBe('');
+  const pngOk = await page.evaluate(() => window.IntMapSafe.url('data:image/png;base64,iVBORw0KG', { allowData: true }));
+  expect(pngOk).toBe('data:image/png;base64,iVBORw0KG');
+});
+
+test('IntMapSafe.url() allows safe schemes unchanged', async () => {
+  const allowed = await page.evaluate((urls) => urls.map((u) => window.IntMapSafe.url(u)), URL_ALLOW);
+  expect(allowed).toEqual(URL_ALLOW);
+});
+
+test('i18n: escaping preserves JP/DE/RU/ES/emoji/accents intact', async () => {
+  const rendered = await page.evaluate((samples) => samples.map((s) => {
+    const d = document.createElement('div');
+    d.innerHTML = window.IntMapSafe.html(s);   // escape then let the browser decode back to text
+    return d.textContent;
+  }), I18N);
+  // Round-trip through escape + DOM text must equal the original (no corruption, no loss).
+  expect(rendered).toEqual(I18N);
+});
+
+test('a pragmatic CSP is present (object-src none, base-uri self)', async () => {
+  const csp = await page.evaluate(() => {
+    const m = document.querySelector('meta[http-equiv="Content-Security-Policy" i]');
+    return m ? m.getAttribute('content') : null;
+  });
+  expect(csp, 'CSP meta present').toBeTruthy();
+  expect(csp).toContain("object-src 'none'");
+  expect(csp).toContain("base-uri 'self'");
+});
+
+test('no uncaught exceptions while running the security probes', async () => {
+  expect(diag.pageErrors, `pageerror(s):\n${diag.pageErrors.join('\n---\n')}`).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

Authorized security audit + hardening of IntMap (P0). The real implementation and data
flows were investigated first, and only **genuinely exploitable** issues were fixed —
additively, preserving the single-`index.html` / no-build / 5-language architecture. No
existing feature was removed. **`npm test` is green** (static 88 files + security-logic 10/10
+ Playwright **18/18**).

> The Supabase **publishable / anon key** is public by design (RLS + column grants + the
> SECURITY DEFINER RPCs + Edge-Function auth are the boundary) and is intentionally **not**
> treated as a leak. A `service_role`/secret key is never committed.

## Attack surfaces investigated

Frontend XSS across every `innerHTML`/`setHTML` sink in `index.html` (357 sinks, ~15
inconsistent `esc()` helpers) and `admin.html`; the Atlas AI / Markdown pipeline; both Edge
Functions (`ai-proxy`, `refresh-news`); Supabase Auth / session; RLS + grants; GitHub Actions
workflows + supply chain; CSP / browser headers; `sw.js`; URL-hash/share, GeoJSON import, and
error rendering.

## Findings, severity, exploit conditions & fixes

| # | Severity | Issue | Exploit condition | Fix |
|---|---|---|---|---|
| 1 | **P0** | Stored XSS: `community_posts.img` → `<img src>` | Any logged-in user inserts a row via Supabase REST with `img="x" onerror=…`; **auto-fires on feed render** for every viewer → session-token theft | `IntMapSafe.html(IntMapSafe.url(img,{allowData}))` |
| 2 | P1 | Stored XSS: community `title`/`body` → map-pin tooltip | Victim hovers the attacker's pin | escape via `IntMapSafe.html` |
| 3 | P1 | Stored XSS: another user's `profiles.avatar_url` → `background:url()` | Victim views the attacker's profile | scheme-validate + escape |
| 4 | **P0/P1** | DOM XSS: news RSS `title`/`publisher`/`name` (6 sinks: card, translate re-render, 2 tooltips, mobile popup) | A crafted headline reaching Google News RSS (entity-decoded → live HTML); #1-style auto-fire | escape all; `window.open` gets an http(s)-only guard |
| 5 | P1 | XSS: OSM-editable webcam `url` → iframe(pano)/video/img/`href` | Anyone edits an OSM `webcam=` tag to `javascript:…`/`x"onload=…`; victim opens that cam | scheme-validate + escape |
| 6 | P1 | XSS: Nominatim `display_name`/`type`/`country` → search result card | OSM name = payload; victim searches + clicks | escape |
| 7 | **P0** | `refresh-news` **fail-open** + timing-unsafe + secret-in-query | With `REFRESH_SECRET` unset, **anyone** triggers paid AI + `service_role` DB writes | **fail-closed** (503 if unset), **header-only**, **constant-time**, POST-only |
| 8 | P2 | admin `feedback.rating` `RangeError` DoS | Unauthenticated `insert rating=6` → `repeat(-1)` bricks the whole admin Feedback tab | client clamp + DB `CHECK` (migration) |
| 9 | P2 | `rollback.yml` shell/expression injection of `${{ inputs.ref }}` | Actor with write access (limited gain) | pass via `env:` |
| 10 | P2 | Third-party action `supabase/setup-cli@v1` not SHA-pinned | Tag repoint → code exec in CI | SHA-pinned (Dependabot bumps) |
| — | — | Also hardened (defence-in-depth): USGS `place` / POI `url` escapes, `escForReader` quote-escaping, one `target=_blank` missing `noopener`, `window.open` scheme guards | | |

**Audited and found already SAFE (no change):** the Atlas AI reply pipeline (escapes before
markdown; forces `https?:` on links), URL-hash/share restore (consumed as numbers/dates/layer-
ids), GeoJSON file import (properties only feed MapLibre paint layers), error rendering
(escaped), `sw.js` (tile-host allowlist, app shell never cached), the RLS baseline (no
privilege escalation; PII gated), and `ai-proxy` (JWT-gated, quota-enforced, input-capped, no
secret logging).

## Primary control: one canonical sanitizer

`window.IntMapSafe` (defined in the first `<head>` script, global to every render path):
- `.html(s)` → escapes `& < > " '` (safe in text + single/double-quoted attributes)
- `.url(s,{allowData})` → allows only `http(s)`/`mailto`/`tel` (+ raster `data:image`, never
  SVG); blocks `javascript:` / `data:text/html` / `vbscript:` / tab-obfuscated schemes.

A pragmatic CSP `<meta>` (tested to not break the app) adds `object-src 'none'`, `base-uri
'self'`, `frame-src 'self' https: blob:`, `worker-src 'self' blob:`, and a `script-src`
allowlist. Because the app is inline/no-build, `'unsafe-inline'` is unavoidable, so
output-encoding — not CSP — is the primary defense (see `docs/SECURITY-ARCHITECTURE.md`).

## Tests added

- **`tests/security.spec.js`** (Playwright) — the commission's exact XSS payloads are pushed
  through `IntMapSafe` into the **live DOM** and proven inert (no script runs, no active
  element) in text + attribute contexts; scheme-blocking; **i18n round-trip** (日本語 / Zürich
  / Москва / España / emoji / accents / long names); CSP present.
- **`tests/security-logic.mjs`** (`node:test`) — constant-time compare + source regression
  guards for the Edge-Function invariants (refresh-news fail-closed/header-only/POST; ai-proxy
  JWT-required/input-capped/no-secret-logging).
- **`supabase/tests/03_security_test.sql`** (pgTAP) — the rating `CHECK` rejects 6/0/-1,
  `profiles_public` exposes no PII, public-read tables aren't anon-writable, `ai_usage` is
  RPC-only.
- CI: **CodeQL** (`security.yml`); `static-checks.mjs` gains a **third-party-action SHA-pin
  check** + Anthropic-key pattern; `ci.yml` runs the security-logic tests.

## CI results

Local `npm test`: static ✓ · security-logic 10/10 ✓ · Playwright 18/18 ✓ (7 security + 8 smoke
+ 3 internal-QA). CI (this PR) runs CI, Security/CodeQL, and Database checks.

## Residual risks (documented in `docs/SECURITY-ARCHITECTURE.md §8`)

`'unsafe-inline'/'unsafe-eval'` unavoidable for an inline no-build app (mitigated by
output-encoding); JWT in `localStorage` (Supabase default; mitigated by the XSS fixes);
`frame-ancestors`/`X-Frame-Options`/HSTS/`Permissions-Policy` are header-only and **GitHub
Pages cannot set them** (mitigations: no click-only sensitive actions, all `_blank` links
`noopener`, HTTPS-only); public CORS relays for some camera lists; OpenAI content-sharing
(disclosed in-app).

## Manual work required (operator — not done by this PR; never put secret values in the repo)

**Supabase — REQUIRED because `refresh-news` is now fail-closed:**
1. `supabase secrets set REFRESH_SECRET=<long random>` — until set, news refresh is
   intentionally **off** (fail-safe).
2. Update the pg_cron job to send header `x-refresh-secret: <secret>` (header only, never
   `?secret=`).
3. Redeploy (gated): `supabase functions deploy refresh-news --no-verify-jwt`.
4. Apply migration `20260720120000_security_hardening.sql` via the gated flow (`docs/MIGRATIONS.md`).
5. Confirm Auth Redirect URLs are production-only (open-redirect).

**GitHub — repo Settings:** enable Secret scanning + Push protection, Private vulnerability
reporting, confirm Dependabot alerts; add branch protection on `main` requiring CI + Database
checks (+ optionally CodeQL); keep Actions default permissions = read.

Full step list: `docs/SECURITY-ARCHITECTURE.md §9`.

## Changes needing production deploy

Only `supabase/functions/refresh-news/index.ts` (operator-gated redeploy + the secret/cron
step above). The frontend (`index.html`/`admin.html`) deploys through the normal Pages flow.
**No production Edge Function was redeployed and no GitHub/Supabase setting was changed by
this PR.**

## Rollback

Frontend/docs/CI: `git revert <merge>` (Pages redeploys the reverted tree). refresh-news:
redeploy the previous function version **or** revert the file; if you must restore service
before setting the secret, the previous behavior returns by reverting that one file (note: it
re-opens the fail-open issue — prefer setting `REFRESH_SECRET`). The migration is
`NOT VALID`/non-destructive; to undo, `drop constraint feedback_rating_range`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
