### PR TITLE
R141: Area Monitors — server-side area watch + change detection + evidence-backed reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       - run: npm ci
       - name: Static checks (syntax, JSON/YAML, merge markers, secrets, assets, action-pinning)
         run: npm run check:static
-      - name: Security-logic tests (Edge Function auth invariants + constant-time compare)
-        run: node --test tests/security-logic.mjs
+      - name: Security-logic + monitor-logic tests (Edge Function invariants; area-monitor comparison engine)
+        run: node --test tests/security-logic.mjs tests/monitor-logic.test.mjs
 
   browser:
     name: Browser smoke + internal QA

--- a/Architecture.md
+++ b/Architecture.md
@@ -1149,4 +1149,15 @@ hash）はすべて敵性入力として扱う。詳細は **`docs/SECURITY-ARCH
 - CI＝**CodeQL**（`security.yml`）＋`check:static`に**第三者Action SHA固定**検査＋`tests/security-logic.mjs`
   （Edge Function認証不変条件）＋pgTAP `03_security_test.sql`。`npm test`で全実行。
 
+## 18. 地域監視基盤 (Area Monitors) — R141
+
+ログインユーザーが**監視地域**（円/描画/解決済み地域/現在の地図表示）を保存し、**サーバー側が定期実行**して**意味のある変化がある時だけ根拠付きレポート**を生成する機能。詳細は [`docs/AREA-MONITORS.md`](docs/AREA-MONITORS.md)。
+
+- **中核原則**＝**変化の有無はコードが判定、AIは説明のみ**。処理順＝取得→正規化/重複排除→スナップショット→機械的diff(new/gone/continuing・件数・クラスタ・媒体多様性)→change score→**変化があり閾値超の時だけAI**→**AIが引いたevidence IDを実行後にコードで検証**（偽ID主張は棄却）→run/evidence/report永続化。**取得失敗は「変化なし」ではなく専用status**。
+- **DB**（migration `20260721090000_area_monitors.sql`）＝4表 `area_monitors`/`monitor_runs`/`monitor_evidence`/`monitor_reports`。**RLS全表owner-only**、runs/evidence/reportsは**service_role書込・user読取専用**（実行結果偽造不可）、area_monitors UPDATEは**列単位grant**でrun-state列除外（ロック/メタ改竄不可）。UUID PK。`monitor_limit()`（plan別上限・**課金接続点**）を挿入トリガで強制。`monitor_claim_due()`＝`FOR UPDATE SKIP LOCKED`で二重実行防止。pgTAP `04_monitors_test.sql`。
+- **Edge Function** `monitor-run`（`--no-verify-jwt`・自前fail-closed）＝①cron（`x-monitor-secret`）で due monitors をclaim・逐次処理、②user「今すぐ実行」（JWT+monitorId・所有権照合）。純ロジックは `logic.mjs`（runtime非依存ESM）を Deno と Node テストで共有。status体系10種（success/success_no_change/partial/source_unavailable/ai_failed/timed_out/invalid_geometry/quota_exceeded/disabled/internal_error）。**AI失敗でもsnapshot/diff/evidenceは保持**。
+- **定期実行**＝pg_cron（refresh-news 同型・`net.http_post` でヘッダに秘密・`docs/AREA-MONITORS.md` にSQL）。
+- **UI/Atlas**（`index.html` 加算）＝**Monitorsタブ**（通常/モバイル/Workspace・5言語）、`window.IntMapMonitors`（一覧/作成ダイアログ/詳細/レポート＝結論・主な変化→evidence chip・数値比較・根拠一覧(出典リンク)・変化地点を地図表示・取得できなかったデータ・制約・日時/status）。Atlas `{"type":"monitor","op":…}`＝**返信は実DB結果のみ**（偽の成功報告なし）。全描画 `IntMapSafe`（XSS-inert 実証）。
+- **コスト制御**＝変化なしはAI非呼出／新規のみAIへ送信（履歴dedup）／run毎cap（evidence60・AI入力40・110s wall-clock・55s AI timeout）／plan別monitor上限・最短間隔30分・手動クールダウン30s／保持（run 100・evidence 12run）。
+
 *変更履歴の詳細は `DEV-NOTES.md`、守るべき原則は `CONSTITUTION.md` を参照。*

--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -5,6 +5,46 @@
 
 ---
 
+## R141 — 地域監視・変化検出・根拠付きレポート機能（Area Monitors） (tag `#R141`)
+
+ユーザーが円/描画/解決済み地域/現在の地図表示から**監視（monitor）**を保存し、**サーバー側（Edge Function + pg_cron）がページを閉じていても定期実行**、対象地域内のニュースを取得→正規化/重複排除→スナップショット→**機械的に**前回/基準期間と比較→**意味のある変化がある時だけAI**で根拠付きレポートを生成、UI（通常/モバイル/Workspace・5言語）とAtlasから作成/一覧/詳細/レポート/根拠/一時停止/再開/削除/手動実行できる。中核原則＝**「変化の有無はコードが判定し、AIは説明だけ」「全主張をevidence IDへ接続」「変化なし/取得失敗ではAIを呼ばない」**。全て加算的（単一index.html・ビルド無し温存）。着手前に**並列サブエージェント4本**で auth/AI・Atlas action・geometry(radius/draw/region)・UI/tabs/i18n を実地調査。`npm test` 緑（静的+node logic 23+security-logic+**Playwright 26/26**）・**pgTAP 180**（新規`04_monitors_test.sql` 38アサーション含む）・ローカルDocker で `db reset`+`test db`+drift 空を実測。
+
+### データモデル（`supabase/migrations/20260721090000_area_monitors.sql`・冪等/非破壊）
+- **`area_monitors`**（owner/name/**geometry(jsonb GeoJSON Polygon/MultiPolygon)**/geometry_kind/center+radius_km(円)/bbox/area_label/**sources[]**(news先行・拡張可)/**comparison**(previous_run|baseline_window)/**sensitivity**(min_new/min_score)/interval_minutes(≥30 CHECK)/enabled/**running_since(claimロック)**/last_run_at/**next_run_at**/last_status/last_change_severity/last_report_id/run_count）。UUID PK（**連番でない**）。geometryサイズ CHECK ≤400KB。
+- **`monitor_runs`**（1実行=1行・status/**snapshot**/**diff**/change_score/report_generated/**ai_used**/ai_skip_reason/ai_provider/model/error_category/retryable/duration_ms/evidence_count）。**service_role のみ書込**＝userは偽造不可。
+- **`monitor_evidence`**（run毎の**ev_key**("ev_1"…)/source_type/name/url(http/https検証)/external_id/title/observed/fetched/lng/lat/**payload**/**dedup_key**/change_kind(new|continuing|gone)）。
+- **`monitor_reports`**（severity/headline/summary/**changes[{claim,evidence_ids}]**/unchanged/data_gaps/limitations/metrics/change_points/ai_provider/model/prompt_version/read）。
+- **RLS＝全表 owner-only**（`user_id=auth.uid()`）。userは**monitorsのみCRUD**、runs/evidence/reportsは**SELECTのみ**（write grant無し＝**実行結果を偽造不可**）。area_monitors の**UPDATEは列単位grant**で run-state列（running_since/last_*/run_count）を除外＝**ロック/実行メタ改竄不可**。**adminにも監視のバックドア無し**（feedback等と違い完全private）。
+- **課金接続点**＝`monitor_limit(uuid)`（free=5/pro・plus=25/admin・unlimited=200）を **BEFORE INSERT トリガ**で強制（上限超過は `check_violation`）。
+- **ロック/claim**＝`monitor_claim_due(limit,stale_min)`＝**`FOR UPDATE SKIP LOCKED`** で due・enabled・未ロックのみ atomically claim＝**二重実行防止**（service_role のみEXECUTE）。`monitor_mark_read(uuid)` で本人のreportをread化（本文はclient不変）。realtime に area_monitors/runs/reports 追加。
+
+### Edge Function `supabase/functions/monitor-run/`（Deno・`--no-verify-jwt`・自前fail-closed認証）
+- **2モード**: ①**CRON**（`x-monitor-secret` ヘッダ＝`MONITOR_SECRET`・定数時間比較・未設定なら全拒否503）→`monitor_claim_due`でN件claim→逐次処理（GLOBAL_DEADLINE 110s で残りは running_since=null に戻し次tickへ）。②**USER「今すぐ実行」**（JWT+`{monitorId}`・所有権照合・手動クールダウン30s）。
+- **パイプライン**（`processMonitor`）＝run行を先にscaffold（内部エラー既定）→**COLLECTORS registry**（`{news:collectNews}`＝拡張seam）で bbox 事前絞り→**`pointInMonitorArea`** 精密判定→正規化/dedup→snapshot→前回run or window の**baselineKeys**→**`diffKeys`(new/gone/continuing)**→新規のみ**クラスタリング+媒体多様性**→**`computeChangeScore`**→**`decideAI`**（初回=insufficient_baseline/新規0=no_change/閾値未満=below_threshold/**取得失敗=source_unavailable でAIを呼ばない**）→呼ぶ時のみ provider直呼び（server-held key・OpenAI Responses API・**web検索無し=evidence only**）→**`validateAndCleanReport`** で**全evidence_idが実在ev_keyか検証**（偽ID主張は落とし、根拠ゼロなら報告棄却→`ai_failed`でsnapshot/diff/evidenceは保持）→run/evidence/report永続化→next_run_at更新→**prune**（run 100件・evidence 12run保持）。
+- **status体系**: success / success_no_change / partial / source_unavailable / ai_failed / timed_out / invalid_geometry / quota_exceeded / disabled / internal_error。**AI失敗でもsnapshot/diff/evidenceは失わない**、一部ソース失敗は取得分保存で**partial**。
+- **純ロジックは `logic.mjs`（runtime非依存ESM）**＝Deno関数と `tests/monitor-logic.test.mjs`(Node)が**同一コードを共有**（point-in-area/正規化/dedup/diff/クラスタ/score/decideAI/evidence検証/URL scheme）。
+
+### フロント（`index.html` 加算）
+- **Monitorsタブ新設**（`#btn-monitors`・`#monitors-feed`・`setMode('monitors')`・`renderUI`分岐・`IntMapOS.register('tab.monitors')`・session restore・モバイルdrag-collapse・**Workspace DEFS**・placeholder）。全5言語（`Object.assign(i18n.*,{tabMonitors})`＋インライン `ML(en,jp,de,ru,es)`）。
+- **`window.IntMapMonitors`**（本体は main scope 内・`IntMapPopArea`直前に挿入＝closureで currentUser/map/radiusItems/i18n/DrawTool/IntMapOutline へアクセス）: `render`(一覧・ログイン必須・realtime自動更新)/`openCreateDialog`(active area or 現在の地図表示・sources/比較/頻度/感度)/`openDetail`(設定+実行履歴+最新report)/`openReport`(結論/主な変化→**evidence chip でスクロール**/数値比較/根拠一覧(出典リンク)/変化地点を地図表示/未確認/取得できなかったデータ/制約/日時/status)/`pause`/`resume`/`remove`/`runNow`(FN直POST+JWT)/`flyTo`/`activeArea`(radius>draw>region の統一アクセサ)/`showOnMap`(area outline+change points レイヤー)。**全描画は `IntMapSafe.html/url`**（XSS-inert をPlaywrightで実証）。CSSは**静的`<style>`**（CSS-in-JS template-literal 回避＝memory教訓）。
+- **DrawTool に `currentGeometry()`** getter 追加（描画中なら finish して Polygon/MultiPolygon 返却）。
+- **Atlas**: `{"type":"monitor","op":"create|list|open|pause|resume|run|delete","which"?,"index"?,...}` を SYS カタログ + dispatch case + localPlan（決定的ショートカット「この範囲を監視」等）に配線。**返信は実DB結果のみ**（未ログイン/範囲未選択/失敗を正直に警告・偽の「作成しました」を出さない＝dispatchで実測確認）。`IntMapMonitors.atlas` bridge。
+
+### デプロイ要件（本番）
+1. `supabase functions deploy monitor-run --no-verify-jwt --project-ref vpekfwdpurzejrrmacac`
+2. `supabase secrets set MONITOR_SECRET=<random> --project-ref vpekfwdpurzejrrmacac`（AIキーは ai-proxy と共有＝設定済）
+3. migration を本番適用（`supabase db push` 要DBパスワード＝メンテナ操作 or Management API）
+4. **pg_cron**: `select cron.schedule('monitor-run-tick','*/10 * * * *', $$ select net.http_post(url:='https://vpekfwdpurzejrrmacac.functions.supabase.co/monitor-run', headers:=jsonb_build_object('Content-Type','application/json','x-monitor-secret','<MONITOR_SECRET>'), body:='{}'::jsonb) $$);`（refresh-news と同型・ヘッダで秘密・詳細 `docs/AREA-MONITORS.md`）。
+
+### 罠・教訓
+- **「変化の有無」をAIに丸投げしない**のが核心＝取得→正規化→dedup→機械diff→scoreまで**コードで確定**し、AIは**検出済み差分の説明**のみ。取得失敗は「変化なし」ではなく専用status。
+- **evidence ID検証は実行後にコードで**＝AIが存在しないev_keyを引いた主張は落とし、根拠ゼロなら報告自体を棄却（`ai_failed`）。R140の「実行前sayを実行結果でゲート」と同じ**正直化は合成側**の思想。
+- **service_role書込＋列単位UPDATE grant**で「実行結果/ロックの偽造不可」をDB層で保証（pgTAPで実証）。RLSだけでなく**grant（列含む）×trigger×RPC権限**の多層。
+- **claim は `FOR UPDATE SKIP LOCKED`** で二重実行を根絶（cron多重tick耐性）。
+- pure ロジックは **`.mjs`（runtime非依存）を Deno と Node で共有**＝本番コードとテストコードが一致。CSS は**静的style**（template-literal CSS 回避）。モジュールは main scope 内に置き closure を利用（page-scoped let は window 非公開のため）。
+
+---
+
 ## R140 — 既知バグ6件バッチ根本修正：ストリートビュー透過＋Coverage無視／タイムマシン国境の間欠不表示／Atlas嘘ハイライト／モバイル・ボトムシート同期 (tag `#R140`)
 
 ユーザー指摘の既知問題**全6件**を根本原因から修正。全て `index.html` の**加算的/微修正**（単一HTML・ビルド無し温存）。着手前に**並列サブエージェント3本**で③④⑤⑥の根本原因を実地調査。`npm test` 緑（静的89＋security-logic 10＋Playwright **18/18**、pageerror 0）。ヘッドレスは `document.hidden` で map 未init のため、②のCoverageエンジンは**実Googleタイルでライブ実測**、⑥のAPIは**maplibre 5.24.0のprototype実ソースで確定**、①は算出スタイルで実測。

--- a/docs/AREA-MONITORS.md
+++ b/docs/AREA-MONITORS.md
@@ -1,0 +1,134 @@
+# Area Monitors (#R141)
+
+Saved, server-side **area watches** that re-check a user-selected region on a schedule
+(even when the page is closed) and produce an **evidence-backed change report only when a
+real change is detected**. News is the first data source; the collector layer is generic so
+earthquakes/weather/fires/etc. can be added without schema churn.
+
+This page is the **architecture + operations** reference. See `DEV-NOTES.md` → R141 for the
+change log, and the inline `(#R141)` comments in the code.
+
+## Design principle — code decides "changed?", the AI only explains
+
+The pipeline is deliberately ordered so the AI is never asked whether something changed:
+
+```
+collect (per source) → normalize + dedup → snapshot → load baseline
+  → MECHANICAL diff (new / gone / continuing, counts, clusters, publisher diversity)
+  → change score (0..1)  → decideAI()
+  → (only on a meaningful change) call the AI with the evidence + the diff
+  → VALIDATE every evidence id the AI cited against THIS run's evidence
+  → persist run + evidence + (maybe) report
+```
+
+- A **source-fetch failure is never "no change"** — it is `source_unavailable` (all sources
+  down) or `partial` (some down, data kept).
+- The AI is called **only** when there is a real, code-detected change above the monitor's
+  sensitivity threshold; first runs establish a baseline (`insufficient_baseline`).
+- Every factual claim in a report must cite evidence ids (`ev_1`…) that exist in that run's
+  `monitor_evidence`. Claims citing a nonexistent id are dropped; a report with no grounded
+  claim is rejected and recorded as `ai_failed` (snapshot + diff + evidence are still kept).
+
+## Data model (`supabase/migrations/20260721090000_area_monitors.sql`)
+
+| table | who writes | RLS |
+|---|---|---|
+| `area_monitors` | the owner (create/edit/delete) + the runner | owner-only; UPDATE is a **column grant** that excludes the run-state columns (`running_since`, `last_*`, `run_count`) so a user cannot forge run metadata or touch the lock |
+| `monitor_runs` | **service_role only** | owner **read-only** — run results cannot be forged |
+| `monitor_evidence` | **service_role only** | owner **read-only** |
+| `monitor_reports` | **service_role only** | owner **read-only**; `read` flips via the `monitor_mark_read` RPC (body stays client-immutable) |
+
+- PKs are random UUIDs (never guessable sequential ids).
+- `monitor_limit(user)` is the **per-plan cap** (free = 5, pro/plus = 25, admin/unlimited =
+  200) enforced by a BEFORE INSERT trigger — this is the billing connection point.
+- `monitor_claim_due(limit, stale_minutes)` claims due monitors with `FOR UPDATE SKIP LOCKED`
+  so two concurrent cron ticks never process the same monitor (service_role only).
+
+## Edge Function (`supabase/functions/monitor-run/`)
+
+Deployed `--no-verify-jwt`; it does its own auth for **two modes**:
+
+1. **Cron** — `x-monitor-secret: <MONITOR_SECRET>` header (constant-time compare, **fail-closed**:
+   with the secret unset every request is refused). Claims up to 5 due monitors per tick.
+2. **User "Run now"** — the UI POSTs the user's JWT + `{ "monitorId": "…" }`; the function
+   verifies ownership and a 30 s manual cooldown, then runs just that one.
+
+The pure comparison logic lives in `logic.mjs` (runtime-agnostic ESM) and is imported by both
+the Deno function and the Node test (`tests/monitor-logic.test.mjs`) — the code under test is
+the code that runs.
+
+### Run status taxonomy
+
+`success` · `success_no_change` · `partial` · `source_unavailable` · `ai_failed` ·
+`timed_out` · `invalid_geometry` · `quota_exceeded` · `disabled` · `internal_error`.
+
+## Deploy / operate
+
+```bash
+# 1. Deploy the function
+supabase functions deploy monitor-run --no-verify-jwt --project-ref vpekfwdpurzejrrmacac
+
+# 2. Set the shared secret (REQUIRED — the function is fail-closed without it).
+#    The AI provider key is shared with ai-proxy and is already set.
+supabase secrets set MONITOR_SECRET="$(openssl rand -hex 24)" --project-ref vpekfwdpurzejrrmacac
+#    Optional kill-switch → mechanical-only, no AI reports:
+#    supabase secrets set MONITOR_AI=off --project-ref vpekfwdpurzejrrmacac
+
+# 3. Apply the migration to production (gated — needs the DB password; see docs/MIGRATIONS.md)
+supabase db push
+```
+
+### 4. Schedule the runner with pg_cron (same pattern as refresh-news)
+
+Run this **once** in the Supabase SQL editor (pg_cron + pg_net are already enabled for
+refresh-news). Replace `<MONITOR_SECRET>` with the value you set above. The secret travels in
+a **header**, never in the URL:
+
+```sql
+select cron.schedule(
+  'monitor-run-tick',
+  '*/10 * * * *',                       -- every 10 minutes; each monitor's own interval (≥30 min) gates it
+  $$
+  select net.http_post(
+    url     := 'https://vpekfwdpurzejrrmacac.functions.supabase.co/monitor-run',
+    headers := jsonb_build_object('Content-Type','application/json','x-monitor-secret','<MONITOR_SECRET>'),
+    body    := '{}'::jsonb
+  );
+  $$
+);
+```
+
+To change the cadence later: `select cron.unschedule('monitor-run-tick');` then re-schedule.
+A monitor only runs when `next_run_at <= now()`, so the 10-minute tick is just the granularity;
+per-monitor frequency is set by `interval_minutes` (minimum 30).
+
+## Cost control
+
+- AI is skipped entirely when there is no meaningful change (most runs).
+- Only **new** items are sent to the AI (deduped across the monitor's history).
+- Per-run caps: ≤ 60 evidence rows stored, ≤ 40 new items sent to the AI, 110 s wall-clock
+  budget per tick (unprocessed claims are released for the next tick), 55 s AI timeout.
+- Per-user monitor cap (`monitor_limit`), 30-minute minimum interval, 30 s manual cooldown.
+- Retention: newest 100 runs per monitor; evidence kept only for the newest 12 runs.
+
+## Data sources / privacy
+
+- The news collector reads the existing server-refreshed `current_news` table (Google News
+  RSS, already documented) and filters it to the monitor's geometry — **no new external data
+  source** is introduced. Evidence stores the article's public link, title, publisher, subject
+  location and observed time.
+- A monitor stores the user's selected **geometry** (a circle center+radius, a drawn polygon,
+  or a resolved region — simplified to ≤ 80 points/ring) and is visible only to its owner (RLS).
+- The runner never fetches arbitrary user-supplied URLs (no SSRF surface); stored `source_url`
+  values are scheme-validated (http/https only) and rendered through `IntMapSafe.url`.
+
+## Tests
+
+- **DB / RLS** — `supabase/tests/04_monitors_test.sql` (pgTAP): cross-user isolation, no
+  forging of runs/evidence/reports, no tampering with the run lock, plan-limit enforcement,
+  service-role claim. Runs in CI (`db.yml`).
+- **Logic** — `tests/monitor-logic.test.mjs` (Node): point-in-circle/polygon, dedup, diff,
+  clustering, change score, first-run vs no-change vs real-change decisions, evidence-id
+  validation. Runs in CI (`ci.yml`).
+- **Browser** — `tests/monitors.spec.js` (Playwright, hermetic): tab present, login gating,
+  honest Atlas routing, geometry accessor, and a report rendering **XSS-inert**. Runs in CI.

--- a/index.html
+++ b/index.html
@@ -2124,6 +2124,72 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
       .m-sheet .layer-dropdown .lyr-star{ margin-left:auto; }
       .m-sheet .layer-fav-chips{ width:100%; }
     }
+    /* ==================== (#R141) AREA MONITORS ==================== */
+    .mon-wrap{padding:4px 2px 20px}
+    .mon-head{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin:2px 0 10px}
+    .mon-new-btn{background:linear-gradient(135deg,#0a84ff,#5e5ce6);color:#fff;border:none;border-radius:9px;padding:8px 14px;font-weight:600;cursor:pointer;font-size:13px}
+    .mon-area-hint{font-size:11px;color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:60%}
+    .mon-empty,.mon-loading{color:var(--text-muted);font-size:13px;padding:18px 6px;text-align:center;line-height:1.5}
+    .mon-list{display:flex;flex-direction:column;gap:8px}
+    .mon-row{display:flex;gap:8px;align-items:stretch;background:var(--card-bg,#fff);border:1px solid rgba(128,128,128,.18);border-radius:12px;padding:10px 11px}
+    .mon-row-main{flex:1;min-width:0;cursor:pointer}
+    .mon-row-top{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+    .mon-name{font-weight:600;font-size:13.5px;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%}
+    .mon-row-sub{font-size:11.5px;color:var(--text-muted);margin-top:2px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    .mon-row-meta{font-size:11px;color:var(--text-muted);margin-top:3px;opacity:.9}
+    .mon-chip{font-size:10.5px;font-weight:600;color:var(--c);border:1px solid var(--c);border-radius:20px;padding:1px 8px;white-space:nowrap}
+    .mon-sev{font-size:10px;font-weight:700;color:#fff;background:var(--c);border-radius:20px;padding:1px 7px}
+    .mon-row-acts{display:flex;flex-direction:column;gap:4px;justify-content:center}
+    .mon-ic{width:30px;height:26px;border-radius:7px;border:1px solid rgba(128,128,128,.2);background:var(--input-bg,rgba(128,128,128,.08));color:var(--text);cursor:pointer;font-size:12px;line-height:1}
+    .mon-ic:hover{background:rgba(10,132,255,.12)}
+    .mon-ov{position:fixed;inset:0;background:rgba(0,0,0,.5);z-index:100000;display:flex;align-items:center;justify-content:center;padding:16px;backdrop-filter:blur(2px)}
+    .mon-dialog{background:var(--card-bg,#fff);color:var(--text);border-radius:16px;max-width:520px;width:100%;max-height:88vh;overflow:auto;padding:20px 18px;position:relative;box-shadow:0 12px 40px rgba(0,0,0,.35)}
+    .mon-x{position:absolute;top:12px;right:12px;width:30px;height:30px;border-radius:50%;border:none;background:rgba(128,128,128,.15);color:var(--text);cursor:pointer;font-size:14px}
+    .mon-h3{margin:0 30px 12px 0;font-size:17px;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+    .mon-h4{margin:16px 0 6px;font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.03em}
+    .mon-lbl{display:block;font-size:12px;color:var(--text-muted);margin:12px 0 4px}
+    .mon-inp{width:100%;box-sizing:border-box;padding:9px 10px;border-radius:9px;border:1px solid rgba(128,128,128,.25);background:var(--input-bg,rgba(128,128,128,.06));color:var(--text);font-size:14px}
+    .mon-area-box{font-size:12.5px;background:rgba(10,132,255,.09);border:1px solid rgba(10,132,255,.25);border-radius:9px;padding:8px 10px;margin-bottom:4px}
+    .mon-area-none{background:rgba(255,159,10,.09);border-color:rgba(255,159,10,.3);color:var(--text-muted)}
+    .mon-viewbtn{margin-top:8px;background:var(--input-bg,rgba(128,128,128,.08));border:1px solid rgba(128,128,128,.2);color:var(--text);border-radius:9px;padding:8px 12px;cursor:pointer;font-size:12.5px;width:100%}
+    .mon-src-row{display:flex;flex-wrap:wrap;gap:8px}
+    .mon-src{display:flex;align-items:center;gap:5px;font-size:12.5px;background:var(--input-bg,rgba(128,128,128,.06));border:1px solid rgba(128,128,128,.2);border-radius:8px;padding:6px 9px;cursor:pointer}
+    .mon-src-off{opacity:.55;cursor:not-allowed}
+    .mon-soon{font-size:9.5px;color:var(--text-muted);border:1px solid rgba(128,128,128,.3);border-radius:6px;padding:0 4px}
+    .mon-note{font-size:11.5px;color:var(--text-muted);line-height:1.5;margin:14px 0 4px;background:rgba(128,128,128,.06);padding:9px 11px;border-radius:9px}
+    .mon-dlg-acts{display:flex;gap:8px;justify-content:flex-end;flex-wrap:wrap;margin-top:16px}
+    .mon-detail-acts{justify-content:flex-start}
+    .mon-cancel,.mon-save,.mon-btn{border-radius:9px;padding:8px 14px;font-size:13px;cursor:pointer;border:1px solid rgba(128,128,128,.25);background:var(--input-bg,rgba(128,128,128,.08));color:var(--text)}
+    .mon-save{background:linear-gradient(135deg,#0a84ff,#5e5ce6);color:#fff;border:none;font-weight:600}
+    .mon-save:disabled{opacity:.45;cursor:not-allowed}
+    .mon-btn-danger{color:#ff453a;border-color:rgba(255,69,58,.4)}
+    .mon-kvs{display:grid;grid-template-columns:1fr 1fr;gap:6px 14px;margin:6px 0}
+    .mon-kv{display:flex;justify-content:space-between;gap:8px;font-size:12.5px;border-bottom:1px solid rgba(128,128,128,.12);padding:4px 0}
+    .mon-kv span{color:var(--text-muted)}
+    .mon-runs{display:flex;flex-direction:column;gap:5px}
+    .mon-run{display:flex;justify-content:space-between;align-items:center;gap:8px;font-size:12px;padding:7px 9px;border:1px solid rgba(128,128,128,.15);border-radius:9px}
+    .mon-run-clickable{cursor:pointer} .mon-run-clickable:hover{background:rgba(10,132,255,.08)}
+    .mon-run-l{display:flex;align-items:center;gap:7px} .mon-run-link{color:#0a84ff;font-weight:600}
+    .mon-rep-head{display:flex;align-items:flex-start;gap:10px}
+    .mon-sev-badge{font-size:11px;font-weight:700;color:#fff;background:var(--c);border-radius:7px;padding:3px 8px;flex:0 0 auto;margin-top:2px}
+    .mon-summary{font-size:13.5px;line-height:1.55;color:var(--text)}
+    .mon-metrics{display:flex;flex-wrap:wrap;gap:8px;margin:8px 0}
+    .mon-metric{background:var(--input-bg,rgba(128,128,128,.07));border-radius:9px;padding:7px 11px;font-size:12px}
+    .mon-metric span{display:block;color:var(--text-muted);font-size:10.5px;margin-bottom:2px}
+    .mon-changes{margin:4px 0;padding-left:2px;list-style:none;display:flex;flex-direction:column;gap:8px}
+    .mon-change{font-size:13px;line-height:1.5}
+    .mon-claim{color:var(--text)}
+    .mon-evchip{font-size:10.5px;font-weight:600;color:#0a84ff;background:rgba(10,132,255,.1);border:1px solid rgba(10,132,255,.3);border-radius:6px;padding:1px 6px;cursor:pointer;margin-left:2px}
+    .mon-ul{margin:4px 0;padding-left:18px;font-size:12.5px;color:var(--text-muted);line-height:1.5}
+    .mon-evlist{display:flex;flex-direction:column;gap:7px}
+    .mon-evcard{display:flex;gap:9px;border:1px solid rgba(128,128,128,.16);border-radius:10px;padding:8px 10px;transition:background .3s}
+    .mon-ev-hl{background:rgba(10,132,255,.14)}
+    .mon-evk{font-size:10.5px;font-weight:700;color:var(--text-muted);flex:0 0 auto;padding-top:2px}
+    .mon-evtitle{font-size:12.5px;line-height:1.4} .mon-evtitle a{color:#0a84ff;text-decoration:none}
+    .mon-evmeta{font-size:10.5px;color:var(--text-muted);margin-top:2px}
+    .mon-evkind-new{color:#30a46c;font-weight:600} .mon-evkind-continuing{color:var(--text-muted)}
+    .mon-repfoot{font-size:10.5px;color:var(--text-muted);margin-top:14px;text-align:right}
+    @media (max-width:768px){ .mon-kvs{grid-template-columns:1fr} .mon-dialog{max-height:92vh} }
   </style>
 </head>
 <body>
@@ -2141,6 +2207,7 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
       <button class="mode-btn" id="btn-news" data-i18n="tabNews">News</button>
       <button class="mode-btn" id="btn-info" data-i18n="tabCompanies">Companies</button><!-- (#R139) Information tab retired → Companies (id kept to avoid churn; mode string stays 'info') -->
       <button class="mode-btn" id="btn-stats" data-i18n="tabStats">Countries</button><!-- (#R73) tab renamed Stats→Data→Countries (user picked from 5 candidates) -->
+      <button class="mode-btn" id="btn-monitors" data-i18n="tabMonitors">Monitors</button><!-- (#R141) area-monitoring feature: saved area watches + evidence-backed change reports -->
       <button class="mode-btn mode-atlas" id="btn-community" title="Atlas">Atlas</button><!-- (#R98) Community removed; this sidebar slot now opens the Atlas AI console (id kept to avoid churn). (#R101) no ✨; Atlas-gradient background, News/Countries shape. -->
     </div>
     <div class="search-bar" id="sidebar-search-bar">
@@ -2176,6 +2243,7 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
     </div>
     <div class="content-area" id="countries-feed" style="display:none;"></div><!-- (#R78e) Countries gets its OWN feed so News & Countries can be separate workspace windows -->
     <div class="content-area" id="info-dashboard" style="display:none;"></div>
+    <div class="content-area" id="monitors-feed" style="display:none;"></div><!-- (#R141) Monitors tab feed (list + report/evidence detail overlays render here) -->
     <div class="content-area" id="community-feed" style="display:none;"></div>
     <!-- (#R112) Atlas is a REAL sidebar tab (like News/Information/Countries): in normal + mobile mode the Atlas
          console mounts, in normal flow, INTO this content area below the tab bar — no popup overlay. Workspace mode
@@ -8114,6 +8182,8 @@ window.addEventListener('DOMContentLoaded', () => {
         onShow:()=>{ try{ window._wsRenderCountries&&window._wsRenderCountries(); }catch(_){} },
         onHide:()=>{ try{ window._clearCompare&&window._clearCompare(); }catch(_){} try{ const p=document.getElementById('country-popup'); if(p) p.style.display='none'; }catch(_){} } },
       {id:'info',     sels:['#info-dashboard'],  t:()=>T('Companies','企業','Unternehmen','Компании','Empresas'), min:[280,260], defHidden:true, onWrap:()=>{ try{ if(typeof renderCompanies==='function') renderCompanies(); }catch(_){} }},
+      /* (#R141) Monitors window — area watches + evidence-backed reports. Adopts the #monitors-feed content area. */
+      {id:'monitors', sels:['#monitors-feed'],   t:()=>T('Monitors','モニター','Monitore','Мониторы','Monitores'), min:[300,300], defHidden:true, onWrap:()=>{ try{ if(window.IntMapMonitors&&IntMapMonitors.render) IntMapMonitors.render(); }catch(_){} }, onShow:()=>{ try{ if(window.IntMapMonitors&&IntMapMonitors.render) IntMapMonitors.render(); }catch(_){} }},
       /* (#R101) Community window removed from workspace mode ("まだコミュニティ機能が残っている") — the community
          feature was already retired from the sidebar (R98); this leftover window/menu entry is gone too. */
       {id:'map',   sels:['#map-container'],   t:()=>T('Map','地図','Karte','Карта','Mapa'), min:[380,300]},
@@ -9562,6 +9632,7 @@ window.addEventListener('DOMContentLoaded', () => {
     try{ pushCommunityFeatures(); }catch(_){}   /* show community pins only on the Community tab */
     /* Hide all panels first (pin-mode toggle now lives inside #ai-geocode-row, #28) */
     feed.style.display='none'; if(cfeed) cfeed.style.display='none'; dash.style.display='none'; comm.style.display='none'; if(afeed) afeed.style.display='none'; filterToggle.style.display='none';
+    { const _mf=document.getElementById('monitors-feed'); if(_mf) _mf.style.display='none'; }   /* (#R141) hide Monitors feed unless its tab is active */
     { const gr=document.getElementById('ai-geocode-row'); if(gr) gr.style.display='none'; }
     /* Stats compare panel only belongs on the Stats tab (#26) */
     if(currentMode!=='stats'){ const scf=document.getElementById('stats-compare-fixed'); if(scf){ scf.classList.remove('show'); scf.innerHTML=''; } feed.style.paddingBottom=''; }
@@ -9581,7 +9652,7 @@ window.addEventListener('DOMContentLoaded', () => {
        Also require the News window to be visible in ws-mode (_wsNewsHidden() is always false outside ws-mode, so
        the normal News-tab behaviour is unchanged). */
     if(sumBtn) sumBtn.style.display=(isNewsTab && !(window._wsNewsHidden&&window._wsNewsHidden()))?'':'none';
-    { const ip=document.getElementById('search-input'); if(ip) ip.placeholder = (currentMode==='stats'||currentMode==='info') ? (currentLang==='jp'?'絞り込み...':currentLang==='de'?'Filtern…':currentLang==='ru'?'Фильтр…':currentLang==='es'?'Filtrar…':'Filter…') : t('searchPh'); }
+    { const ip=document.getElementById('search-input'); if(ip) ip.placeholder = (currentMode==='stats'||currentMode==='info'||currentMode==='monitors') ? (currentLang==='jp'?'絞り込み...':currentLang==='de'?'Filtern…':currentLang==='ru'?'Фильтр…':currentLang==='es'?'Filtrar…':'Filter…') : t('searchPh'); }
 
     /* (#R11) No tab selected → blank sidebar content (map stays prominent). News pins still load when the
        user opens the News tab. (#R19) The blank state now hosts the opt-in Apple-style widget board. */
@@ -9594,6 +9665,9 @@ window.addEventListener('DOMContentLoaded', () => {
       try{ window.IntMapConsole&&window.IntMapConsole.mountTab&&window.IntMapConsole.mountTab(); }catch(_){}
       try{ updateOcclusion(); }catch(_){} return; }
     if(currentMode==='info'){ dash.style.display='flex'; sb.style.display='flex'; renderDashboard(); updateOcclusion(); return; }
+    if(currentMode==='monitors'){ const mf=document.getElementById('monitors-feed'); if(mf) mf.style.display='flex'; sb.style.display='flex';   /* (#R141) Monitors tab */
+      try{ window.IntMapMonitors&&window.IntMapMonitors.render(searchVal()); }catch(_){}
+      try{ updateOcclusion(); }catch(_){} return; }
     if(currentMode==='community'){ comm.style.display='flex'; sb.style.display='none'; loadCommunity(); updateOcclusion(); return; }
     if(currentMode==='stats'){ if(cfeed) cfeed.style.display='flex'; sb.style.display='flex'; renderStats(searchVal()); return; }
     if(currentMode==='news'||currentMode==='saved'){
@@ -11081,7 +11155,7 @@ window.addEventListener('DOMContentLoaded', () => {
         want.forEach(id=>{ const cb=document.getElementById(id); if(cb){ if(!cb.checked){ try{ cb.checked=true; cb.dispatchEvent(new Event('change',{bubbles:true})); }catch(_){} } } else pending.push(id); });
         if(pending.length&&tries<25){ want.length=0; want.push.apply(want,pending); setTimeout(poll,220); } })();
       /* open the saved tab */
-      try{ if(s.mode){ const map2={news:'tab.news',saved:'tab.news',info:'tab.info',stats:'tab.stats',atlas:'tab.atlas'}[s.mode]; if(map2&&window.IntMapOS) setTimeout(()=>{ try{ if(!currentMode) IntMapOS.exec(map2,{source:'restore'}); }catch(_){} },500); } }catch(_){}
+      try{ if(s.mode){ const map2={news:'tab.news',saved:'tab.news',info:'tab.info',stats:'tab.stats',monitors:'tab.monitors',atlas:'tab.atlas'}[s.mode]; if(map2&&window.IntMapOS) setTimeout(()=>{ try{ if(!currentMode) IntMapOS.exec(map2,{source:'restore'}); }catch(_){} },500); } }catch(_){}
       /* set the time-machine year */
       try{ if(s.year&&window.IntMapTime&&window.IntMapTime.setYear){ setTimeout(()=>{ try{ window.IntMapTime.setYear(s.year,{source:'restore'}); }catch(_){} },900); } }catch(_){}
       setTimeout(()=>{ _restoring=false; },1600);   /* stop suppressing saves once the restore settles */ }
@@ -11092,6 +11166,7 @@ window.addEventListener('DOMContentLoaded', () => {
   IntMapOS.register('tab.news', ()=>setMode('news','btn-news'), {label:'News tab', btn:'btn-news', group:'tab'});
   IntMapOS.register('tab.info', ()=>setMode('info','btn-info'), {label:'Companies tab', btn:'btn-info', group:'tab'});   /* (#R139) Information → Companies (command id kept) */
   IntMapOS.register('tab.stats', ()=>setMode('stats','btn-stats'), {label:'Countries tab', btn:'btn-stats', group:'tab'});
+  IntMapOS.register('tab.monitors', ()=>setMode('monitors','btn-monitors'), {label:'Monitors tab', btn:'btn-monitors', group:'tab'});   /* (#R141) area monitors */
   /* (#R112) The 4th sidebar slot is Atlas. In normal + mobile mode it is a REAL tab (setMode → renders into
      #atlas-feed like News/Info/Countries); in workspace mode Atlas keeps its own floating window. */
   const _atlasTab=()=>{ try{ if(document.body.classList.contains('ws-mode')){ if(window.IntMapConsole&&IntMapConsole.open) IntMapConsole.open(); } else setMode('atlas','btn-community'); }catch(_){} };
@@ -11103,6 +11178,7 @@ window.addEventListener('DOMContentLoaded', () => {
   document.getElementById('newsfilter-saved').onclick=()=>{ if(currentMode!=='saved') setMode('saved','btn-news'); };
   document.getElementById('btn-info').onclick=()=>IntMapOS.exec('tab.info',{source:'ui'});
   document.getElementById('btn-stats').onclick=()=>IntMapOS.exec('tab.stats',{source:'ui'});
+  document.getElementById('btn-monitors').onclick=()=>IntMapOS.exec('tab.monitors',{source:'ui'});   /* (#R141) */
   /* (#R98) Community feature removed — this sidebar button is the Atlas tab. (#R112) It now behaves like the other
      tabs (News/Info/Countries): a true kernel tab command that renders Atlas INSIDE the sidebar/bottom-sheet. */
   document.getElementById('btn-community').onclick=()=>IntMapOS.exec('tab.atlas',{source:'ui'});
@@ -15769,7 +15845,7 @@ window.addEventListener('DOMContentLoaded', () => {
       grip.addEventListener('pointerup',dragEnd); grip.addEventListener('pointercancel',dragEnd);
     }
     /* drag-to-collapse from the top of the content, only when fully expanded */
-    ['live-news-feed','info-dashboard','community-feed','news-reader-pane'].forEach(id=>{
+    ['live-news-feed','info-dashboard','monitors-feed','community-feed','news-reader-pane'].forEach(id=>{   /* (#R141) Monitors feed drags-to-collapse like the others */
       const sc=document.getElementById(id); if(!sc) return; let active=false,sy=0;
       sc.addEventListener('touchstart',e=>{ if(!mq.matches||currentDetent!=='full'){active=false;return;} sy=e.touches[0].clientY; active=false; },{passive:true});
       sc.addEventListener('touchmove',e=>{ if(!mq.matches||currentDetent!=='full') return; const y=e.touches[0].clientY,dy=y-sy;
@@ -18036,6 +18112,9 @@ window.addEventListener('DOMContentLoaded', () => {
       toggle(){ if(this.active()) this.exit(); else this.start(); },
       exit(){ state='off'; raw=[]; simplified=[]; loopRings=[]; lockedArea=0; lengthKm=0; lastPx=null; closeAux=null; setData(); unwire(); try{ map.dragPan.enable(); }catch(_){} try{ map.getCanvas().style.cursor=''; }catch(_){} setBtn(false); if(panel) panel.style.display='none'; },
       onResolution(v){ smoothing=Math.max(0,Math.min(100,+v||0)); recomputeLine(); setData(); updateNumbers(); },
+      /* (#R141) Expose the drawn area as a GeoJSON Polygon/MultiPolygon for the area-monitor feature.
+         Finishes the stroke first if it is still being drawn, so "monitor this drawn area" works mid-gesture. */
+      currentGeometry(){ try{ if(state==='drawing') finish(); const rings=(loopRings||[]).filter(r=>r&&r.length>=4); if(!rings.length) return null; return rings.length===1?{type:'Polygon',coordinates:[rings[0]]}:{type:'MultiPolygon',coordinates:rings.map(r=>[r])}; }catch(_){ return null; } },
       /* Debug/verification hook (same spirit as window.__sat / window.__ai): lets us prove the
          area-invariant-under-smoothing contract and the geodesic length without map interaction. */
       _debug:{ enclosedArea, rdp,
@@ -30136,6 +30215,38 @@ window.addEventListener('DOMContentLoaded', () => {
           if(!okE&&_pois.length) html+=warn('⚠ '+L('Could not draw the pins (map still loading)','ピンを描画できませんでした（地図読込中）','Pins nicht gezeichnet','Метки не отрисованы','Pines no dibujados'));
           return R(true, html); }
         case 'module': return doModule(a);
+        case 'monitor': {   /* (#R141) area monitors — every reply reflects the REAL DB result (never a false "created/ran") */
+          const M=window.IntMapMonitors;
+          if(!M) return R(false, warn('⚠ '+L('Monitors are unavailable.','監視機能を利用できません。','Monitore nicht verfügbar.','Мониторы недоступны.','Monitores no disponibles.')));
+          const op=String(a.op||(a.name?'create':'list')).toLowerCase();
+          const loginWarn=()=>R(false, warn('⚠ '+L('Log in to use monitors.','監視機能を使うにはログインが必要です。','Zum Nutzen der Monitore anmelden.','Войдите, чтобы использовать мониторы.','Inicia sesión para usar los monitores.')));
+          const openBtn='<button class="atl-ctl-btn" data-run="'+esc(encodeURIComponent(L('open my monitors','監視一覧を開く','meine Monitore öffnen','открыть мои мониторы','abrir mis monitores')))+'">'+esc(L('Open Monitors','監視を開く','Monitore öffnen','Открыть мониторы','Abrir monitores'))+'</button>';
+          const needTarget=['open','pause','resume','run','delete'].includes(op);
+          let rows=null, target=null;
+          if(needTarget){ const lr=await M.atlas.listText(); if(lr&&lr.error==='login') return loginWarn(); rows=(lr&&lr.ok)?lr.rows:[];
+            const which=String(a.which||a.name||'').trim().toLowerCase();
+            if(which) target=rows.find(r=>String(r.name||'').toLowerCase().includes(which))||rows.find(r=>String(r.area_label||'').toLowerCase().includes(which));
+            if(!target && a.index!=null && isFinite(+a.index)) target=rows[(+a.index)-1];
+            if(!target && rows.length===1) target=rows[0];
+            if(!target) return R(false, warn('⚠ '+L('No matching monitor found.','該当する監視が見つかりません。','Kein passender Monitor.','Подходящий монитор не найден.','No se encontró un monitor.'))); }
+          if(op==='create'){ const area=M.activeArea();
+            if(!area) return R(false, warn('⚠ '+L('Select a radius, draw an area, or resolve a region first — then say “monitor this area”.','先に半径・描画・地域指定で範囲を決めてから「この範囲を監視して」と指示してください。','Erst einen Radius/gezeichneten Bereich/eine Region wählen.','Сначала выберите радиус, область или регион.','Primero selecciona un radio, dibuja un área o resuelve una región.')));
+            const res=await M.atlas.create({name:a.name, sources:a.sources, intervalMin:a.intervalMin});
+            if(!res||!res.ok){ if(res&&res.error==='login') return loginWarn(); return R(false, warn('⚠ '+esc((res&&res.error)||L('Could not create the monitor.','監視を作成できませんでした。','Monitor konnte nicht erstellt werden.','Не удалось создать монитор.','No se pudo crear el monitor.')))); }
+            try{ IntMapOS.exec('tab.monitors',{source:'atlas'}); }catch(_){}
+            return R(true, note('✓ '+L('Monitor created','監視を作成しました','Monitor erstellt','Монитор создан','Monitor creado')+': '+esc(res.monitor.name))+openBtn, {objectIds:[res.monitor.id]}); }
+          if(op==='list'){ const lr=await M.atlas.listText(); if(lr&&lr.error==='login') return loginWarn(); try{ IntMapOS.exec('tab.monitors',{source:'atlas'}); }catch(_){}
+            const n=(lr&&lr.ok&&lr.rows)?lr.rows.length:0; return R(true, note('✓ '+L('Your monitors','あなたの監視','Ihre Monitore','Ваши мониторы','Tus monitores')+' ('+n+')')+openBtn); }
+          if(op==='open'){ M.openDetail(target.id); return R(true, note('✓ '+L('Opened','開きました','Geöffnet','Открыто','Abierto')+': '+esc(target.name))); }
+          if(op==='pause'){ const r=await M.atlas.pause(target.id); return r&&r.ok?R(true, note('✓ '+L('Paused','一時停止しました','Pausiert','Приостановлено','Pausado')+': '+esc(target.name))):R(false, warn('⚠ '+L('Could not pause the monitor.','一時停止できませんでした。','Konnte nicht pausieren.','Не удалось приостановить.','No se pudo pausar.'))); }
+          if(op==='resume'){ const r=await M.atlas.resume(target.id); return r&&r.ok?R(true, note('✓ '+L('Resumed','再開しました','Fortgesetzt','Возобновлено','Reanudado')+': '+esc(target.name))):R(false, warn('⚠ '+L('Could not resume the monitor.','再開できませんでした。','Konnte nicht fortsetzen.','Не удалось возобновить.','No se pudo reanudar.'))); }
+          if(op==='run'){ const r=await M.atlas.run(target.id);
+            if(r&&r.ok) return R(true, note('✓ '+L('Ran now','今すぐ実行しました','Jetzt ausgeführt','Запущено','Ejecutado')+': '+esc(target.name)+' — '+esc(M.statusLabel(r.status)))+openBtn);
+            if(r&&r.error==='login') return loginWarn();
+            return R(false, warn('⚠ '+esc((r&&r.error)||L('The run failed.','実行に失敗しました。','Lauf fehlgeschlagen.','Запуск не удался.','Falló la ejecución.')))); }
+          if(op==='delete'){ const r=await M.atlas.remove(target.id); return r&&r.ok?R(true, note('✓ '+L('Deleted','削除しました','Gelöscht','Удалено','Eliminado')+': '+esc(target.name))):R(false, warn('⚠ '+L('Could not delete the monitor.','削除できませんでした。','Konnte nicht löschen.','Не удалось удалить.','No se pudo eliminar.'))); }
+          return R(false, warn('⚠ '+L('Unknown monitor operation.','不明な監視操作です。','Unbekannte Monitor-Operation.','Неизвестная операция монитора.','Operación de monitor desconocida.')));
+        }
         case 'control': return doControl(a);
         case 'answer': return R(true, '<div style="font-size:12.5px;line-height:1.62;">'+mdMini(a.text||'')+'</div>');
         default: { if(a.target||a.name){ const c=doControl({target:a.target||a.name,value:a.value,on:a.on}); if(c.ok) return c; } return R(false, warn('⚠ '+L('Unknown action','不明な操作','Unbekannte Aktion','Неизвестное действие','Acción desconocida')+': '+esc(a.type||''))); }
@@ -30197,6 +30308,7 @@ window.addEventListener('DOMContentLoaded', () => {
         +'ANSWER: {"type":"answer","text":str} — for STABLE knowledge or explanation questions ("ギリシャの文化を教えて", "why is the Sahel dry?"), LISTEN to what was actually asked and give the FULL substantive answer HERE, in "text", in '+lang+' (up to ~250 words; you may use ## section lines, **bold**, "- " bullets). CITE sources by NAME only (e.g. "according to the World Bank", "Reuters reported") — do NOT put article/source URLs or markdown links in the prose: the user reported that Atlas\'s attached links frequently 404, and fabricated or guessed URLs are the cause. The ONLY urls you may output are ones that literally appear in the evidence block or your web_search results, and only inside "analyze"/"mapReport" items — never invent a URL for an "answer". Do NOT deflect such questions to "brief" or any panel — the user asked a question, so answer it (you may ADD a relevant map action like flyTo alongside). Also use "answer" to honestly explain anything you could NOT do. Answer text must NOT pretend an un-emitted action happened.\n'
         +'INTMAP HELP / HOW-TO: you are ALSO IntMap\'s built-in help. When the user asks how to DO something in IntMap, what a feature does, or what the app / you can do ("how do I compare countries?", "タイムマシンの使い方", "how do I turn on a layer?", "what can you do?"), ANSWER it with {"type":"answer"} using the feature knowledge in THIS prompt (the action list above IS the feature set). Be concrete and concise: name the panel/control (Layers panel, the Countries tab, the time-machine button bottom-right, workspace mode) AND give the exact plain-language phrase they can type to me to do it (e.g. \'just say "compare Japan and Germany"\'). You MAY also emit the action itself alongside the answer to demonstrate it. Do not route how-to questions through analyze/brief.\n'
         +'CURRENT-FACT GROUNDING (hallucination ban — the user was given a WRONG current prime minister once; that must never happen again): your parametric memory of "who currently holds office / what is the current government, war status, price, record" is stale by definition. For ANY question whose answer can change over time — current leaders (首相/大統領/首脳), cabinets, election results, ongoing conflicts, prices, "latest/current/now/最近/現在" anything — NEVER answer from memory with {"type":"answer"}. Emit {"type":"analyze","question":...} (it runs a live web search and answers from evidence) or {"type":"mapReport"} when mappable. If you are not fully certain a fact is timeless, treat it as current and route it through analyze.\n'
+        +'AREA MONITORS (saved SERVER-SIDE watches — they re-check an area on a schedule even when the page is closed, and generate an EVIDENCE-BACKED report ONLY when a real change is detected, never on every run): {"type":"monitor","op":"create"|"list"|"open"|"pause"|"resume"|"run"|"delete","name"?:str,"which"?:str,"index"?:int,"intervalMin"?:int,"sources"?:[str]}. op:"create" saves a monitor over the CURRENTLY SELECTED AREA — a radius circle, a drawn area, OR a resolved region outline (the user must have ONE active; if none is active, the action tells them to set one first — do NOT invent an area). Pass "name" and optionally "intervalMin" (minutes, ≥30, default 360) and "sources" (["news"] is the only source for now). op:"list" opens the Monitors tab. op:"open"/"pause"/"resume"/"run"/"delete" act on an EXISTING monitor identified by "which" (its name/area, fuzzy-matched) or "index" (1-based). Use for "この範囲を監視して"/"monitor this area" (create), "監視一覧"/"my monitors" (list), "東京の監視を今すぐ実行/一時停止/削除". Login is required. NEVER claim a monitor was created/paused/run/deleted unless the action actually succeeded (the reply reflects the real result).\n'
         +'UNIVERSAL fallback for anything not listed above (so EVERY operation is possible): {"type":"control","target":"<on-screen control name or #id>","value"?:str|num,"on"?:bool} — finds & clicks/sets/toggles any button, checkbox, dropdown, slider, date picker or input. Useful addressable patterns (every UI element is named, incl. per-layer micro-controls): "favorite: <layer name>" (★), "date: <layer name>" with value "YYYY-MM-DD" (change a dated raster layer\'s date — e.g. 「気温レイヤーの日付を2023-06-01に」), "close legend: <name>", "opacity: <layer>". Prefer a specific action; otherwise ALWAYS use "control" rather than refusing.\n'
         +'MODULE fallback (advanced — open/close any IntMap subsystem panel by name, incl. ones with no toolbar button): {"type":"module","name":"IntMapX","method":"open"|"toggle"|"close"|"clear"}. Use only when no specific action or "control" fits. Available modules: '+moduleCatalog()+'\n'
         +'Valid metric KEY values ONLY: pop, density, area, gdp, gdppc, hdi, dem (democracy index), milSpend (military spending), milSpendGDP (military % of GDP), tfr (fertility rate). If a needed metric is not in this list, do NOT invent it — explain in "say" and omit that action. Default n=15.\n'
@@ -30766,6 +30878,9 @@ window.addEventListener('DOMContentLoaded', () => {
       return {keys:out,miss}; }
     function localPlan(q){ const s=String(q||'').trim(); if(!s) return null; const low=s.toLowerCase();
       const A=a=>({actions:[a],confident:true});
+      /* (#R141) AREA MONITORS — deterministic (no-AI) shortcuts. Anchored so they never shadow a compound request. */
+      if(/^(monitor|watch)( this| the)?( area| region| radius| circle| selection| here)?$|^(この(範囲|地域|エリア|円)を?|ここを?)(監視|ウォッチ)(して|する)?$|^(diese[nrs]? (bereich|region|gebiet)|hier) (überwachen|beobachten)$|^(следить за|мониторить)( этой)?( областью| зоной)?$|^(monitorear|vigilar)( esta)?( área| zona| región)?$/i.test(low)) return A({type:'monitor',op:'create'});
+      if(/^(open |show |view )?(my )?monitors$|^監視一覧を?開く$|^(モニター一覧|監視一覧|監視リスト|監視を開く|モニターを開く)$|^(meine )?monitore( öffnen)?$|^(открыть )?(мои )?мониторы$|^(abrir |ver )?(mis )?monitores$/i.test(low)) return A({type:'monitor',op:'list'});
       if(/^(switch to |go |set |enable |turn on )?(dark( ?mode| ?theme)?|ダーク(モード|テーマ)?|暗い(テーマ|モード)|dunkel(modus|es design)?|тёмн(ая|ый)( тема| режим)?|modo oscuro|tema oscuro)$/i.test(low)) return A({type:'theme',mode:'dark'});
       if(/^(switch to |go |set |enable |turn on )?(light( ?mode| ?theme)?|ライト(モード|テーマ)?|明るい(テーマ|モード)|hell(es design|modus)?|светл(ая|ый)( тема| режим)?|modo claro|tema claro)$/i.test(low)) return A({type:'theme',mode:'light'});
       if(/^(auto|system)( ?theme| ?mode| default)?$|^(自動|システム)(テーマ|デフォルト)?$/i.test(low)) return A({type:'theme',mode:'auto'});
@@ -32125,6 +32240,343 @@ window.addEventListener('DOMContentLoaded', () => {
      Real gridded-census data, not a country-share guess: the WorldPop Global Project population raster
      (~100 m grid, 2020) summed over the exact polygon by the WorldPop stats API (api.worldpop.org, CORS-open,
      async task polling). Rings are decimated to ≤80 vertices for the GET URL; results are cached per shape. */
+  /* ==================== (#R141) AREA MONITORS — saved area watches + evidence-backed change reports ====================
+     Additive & self-contained. Lives inside the main app scope so it can read currentLang / map / radiusItems /
+     currentUser / requireLogin / DrawTool / IntMapRegionResolver / IntMapOutline. Data + auth via window.sb (RLS
+     scopes every read to the owner). The server-side runner is the monitor-run Edge Function; this module only
+     CREATES/EDITS monitors and DISPLAYS runs/evidence/reports — it never fabricates a run or a report. */
+  (function(){
+    const I18=(o)=>{ try{ Object.assign(i18n.en,o.en); Object.assign(i18n.jp,o.jp); Object.assign(i18n.de,o.de); Object.assign(i18n.ru,o.ru); Object.assign(i18n.es,o.es); }catch(_){} };
+    I18({
+      en:{ tabMonitors:'Monitors' }, jp:{ tabMonitors:'モニター' }, de:{ tabMonitors:'Monitore' }, ru:{ tabMonitors:'Мониторы' }, es:{ tabMonitors:'Monitores' }
+    });
+  })();
+  window.IntMapMonitors=(function(){
+    const DB=window.sb;
+    const FN_URL=((window.SUPABASE_URL||'').replace(/\/$/,''))+'/functions/v1/monitor-run';
+    const S=(v)=>{ try{ return window.IntMapSafe? window.IntMapSafe.html(v==null?'':String(v)) : String(v==null?'':v).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }catch(_){ return ''; } };
+    const URLS=(v)=>{ try{ return window.IntMapSafe? window.IntMapSafe.url(v) : (/^https?:\/\//i.test(String(v||''))?String(v):'#'); }catch(_){ return '#'; } };
+    const ML=(en,jp,de,ru,es)=>{ const l=(typeof currentLang!=='undefined'?currentLang:'en'); return l==='jp'?jp:l==='de'?de:l==='ru'?ru:l==='es'?(es||en):en; };
+    const _loggedIn=()=> typeof currentUser!=='undefined' && !!currentUser;
+    const _promptLogin=()=>{ try{ if(typeof requireLogin==='function') return requireLogin(); if(typeof openAuthModal==='function') openAuthModal(); }catch(_){} };
+
+    /* ---- status / severity vocab (5 languages) ---- */
+    const STATUS_L={
+      success:()=>ML('Change reported','変化を報告','Änderung gemeldet','Изменение','Cambio informado'),
+      'success+report':()=>ML('Change reported','変化を報告','Änderung gemeldet','Изменение','Cambio informado'),
+      'partial+report':()=>ML('Change (partial)','変化（一部）','Änderung (teilweise)','Изменение (частично)','Cambio (parcial)'),
+      success_no_change:()=>ML('No change','変化なし','Keine Änderung','Без изменений','Sin cambios'),
+      partial:()=>ML('Partial','一部取得','Teilweise','Частично','Parcial'),
+      source_unavailable:()=>ML('Source unavailable','ソース取得不可','Quelle nicht verfügbar','Источник недоступен','Fuente no disponible'),
+      ai_failed:()=>ML('AI failed (data kept)','AI失敗（データは保持）','KI fehlgeschlagen','Сбой ИИ','Fallo de IA'),
+      timed_out:()=>ML('Timed out','タイムアウト','Zeitüberschreitung','Тайм-аут','Tiempo agotado'),
+      invalid_geometry:()=>ML('Invalid area','範囲が無効','Ungültiger Bereich','Неверная область','Área no válida'),
+      quota_exceeded:()=>ML('Quota exceeded','上限超過','Kontingent überschritten','Превышена квота','Cuota excedida'),
+      disabled:()=>ML('Paused','停止中','Pausiert','Пауза','Pausado'),
+      internal_error:()=>ML('Error','エラー','Fehler','Ошибка','Error'),
+      running:()=>ML('Running…','実行中…','Läuft…','Выполняется…','Ejecutando…')
+    };
+    const statusLabel=(s)=>{ const f=STATUS_L[s]; return f?f():(s||'—'); };
+    const SEV_COLOR={ none:'#8e8e93', low:'#30a46c', medium:'#ff9f0a', high:'#ff453a', critical:'#ff2d55' };
+    const SEV_L={
+      none:()=>ML('None','なし','Keine','Нет','Ninguna'), low:()=>ML('Low','低','Niedrig','Низкая','Baja'),
+      medium:()=>ML('Medium','中','Mittel','Средняя','Media'), high:()=>ML('High','高','Hoch','Высокая','Alta'),
+      critical:()=>ML('Critical','重大','Kritisch','Критическая','Crítica')
+    };
+    const sevLabel=(s)=>{ const f=SEV_L[s]; return f?f():(s||'—'); };
+    const SRC_L={ news:()=>ML('News','ニュース','Nachrichten','Новости','Noticias'), earthquake:()=>ML('Earthquakes','地震','Erdbeben','Землетрясения','Terremotos'), weather:()=>ML('Weather','気象','Wetter','Погода','Clima'), fire:()=>ML('Fires','火災','Brände','Пожары','Incendios') };
+    const srcLabel=(s)=>{ const f=SRC_L[s]; return f?f():s; };
+
+    /* ---- small helpers ---- */
+    function _fmtWhen(iso){ if(!iso) return '—'; try{ const d=new Date(iso), now=Date.now(), diff=(now-d.getTime())/1000;
+      const rel=(n,u1,uj)=>{ const l=(typeof currentLang!=='undefined'?currentLang:'en'); return l==='jp'?(Math.round(n)+uj):(Math.round(n)+' '+u1+(Math.round(n)===1?'':'s')+' '+ML('ago','','','','')); };
+      if(Math.abs(diff)<60) return ML('just now','たった今','gerade eben','только что','ahora mismo');
+      if(diff<3600) return ML(Math.round(diff/60)+' min ago',Math.round(diff/60)+'分前','vor '+Math.round(diff/60)+' Min','мин назад',Math.round(diff/60)+' min');
+      if(diff<86400) return ML(Math.round(diff/3600)+'h ago',Math.round(diff/3600)+'時間前','vor '+Math.round(diff/3600)+' Std',Math.round(diff/3600)+'ч назад','hace '+Math.round(diff/3600)+' h');
+      return d.toLocaleDateString();
+    }catch(_){ return '—'; } }
+    function _fmtNext(iso,enabled){ if(enabled===false) return statusLabel('disabled'); if(!iso) return '—'; try{ const d=new Date(iso), diff=(d.getTime()-Date.now())/1000;
+      if(diff<=0) return ML('due now','まもなく','fällig','скоро','pronto');
+      if(diff<3600) return ML('in '+Math.round(diff/60)+' min','約'+Math.round(diff/60)+'分後','in '+Math.round(diff/60)+' Min','через '+Math.round(diff/60)+' мин','en '+Math.round(diff/60)+' min');
+      if(diff<86400) return ML('in '+Math.round(diff/3600)+'h','約'+Math.round(diff/3600)+'時間後','in '+Math.round(diff/3600)+' Std','через '+Math.round(diff/3600)+'ч','en '+Math.round(diff/3600)+' h');
+      return ML('in '+Math.round(diff/86400)+'d','約'+Math.round(diff/86400)+'日後','in '+Math.round(diff/86400)+' T','через '+Math.round(diff/86400)+'д','en '+Math.round(diff/86400)+' d');
+    }catch(_){ return '—'; } }
+    function _decimGeom(geom){ try{ if(!geom||!geom.coordinates) return geom;
+      const dr=(ring)=>{ let r=ring.map(p=>[+(+p[0]).toFixed(5),+(+p[1]).toFixed(5)]); if(r.length>82){ const step=Math.ceil(r.length/80); const out=[]; for(let i=0;i<r.length;i+=step) out.push(r[i]); if(out[out.length-1][0]!==r[r.length-1][0]||out[out.length-1][1]!==r[r.length-1][1]) out.push(r[r.length-1]); r=out; } return r; };
+      if(geom.type==='Polygon') return {type:'Polygon',coordinates:geom.coordinates.map(dr)};
+      if(geom.type==='MultiPolygon') return {type:'MultiPolygon',coordinates:geom.coordinates.map(poly=>poly.map(dr))};
+      return geom; }catch(_){ return geom; } }
+    function _bboxOf(geom){ try{ let w=Infinity,s=Infinity,e=-Infinity,n=-Infinity; const scan=(ring)=>ring.forEach(p=>{ if(p[0]<w)w=p[0]; if(p[0]>e)e=p[0]; if(p[1]<s)s=p[1]; if(p[1]>n)n=p[1]; });
+      if(geom.type==='Polygon') geom.coordinates.forEach(scan); else if(geom.type==='MultiPolygon') geom.coordinates.forEach(poly=>poly.forEach(scan)); else return null;
+      return isFinite(w)?[w,s,e,n]:null; }catch(_){ return null; } }
+    function _circlePoly(center,km){ try{ if(window.IntMapPopArea&&IntMapPopArea.circleGeom) return IntMapPopArea.circleGeom(center,km);
+      const pts=[],R=6371; for(let i=0;i<=48;i++){ const brng=i/48*2*Math.PI; const lat1=center[1]*Math.PI/180,lng1=center[0]*Math.PI/180,d=km/R;
+        const lat2=Math.asin(Math.sin(lat1)*Math.cos(d)+Math.cos(lat1)*Math.sin(d)*Math.cos(brng));
+        const lng2=lng1+Math.atan2(Math.sin(brng)*Math.sin(d)*Math.cos(lat1),Math.cos(d)-Math.sin(lat1)*Math.sin(lat2));
+        pts.push([lng2*180/Math.PI,lat2*180/Math.PI]); } return {type:'Polygon',coordinates:[pts]}; }catch(_){ return null; } }
+    function _distLabel(km){ try{ if(typeof distHTML==='function'){ const t=distHTML(km); return String(t).replace(/<[^>]+>/g,''); } }catch(_){} return Math.round(km)+' km'; }
+
+    /* ---- the unified "active area" accessor: radius > drawn > resolved region ---- */
+    function activeArea(){
+      try{
+        if(typeof radiusItems!=='undefined' && radiusItems && radiusItems.length){
+          const c=radiusItems.find(r=>r.id===window._activeRadiusId)||radiusItems[radiusItems.length-1];
+          if(c&&c.center&&isFinite(c.radiusKm)){ const geom=_circlePoly(c.center,c.radiusKm);
+            return { geometry_kind:'circle', center_lng:c.center[0], center_lat:c.center[1], radius_km:c.radiusKm, geometry:geom, bbox:_bboxOf(geom),
+              label:_distLabel(c.radiusKm)+' · '+c.center[1].toFixed(2)+', '+c.center[0].toFixed(2) }; }
+        }
+        if(window.DrawTool&&DrawTool.active&&DrawTool.active()&&DrawTool.currentGeometry){ const g=DrawTool.currentGeometry();
+          if(g){ const dg=_decimGeom(g); return { geometry_kind:(g.type==='MultiPolygon'?'multipolygon':'polygon'), geometry:dg, bbox:_bboxOf(dg), label:ML('Drawn area','描画範囲','Gezeichneter Bereich','Нарисованная область','Área dibujada') }; } }
+        if(window.IntMapOutline&&IntMapOutline.active&&IntMapOutline.active()&&IntMapOutline.current){ const cur=IntMapOutline.current();
+          if(cur&&cur.geo){ const dg=_decimGeom(cur.geo); return { geometry_kind:'region', geometry:dg, bbox:_bboxOf(dg), label:(cur.name||ML('Region','地域','Region','Регион','Región')) }; } }
+      }catch(_){}
+      return null;
+    }
+    function mapViewArea(){ try{ if(!map||!map.getBounds) return null; const b=map.getBounds(),w=b.getWest(),s=b.getSouth(),e=b.getEast(),n=b.getNorth();
+      const geom={type:'Polygon',coordinates:[[[w,s],[e,s],[e,n],[w,n],[w,s]]]}; return { geometry_kind:'polygon', geometry:geom, bbox:[w,s,e,n], label:ML('Current map view','現在の地図表示','Aktuelle Kartenansicht','Текущий вид карты','Vista actual del mapa') }; }catch(_){ return null; } }
+
+    /* ---- map overlay for a monitor area + change points ---- */
+    function _ensureLayers(){ try{ if(!map||!map.getStyle||!map.isStyleLoaded||!map.isStyleLoaded()) return false;
+      if(!map.getSource('im-mon-area')){ map.addSource('im-mon-area',{type:'geojson',data:{type:'FeatureCollection',features:[]}});
+        map.addLayer({id:'im-mon-area-fill',type:'fill',source:'im-mon-area',paint:{'fill-color':'#0a84ff','fill-opacity':0.10}});
+        map.addLayer({id:'im-mon-area-line',type:'line',source:'im-mon-area',paint:{'line-color':'#0a84ff','line-width':2,'line-dasharray':[2,1.5]}}); }
+      if(!map.getSource('im-mon-pts')){ map.addSource('im-mon-pts',{type:'geojson',data:{type:'FeatureCollection',features:[]}});
+        map.addLayer({id:'im-mon-pts-c',type:'circle',source:'im-mon-pts',paint:{'circle-radius':7,'circle-color':'#ff375f','circle-stroke-color':'#fff','circle-stroke-width':2,'circle-opacity':0.9}}); }
+      return true; }catch(_){ return false; } }
+    function showOnMap(area,points){ try{ if(!_ensureLayers()) return; const af=[]; if(area&&area.geometry) af.push({type:'Feature',geometry:area.geometry,properties:{}});
+      map.getSource('im-mon-area').setData({type:'FeatureCollection',features:af});
+      const pf=(points||[]).filter(p=>isFinite(p.lng)&&isFinite(p.lat)).map(p=>({type:'Feature',geometry:{type:'Point',coordinates:[p.lng,p.lat]},properties:{label:p.label||''}}));
+      map.getSource('im-mon-pts').setData({type:'FeatureCollection',features:pf});
+      if(area&&area.bbox){ try{ map.fitBounds([[area.bbox[0],area.bbox[1]],[area.bbox[2],area.bbox[3]]],{padding:80,maxZoom:9,duration:800}); }catch(_){} }
+    }catch(_){} }
+    function clearMap(){ try{ if(map.getSource('im-mon-area')) map.getSource('im-mon-area').setData({type:'FeatureCollection',features:[]}); if(map.getSource('im-mon-pts')) map.getSource('im-mon-pts').setData({type:'FeatureCollection',features:[]}); }catch(_){} }
+
+    /* ---- data access (RLS scopes to the owner) ---- */
+    async function _list(){ const {data,error}=await DB.from('area_monitors').select('*').order('created_at',{ascending:false}); if(error) throw error; return data||[]; }
+    async function _get(id){ try{ const {data}=await DB.from('area_monitors').select('*').eq('id',id).maybeSingle(); return data||null; }catch(_){ return null; } }
+    async function _runs(id){ try{ const {data}=await DB.from('monitor_runs').select('*').eq('monitor_id',id).order('started_at',{ascending:false}).limit(30); return data||[]; }catch(_){ return []; } }
+    async function _report(id){ try{ const {data}=await DB.from('monitor_reports').select('*').eq('id',id).maybeSingle(); return data||null; }catch(_){ return null; } }
+    async function _evidence(runId){ try{ const {data}=await DB.from('monitor_evidence').select('*').eq('run_id',runId).order('ev_key'); return data||[]; }catch(_){ return []; } }
+
+    function _errMsg(error){ const m=String(error&&error.message||error||''); if(/monitor_limit_reached/.test(m)) return ML('You have reached your monitor limit for this plan.','このプランの監視上限に達しました。','Sie haben Ihr Monitor-Limit erreicht.','Достигнут лимит мониторов для вашего плана.','Has alcanzado el límite de monitores de tu plan.');
+      if(/geom/i.test(m)&&/size|400000|check/i.test(m)) return ML('That area is too large/detailed to save. Try a simpler shape.','範囲が大きすぎ/複雑すぎます。単純な形にしてください。','Bereich zu groß/detailliert.','Область слишком большая/подробная.','El área es demasiado grande/detallada.');
+      return ML('Could not save the monitor.','監視を保存できませんでした。','Konnte den Monitor nicht speichern.','Не удалось сохранить монитор.','No se pudo guardar el monitor.'); }
+
+    /* ---- CRUD ---- */
+    async function create(opts){ opts=opts||{}; if(!_loggedIn()){ _promptLogin(); return {ok:false,error:'login'}; }
+      const area=opts.area||activeArea(); if(!area||!area.geometry) return {ok:false,error:'no_area'};
+      const row={ name:String(opts.name||area.label||ML('Area monitor','エリア監視','Gebietsmonitor','Монитор области','Monitor de área')).slice(0,120),
+        geometry:area.geometry, geometry_kind:area.geometry_kind||'polygon',
+        center_lng:(area.center_lng!=null?area.center_lng:null), center_lat:(area.center_lat!=null?area.center_lat:null), radius_km:(area.radius_km!=null?area.radius_km:null),
+        bbox:area.bbox||_bboxOf(area.geometry)||null, area_label:area.label||null,
+        sources:(opts.sources&&opts.sources.length?opts.sources:['news']),
+        comparison:opts.comparison||{mode:'previous_run',window_days:30}, sensitivity:opts.sensitivity||{},
+        interval_minutes:Math.max(30,parseInt(opts.intervalMin||360,10)||360), enabled:true, next_run_at:new Date().toISOString() };
+      try{ const {data,error}=await DB.from('area_monitors').insert(row).select('*').single(); if(error) return {ok:false,error:_errMsg(error),raw:error}; return {ok:true,monitor:data}; }
+      catch(e){ return {ok:false,error:_errMsg(e),raw:e}; } }
+    async function setEnabled(id,on){ try{ const {error}=await DB.from('area_monitors').update({enabled:!!on}).eq('id',id); return !error; }catch(_){ return false; } }
+    async function remove(id){ try{ const {error}=await DB.from('area_monitors').delete().eq('id',id); return !error; }catch(_){ return false; } }
+    async function pause(id){ const ok=await setEnabled(id,false); if(ok) render(); return ok; }
+    async function resume(id){ const ok=await setEnabled(id,true); if(ok) render(); return ok; }
+    async function runNow(id){ if(!_loggedIn()){ _promptLogin(); return {ok:false,error:'login'}; }
+      let token=''; try{ const r=await DB.auth.getSession(); token=(r&&r.data&&r.data.session&&r.data.session.access_token)||''; }catch(_){}
+      if(!token) return {ok:false,error:'login'};
+      try{ const resp=await fetch(FN_URL,{method:'POST',headers:{'Content-Type':'application/json','apikey':window.SUPABASE_ANON_KEY||'','Authorization':'Bearer '+token},body:JSON.stringify({monitorId:id})});
+        const j=await resp.json().catch(()=>null);
+        if(!resp.ok){ const err=(j&&(j.message||j.error))||('HTTP '+resp.status); return {ok:false,error:err,status:resp.status}; }
+        return {ok:true,status:(j&&j.status)||'ok'}; }
+      catch(e){ return {ok:false,error:String(e&&e.message||e)}; } }
+
+    /* ---- rendering: the list ---- */
+    function _statusChip(m){ const run=(m.running_since&&(Date.now()-new Date(m.running_since).getTime())<15*60000); const key=run?'running':(m.enabled===false?'disabled':(m.last_status||'')); const sev=m.last_change_severity;
+      let color='var(--text-muted)'; if(run) color='#0a84ff'; else if(m.enabled===false) color='#8e8e93'; else if(m.last_status==='source_unavailable'||m.last_status==='ai_failed'||m.last_status==='internal_error'||m.last_status==='invalid_geometry') color='#ff9f0a'; else if(sev&&SEV_COLOR[sev]&&sev!=='none') color=SEV_COLOR[sev]; else if(m.last_status) color='#30a46c';
+      const label=run?statusLabel('running'):(m.enabled===false?statusLabel('disabled'):(m.last_status?statusLabel(m.last_status):ML('Scheduled','予定','Geplant','Запланирован','Programado')));
+      return '<span class="mon-chip" style="--c:'+color+'">'+S(label)+'</span>'; }
+    function _rowHtml(m){ const sources=(m.sources||[]).map(srcLabel).join(', ');
+      const sev=(m.last_change_severity&&m.last_change_severity!=='none')?('<span class="mon-sev" style="--c:'+(SEV_COLOR[m.last_change_severity]||'#8e8e93')+'">'+S(sevLabel(m.last_change_severity))+'</span>'):'';
+      return '<div class="mon-row" data-mid="'+S(m.id)+'">'
+        +'<div class="mon-row-main">'
+          +'<div class="mon-row-top"><span class="mon-name">'+S(m.name)+'</span>'+_statusChip(m)+sev+'</div>'
+          +'<div class="mon-row-sub">'+S(m.area_label||'')+' · '+S(sources)+'</div>'
+          +'<div class="mon-row-meta">'+S(ML('Last','前回','Zuletzt','Последний','Último'))+': '+S(_fmtWhen(m.last_run_at))+' · '+S(ML('Next','次回','Nächste','Следующий','Próximo'))+': '+S(_fmtNext(m.next_run_at,m.enabled))+'</div>'
+        +'</div>'
+        +'<div class="mon-row-acts">'
+          +'<button class="mon-ic" data-act="run" title="'+S(ML('Run now','今すぐ実行','Jetzt ausführen','Запустить','Ejecutar ahora'))+'">▶</button>'
+          +'<button class="mon-ic" data-act="'+(m.enabled===false?'resume':'pause')+'" title="'+S(m.enabled===false?ML('Resume','再開','Fortsetzen','Возобновить','Reanudar'):ML('Pause','一時停止','Pause','Пауза','Pausar'))+'">'+(m.enabled===false?'▷':'❚❚')+'</button>'
+          +'<button class="mon-ic" data-act="map" title="'+S(ML('Show on map','地図に表示','Auf Karte','На карте','En el mapa'))+'">◎</button>'
+        +'</div></div>'; }
+
+    async function render(query){ const feed=document.getElementById('monitors-feed'); if(!feed) return;
+      if(!_loggedIn()){ feed.innerHTML='<div class="mon-wrap"><div class="mon-empty">'+S(ML('Log in to create and view area monitors.','ログインすると地域監視を作成・表示できます。','Melden Sie sich an, um Gebietsmonitore zu nutzen.','Войдите, чтобы использовать мониторы областей.','Inicia sesión para usar los monitores de área.'))+'</div>'
+          +'<button class="mon-new-btn" id="mon-login-btn">'+S(ML('Log in','ログイン','Anmelden','Войти','Iniciar sesión'))+'</button></div>';
+        const lb=feed.querySelector('#mon-login-btn'); if(lb) lb.onclick=_promptLogin; return; }
+      feed.innerHTML='<div class="mon-wrap"><div class="mon-loading">'+S(ML('Loading monitors…','監視を読み込み中…','Monitore werden geladen…','Загрузка…','Cargando…'))+'</div></div>';
+      let rows=[]; try{ rows=await _list(); }catch(e){ feed.innerHTML='<div class="mon-wrap"><div class="mon-empty">'+S(ML('Could not load monitors.','監視を読み込めませんでした。','Konnte Monitore nicht laden.','Не удалось загрузить.','No se pudieron cargar.'))+'</div></div>'; return; }
+      const q=String(query||'').trim().toLowerCase(); if(q) rows=rows.filter(r=>((r.name||'')+' '+(r.area_label||'')).toLowerCase().includes(q));
+      const area=activeArea();
+      let html='<div class="mon-wrap"><div class="mon-head">'
+        +'<button class="mon-new-btn" id="mon-new-btn">＋ '+S(ML('New monitor','新規監視','Neuer Monitor','Новый монитор','Nuevo monitor'))+'</button>'
+        +(area?'<span class="mon-area-hint">'+S(ML('Area ready','範囲あり','Bereich bereit','Область готова','Área lista'))+': '+S(area.label)+'</span>':'')
+        +'</div>';
+      if(!rows.length){ html+='<div class="mon-empty">'+S(ML('No monitors yet. Set a radius, draw an area, or resolve a region, then create a monitor to watch it for changes.','監視がまだありません。半径・描画・地域指定で範囲を決めてから監視を作成してください。','Noch keine Monitore. Wählen Sie einen Bereich und erstellen Sie einen Monitor.','Пока нет мониторов. Задайте область и создайте монитор.','Aún no hay monitores. Define un área y crea un monitor.'))+'</div>'; }
+      else { html+='<div class="mon-list">'+rows.map(_rowHtml).join('')+'</div>'; }
+      html+='</div>'; feed.innerHTML=html; _wireList(feed,rows); }
+
+    function _wireList(feed,rows){ const nb=feed.querySelector('#mon-new-btn'); if(nb) nb.onclick=()=>openCreateDialog();
+      const byId={}; (rows||[]).forEach(r=>byId[r.id]=r);
+      feed.querySelectorAll('.mon-row').forEach(row=>{ const id=row.getAttribute('data-mid');
+        row.querySelector('.mon-row-main').onclick=()=>openDetail(id);
+        row.querySelectorAll('.mon-ic').forEach(b=>{ b.onclick=async(e)=>{ e.stopPropagation(); const act=b.getAttribute('data-act');
+          if(act==='pause'){ await pause(id); }
+          else if(act==='resume'){ await resume(id); }
+          else if(act==='map'){ const m=byId[id]||await _get(id); if(m){ let pts=[]; try{ if(m.last_report_id){ const rep=await _report(m.last_report_id); if(rep&&rep.change_points) pts=rep.change_points; } }catch(_){} showOnMap({geometry:m.geometry,bbox:m.bbox},pts); _closeSheetIfMobile(); } }
+          else if(act==='run'){ b.disabled=true; b.textContent='…'; const r=await runNow(id); b.disabled=false; b.textContent='▶';
+            if(r.ok){ _toast(ML('Monitor ran: ','実行しました: ','Ausgeführt: ','Запущено: ','Ejecutado: ')+statusLabel(r.status)); render(); }
+            else if(r.error==='login'){ _promptLogin(); }
+            else { _toast(ML('Run failed: ','実行失敗: ','Fehlgeschlagen: ','Ошибка: ','Fallo: ')+String(r.error||'')); } }
+        }; });
+      }); }
+
+    /* ---- create dialog ---- */
+    function _overlay(inner,cls){ const ov=document.createElement('div'); ov.className='mon-ov '+(cls||''); ov.innerHTML='<div class="mon-dialog" role="dialog" aria-modal="true">'+inner+'</div>';
+      document.body.appendChild(ov); ov.addEventListener('click',e=>{ if(e.target===ov) ov.remove(); }); const x=ov.querySelector('.mon-x'); if(x) x.onclick=()=>ov.remove(); return ov; }
+    function openCreateDialog(prefill){ if(!_loggedIn()){ _promptLogin(); return; }
+      prefill=prefill||{}; let area=prefill.area||activeArea(); let usingView=false;
+      const intervals=[[30,ML('Every 30 min','30分ごと','Alle 30 Min','Каждые 30 мин','Cada 30 min')],[60,ML('Hourly','1時間ごと','Stündlich','Каждый час','Cada hora')],[180,ML('Every 3 hours','3時間ごと','Alle 3 Std','Каждые 3 ч','Cada 3 h')],[360,ML('Every 6 hours','6時間ごと','Alle 6 Std','Каждые 6 ч','Cada 6 h')],[720,ML('Every 12 hours','12時間ごと','Alle 12 Std','Каждые 12 ч','Cada 12 h')],[1440,ML('Daily','1日ごと','Täglich','Ежедневно','Diario')]];
+      const sens=[['low',ML('Low — only big changes','低 — 大きな変化のみ','Niedrig','Низкая','Baja')],['medium',ML('Medium (default)','中（既定）','Mittel','Средняя','Media')],['high',ML('High — smaller changes','高 — 小さな変化も','Hoch','Высокая','Alta')]];
+      const srcOpts=[['news',true],['earthquake',false],['weather',false],['fire',false]];
+      const areaLine=area?('<div class="mon-area-box">'+S(ML('Watching','監視範囲','Überwacht','Область','Vigilando'))+': <b>'+S(area.label)+'</b></div>')
+        :('<div class="mon-area-box mon-area-none">'+S(ML('No area selected. Set a radius, draw an area, or resolve a region — or use the current map view below.','範囲が未選択です。半径・描画・地域指定するか、下の「現在の地図表示」を使ってください。','Kein Bereich gewählt.','Область не выбрана.','Sin área seleccionada.'))+'</div>');
+      const inner='<button class="mon-x" aria-label="Close">✕</button>'
+        +'<h3 class="mon-h3">'+S(ML('New monitor','新規監視','Neuer Monitor','Новый монитор','Nuevo monitor'))+'</h3>'
+        +areaLine
+        +(area?'':'<button class="mon-viewbtn" id="mon-usemapview">'+S(ML('Use current map view','現在の地図表示を使う','Aktuelle Kartenansicht verwenden','Использовать вид карты','Usar vista del mapa'))+'</button>')
+        +'<label class="mon-lbl">'+S(ML('Name','名前','Name','Название','Nombre'))+'</label>'
+        +'<input class="mon-inp" id="mon-name" maxlength="120" value="'+S(area?area.label:'')+'">'
+        +'<label class="mon-lbl">'+S(ML('Watch for','監視対象','Überwachen','Отслеживать','Vigilar'))+'</label>'
+        +'<div class="mon-src-row">'+srcOpts.map(([s,on])=>'<label class="mon-src '+(on?'':'mon-src-off')+'"><input type="checkbox" value="'+s+'" '+(on?'checked':'disabled')+'> '+S(srcLabel(s))+(on?'':' <span class="mon-soon">'+S(ML('soon','近日','bald','скоро','pronto'))+'</span>')+'</label>').join('')+'</div>'
+        +'<label class="mon-lbl">'+S(ML('Compare against','比較対象','Vergleichen mit','Сравнивать с','Comparar con'))+'</label>'
+        +'<select class="mon-inp" id="mon-cmp"><option value="previous_run">'+S(ML('The previous run','前回の実行','Vorheriger Lauf','Предыдущий запуск','Ejecución anterior'))+'</option><option value="baseline_window">'+S(ML('The past 30 days','過去30日','Letzte 30 Tage','Последние 30 дней','Últimos 30 días'))+'</option></select>'
+        +'<label class="mon-lbl">'+S(ML('How often','実行頻度','Häufigkeit','Частота','Frecuencia'))+'</label>'
+        +'<select class="mon-inp" id="mon-int">'+intervals.map(([v,l])=>'<option value="'+v+'"'+(v===360?' selected':'')+'>'+S(l)+'</option>').join('')+'</select>'
+        +'<label class="mon-lbl">'+S(ML('Sensitivity','感度','Empfindlichkeit','Чувствительность','Sensibilidad'))+'</label>'
+        +'<select class="mon-inp" id="mon-sens">'+sens.map(([v,l])=>'<option value="'+v+'"'+(v==='medium'?' selected':'')+'>'+S(l)+'</option>').join('')+'</select>'
+        +'<div class="mon-note">'+S(ML('The monitor runs on our servers even when this page is closed. A report is generated only when a meaningful change is detected — every claim links to its source.','このページを閉じてもサーバー側で実行されます。意味のある変化が検出された時だけレポートが生成され、各主張は出典にリンクします。','Läuft serverseitig, auch wenn die Seite geschlossen ist. Ein Bericht entsteht nur bei einer bedeutsamen Änderung.','Работает на сервере, даже если страница закрыта. Отчёт создаётся только при значимом изменении.','Se ejecuta en el servidor aunque cierres la página. El informe solo se genera ante un cambio significativo.'))+'</div>'
+        +'<div class="mon-dlg-acts"><button class="mon-cancel">'+S(ML('Cancel','キャンセル','Abbrechen','Отмена','Cancelar'))+'</button><button class="mon-save" id="mon-create-btn"'+(area?'':' disabled')+'>'+S(ML('Create monitor','監視を作成','Monitor erstellen','Создать','Crear monitor'))+'</button></div>';
+      const ov=_overlay(inner,'mon-ov-create');
+      const upd=()=>{ const box=ov.querySelector('.mon-area-box'); const btn=ov.querySelector('#mon-create-btn'); const nm=ov.querySelector('#mon-name');
+        if(box){ box.classList.toggle('mon-area-none',!area); box.innerHTML=area?(S(ML('Watching','監視範囲','Überwacht','Область','Vigilando'))+': <b>'+S(area.label)+'</b>'):S(ML('No area selected.','範囲が未選択です。','Kein Bereich gewählt.','Область не выбрана.','Sin área.')); }
+        if(btn) btn.disabled=!area; if(nm&&!nm.value&&area) nm.value=area.label; };
+      const uv=ov.querySelector('#mon-usemapview'); if(uv) uv.onclick=()=>{ area=mapViewArea(); usingView=true; uv.style.display='none'; upd(); };
+      ov.querySelector('.mon-cancel').onclick=()=>ov.remove();
+      ov.querySelector('#mon-create-btn').onclick=async(e)=>{ const btn=e.target; if(!area){ return; } btn.disabled=true; btn.textContent='…';
+        const sources=[...ov.querySelectorAll('.mon-src input:checked')].map(c=>c.value); if(!sources.length) sources.push('news');
+        const cmp=ov.querySelector('#mon-cmp').value; const intv=parseInt(ov.querySelector('#mon-int').value,10)||360;
+        const sensV=ov.querySelector('#mon-sens').value; const sensMap={low:{min_score:0.45,min_new:3},medium:{min_score:0.3,min_new:1},high:{min_score:0.18,min_new:1}};
+        const res=await create({ name:ov.querySelector('#mon-name').value, area, sources, comparison:{mode:cmp,window_days:30}, intervalMin:intv, sensitivity:sensMap[sensV]||{} });
+        if(res.ok){ ov.remove(); _toast(ML('Monitor created.','監視を作成しました。','Monitor erstellt.','Монитор создан.','Monitor creado.')); render();
+          try{ if(map){ showOnMap({geometry:res.monitor.geometry,bbox:res.monitor.bbox},[]); } }catch(_){} }
+        else if(res.error==='login'){ _promptLogin(); }
+        else { btn.disabled=false; btn.textContent=ML('Create monitor','監視を作成','Monitor erstellen','Создать','Crear monitor'); _toast(String(res.error||'')); } };
+    }
+
+    /* ---- monitor detail overlay (config + run history + latest report) ---- */
+    async function openDetail(id){ const m=await _get(id); if(!m){ _toast(ML('Monitor not found.','監視が見つかりません。','Nicht gefunden.','Не найдено.','No encontrado.')); return; }
+      const runs=await _runs(id);
+      const kv=(k,v)=>'<div class="mon-kv"><span>'+S(k)+'</span><b>'+v+'</b></div>';
+      const runsHtml=runs.length?('<div class="mon-runs">'+runs.map(r=>{ const sev=(r.report_generated&&r.change_score!=null)?'':''; const badge='<span class="mon-chip" style="--c:'+(r.status==='success'||r.status==='partial'?'#30a46c':(r.status==='success_no_change'?'#8e8e93':(r.status==='source_unavailable'||r.status==='ai_failed'?'#ff9f0a':'#ff453a')))+'">'+S(statusLabel(r.status))+'</span>';
+        return '<div class="mon-run" data-rid="'+S(r.id)+'" data-rep="'+S(r.report_id||'')+'"><div class="mon-run-l"><span class="mon-run-when">'+S(_fmtWhen(r.started_at))+'</span>'+badge+'</div>'
+          +'<span class="mon-run-r">'+(r.report_generated?'<span class="mon-run-link">'+S(ML('View report','レポートを見る','Bericht','Отчёт','Ver informe'))+' →</span>':(r.evidence_count?S(r.evidence_count)+' '+S(ML('items','件','Einträge','эл.','elem.')):'—'))+'</span></div>'; }).join('')+'</div>'):('<div class="mon-empty">'+S(ML('No runs yet.','実行履歴はまだありません。','Noch keine Läufe.','Пока нет запусков.','Sin ejecuciones.'))+'</div>');
+      const inner='<button class="mon-x" aria-label="Close">✕</button>'
+        +'<h3 class="mon-h3">'+S(m.name)+' '+_statusChip(m)+'</h3>'
+        +'<div class="mon-kvs">'
+          +kv(ML('Area','範囲','Bereich','Область','Área'),S(m.area_label||'—'))
+          +kv(ML('Watching','監視対象','Überwacht','Отслеживает','Vigila'),S((m.sources||[]).map(srcLabel).join(', ')))
+          +kv(ML('Every','頻度','Alle','Каждые','Cada'),S(_intLabel(m.interval_minutes)))
+          +kv(ML('Compare','比較','Vergleich','Сравнение','Comparar'),S(m.comparison&&m.comparison.mode==='baseline_window'?ML('past 30 days','過去30日','30 Tage','30 дней','30 días'):ML('previous run','前回','Vorlauf','пред. запуск','ejec. anterior')))
+          +kv(ML('Last run','前回実行','Letzter Lauf','Последний','Último'),S(_fmtWhen(m.last_run_at)))
+          +kv(ML('Next run','次回実行','Nächster Lauf','Следующий','Próximo'),S(_fmtNext(m.next_run_at,m.enabled)))
+        +'</div>'
+        +'<div class="mon-dlg-acts mon-detail-acts">'
+          +'<button class="mon-btn" data-d="run">▶ '+S(ML('Run now','今すぐ実行','Jetzt','Запустить','Ejecutar'))+'</button>'
+          +'<button class="mon-btn" data-d="map">◎ '+S(ML('Map','地図','Karte','Карта','Mapa'))+'</button>'
+          +'<button class="mon-btn" data-d="'+(m.enabled===false?'resume':'pause')+'">'+(m.enabled===false?'▷ '+S(ML('Resume','再開','Fortsetzen','Возобновить','Reanudar')):'❚❚ '+S(ML('Pause','一時停止','Pause','Пауза','Pausar')))+'</button>'
+          +'<button class="mon-btn mon-btn-danger" data-d="del">🗑 '+S(ML('Delete','削除','Löschen','Удалить','Eliminar'))+'</button>'
+        +'</div>'
+        +'<h4 class="mon-h4">'+S(ML('Run history','実行履歴','Verlauf','История','Historial'))+'</h4>'+runsHtml;
+      const ov=_overlay(inner,'mon-ov-detail');
+      ov.querySelectorAll('.mon-detail-acts .mon-btn').forEach(b=>{ b.onclick=async()=>{ const d=b.getAttribute('data-d');
+        if(d==='run'){ b.disabled=true; b.textContent='…'; const r=await runNow(id); if(r.ok){ _toast(ML('Ran: ','実行: ','Lauf: ','Запуск: ','Ejec.: ')+statusLabel(r.status)); ov.remove(); render(); setTimeout(()=>openDetail(id),400); } else if(r.error==='login'){ _promptLogin(); } else { b.disabled=false; _toast(String(r.error||'')); } }
+        else if(d==='map'){ let pts=[]; try{ if(m.last_report_id){ const rep=await _report(m.last_report_id); if(rep&&rep.change_points) pts=rep.change_points; } }catch(_){} showOnMap({geometry:m.geometry,bbox:m.bbox},pts); ov.remove(); _closeSheetIfMobile(); }
+        else if(d==='pause'){ await pause(id); ov.remove(); }
+        else if(d==='resume'){ await resume(id); ov.remove(); }
+        else if(d==='del'){ if(confirm(ML('Delete this monitor and its history?','この監視と履歴を削除しますか？','Diesen Monitor löschen?','Удалить этот монитор?','¿Eliminar este monitor?'))){ await remove(id); ov.remove(); render(); } }
+      }; });
+      ov.querySelectorAll('.mon-run').forEach(rr=>{ const rep=rr.getAttribute('data-rep'); if(rep){ rr.classList.add('mon-run-clickable'); rr.onclick=()=>{ openReport(rep); }; } }); }
+    function _intLabel(mins){ mins=+mins||360; if(mins<60) return ML(mins+' min','約'+mins+'分','','','')||mins+' min'; const h=Math.round(mins/60); if(h<24) return ML(h+' h',h+'時間',h+' Std',h+' ч',h+' h'); return ML(Math.round(h/24)+' d',Math.round(h/24)+'日',Math.round(h/24)+' T',Math.round(h/24)+' д',Math.round(h/24)+' d'); }
+
+    /* ---- report overlay: conclusion + changes(→evidence) + metrics + evidence list + gaps + limitations ---- */
+    async function openReport(reportId){ const rep=(typeof reportId==='object')?reportId:await _report(reportId); if(!rep){ _toast(ML('Report not found.','レポートが見つかりません。','Bericht nicht gefunden.','Отчёт не найден.','Informe no encontrado.')); return; }
+      const ev=await _evidence(rep.run_id); const evByKey={}; ev.forEach(e=>evByKey[e.ev_key]=e);
+      try{ if(!rep.read) DB.rpc('monitor_mark_read',{p_report:rep.id}); }catch(_){}
+      const sevC=SEV_COLOR[rep.severity]||'#8e8e93';
+      const chip=(k)=>{ const e=evByKey[k]; return '<button class="mon-evchip" data-ev="'+S(k)+'">'+S(k)+'</button>'; };
+      const changes=(rep.changes||[]).map(c=>'<li class="mon-change"><span class="mon-claim">'+S(c.claim)+'</span> '+(c.evidence_ids||[]).map(chip).join(' ')+'</li>').join('');
+      const metrics=rep.metrics&&rep.metrics.articles?('<div class="mon-metrics">'
+        +'<div class="mon-metric"><span>'+S(ML('Reports','記事','Berichte','Статьи','Artículos'))+'</span><b>'+S(rep.metrics.articles.prev)+' → '+S(rep.metrics.articles.cur)+' <em style="color:'+(rep.metrics.articles.delta>=0?'#30a46c':'#ff453a')+'">('+(rep.metrics.articles.delta>=0?'+':'')+S(rep.metrics.articles.delta)+')</em></b></div>'
+        +(rep.metrics.new_clusters!=null?'<div class="mon-metric"><span>'+S(ML('New event clusters','新規クラスター','Neue Cluster','Новые кластеры','Nuevos grupos'))+'</span><b>'+S(rep.metrics.new_clusters)+'</b></div>':'')
+        +(rep.metrics.publishers?'<div class="mon-metric"><span>'+S(ML('Publishers','媒体数','Quellen','Источники','Fuentes'))+'</span><b>'+S(rep.metrics.publishers.prev)+' → '+S(rep.metrics.publishers.cur)+'</b></div>':'')
+        +'</div>'):'';
+      const list=(arr,titleEn,titleJp,titleDe,titleRu,titleEs)=>{ if(!arr||!arr.length) return ''; return '<h4 class="mon-h4">'+S(ML(titleEn,titleJp,titleDe,titleRu,titleEs))+'</h4><ul class="mon-ul">'+arr.map(x=>'<li>'+S(x)+'</li>').join('')+'</ul>'; };
+      const evCards=ev.map(e=>'<div class="mon-evcard" id="mon-ev-'+S(e.ev_key)+'"><div class="mon-evk">'+S(e.ev_key)+'</div><div class="mon-evb">'
+        +'<div class="mon-evtitle">'+(e.source_url?'<a href="'+URLS(e.source_url)+'" target="_blank" rel="noopener">'+S(e.title||e.source_url)+'</a>':S(e.title||'—'))+'</div>'
+        +'<div class="mon-evmeta">'+S(e.source_name||'')+(e.observed_at?' · '+S(new Date(e.observed_at).toLocaleString()):'')+((e.payload&&e.payload.subject)?' · '+S(e.payload.subject):'')+' · <span class="mon-evkind mon-evkind-'+S(e.change_kind||'')+'">'+S(e.change_kind||'')+'</span></div>'
+        +'</div></div>').join('');
+      const inner='<button class="mon-x" aria-label="Close">✕</button>'
+        +'<div class="mon-rep-head"><span class="mon-sev-badge" style="--c:'+sevC+'">'+S(sevLabel(rep.severity))+'</span><h3 class="mon-h3">'+S(rep.headline)+'</h3></div>'
+        +(rep.summary?'<p class="mon-summary">'+S(rep.summary)+'</p>':'')
+        +metrics
+        +(changes?'<h4 class="mon-h4">'+S(ML('Key changes','主な変化','Wichtige Änderungen','Основные изменения','Cambios clave'))+'</h4><ul class="mon-changes">'+changes+'</ul>':'')
+        +(ev.length?'<button class="mon-viewbtn" id="mon-rep-map">◎ '+S(ML('Show change points on map','変化地点を地図に表示','Auf Karte zeigen','Показать на карте','Mostrar en el mapa'))+'</button>':'')
+        +list(rep.unchanged,'Unchanged / not confirmed','変化なし・未確認','Unverändert','Без изменений','Sin cambios')
+        +list(rep.data_gaps,'Data gaps','取得できなかったデータ','Datenlücken','Пробелы в данных','Lagunas de datos')
+        +list(rep.limitations,'Limitations','制約・不確実性','Einschränkungen','Ограничения','Limitaciones')
+        +'<h4 class="mon-h4">'+S(ML('Evidence','根拠','Belege','Доказательства','Evidencia'))+' ('+ev.length+')</h4><div class="mon-evlist">'+(evCards||('<div class="mon-empty">'+S(ML('No evidence stored.','根拠が保存されていません。','Keine Belege.','Нет данных.','Sin evidencia.'))+'</div>'))+'</div>'
+        +'<div class="mon-repfoot">'+S(ML('Generated','生成','Erstellt','Создано','Generado'))+': '+S(_fmtWhen(rep.created_at))+(rep.ai_model?' · '+S(rep.ai_model):'')+'</div>';
+      const ov=_overlay(inner,'mon-ov-report');
+      ov.querySelectorAll('.mon-evchip').forEach(ch=>{ ch.onclick=()=>{ const k=ch.getAttribute('data-ev'); const t=ov.querySelector('#mon-ev-'+CSS.escape(k)); if(t){ t.scrollIntoView({behavior:'smooth',block:'center'}); t.classList.add('mon-ev-hl'); setTimeout(()=>t.classList.remove('mon-ev-hl'),1500); } }; });
+      const rm=ov.querySelector('#mon-rep-map'); if(rm) rm.onclick=async()=>{ let area=null; try{ const m=await _get(rep.monitor_id); if(m) area={geometry:m.geometry,bbox:m.bbox}; }catch(_){} showOnMap(area,rep.change_points||[]); ov.remove(); _closeSheetIfMobile(); }; }
+
+    async function flyTo(id){ try{ const m=(typeof id==='object')?id:await _get(id); if(!m) return false; let pts=[]; try{ if(m.last_report_id){ const rep=await _report(m.last_report_id); if(rep&&rep.change_points) pts=rep.change_points; } }catch(_){} showOnMap({geometry:m.geometry,bbox:m.bbox},pts); return true; }catch(_){ return false; } }
+
+    function _toast(msg){ try{ if(window.imToast) return imToast(msg); if(window.aiToast) return aiToast(msg); }catch(_){} }
+    function _closeSheetIfMobile(){ try{ if(window.__setDetent && window.matchMedia('(max-width:768px)').matches) window.__setDetent('peek'); }catch(_){} }
+
+    /* ---- realtime: refresh the list when a run finishes / a report lands (if the tab is open) ---- */
+    (function subscribe(){ try{ if(!DB||!DB.channel) return; let t=null; const bump=()=>{ clearTimeout(t); t=setTimeout(()=>{ try{ if(typeof currentMode!=='undefined'&&currentMode==='monitors') render(); }catch(_){} },600); };
+      DB.channel('im-monitors').on('postgres_changes',{event:'*',schema:'public',table:'area_monitors'},bump).on('postgres_changes',{event:'*',schema:'public',table:'monitor_reports'},bump).subscribe();
+    }catch(_){} })();
+
+    /* ---- styles live in a STATIC <style id="mon-styles"> in <head> (no CSS-in-JS template literal — see
+           memory: template-literal CSS backtick = blank site). ---- */
+
+    /* ---- Atlas bridge (structured results for the dispatch cases) ---- */
+    const atlas={
+      async create(o){ const r=await create(o||{}); return r; },
+      async openList(){ try{ IntMapOS.exec('tab.monitors',{source:'atlas'}); }catch(_){} return {ok:true}; },
+      async open(id){ if(id) return openDetail(id); return this.openList(); },
+      async listText(){ try{ if(!_loggedIn()) return {ok:false,error:'login'}; const rows=await _list(); return {ok:true,rows}; }catch(e){ return {ok:false,error:String(e&&e.message||e)}; } },
+      async pause(id){ return {ok:await setEnabled(id,false)}; },
+      async resume(id){ return {ok:await setEnabled(id,true)}; },
+      async run(id){ return runNow(id); },
+      async remove(id){ return {ok:await remove(id)}; },
+      openReport, flyTo, activeArea
+    };
+
+    return { render, create, openCreateDialog, openDetail, openReport, pause, resume, remove, runNow, flyTo, activeArea, mapViewArea, showOnMap, clearMap, atlas,
+      _list, _get, statusLabel, sevLabel };
+  })();
+
   window.IntMapPopArea=(function(){
     const cache=new Map();
     function _decim(ring){ const r=ring.map(p=>[+(+p[0]).toFixed(5),+(+p[1]).toFixed(5)]);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:qa": "playwright test tests/internal-qa.spec.js",
     "test:e2e": "playwright test",
     "test:security": "node --test tests/security-logic.mjs",
-    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs && playwright test",
+    "test:monitor": "node --test tests/monitor-logic.test.mjs",
+    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs tests/monitor-logic.test.mjs && playwright test",
     "report": "playwright show-report"
   },
   "devDependencies": {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -68,3 +68,9 @@ verify_jwt = true
 
 [functions.refresh-news]
 verify_jwt = false
+
+# monitor-run (#R141) is deployed --no-verify-jwt: pg_cron calls it with a shared
+# secret (x-monitor-secret) and the "Run now" UI calls it with a user JWT; the
+# function does its OWN auth for both paths (fail-closed on the secret).
+[functions.monitor-run]
+verify_jwt = false

--- a/supabase/functions/monitor-run/index.ts
+++ b/supabase/functions/monitor-run/index.ts
@@ -112,18 +112,24 @@ const AI_SYS =
 
 async function callAI(cfg: { provider: string; key: string; model: string }, userMsg: string): Promise<string> {
   if (cfg.provider === "openai") {
-    const body = {
+    // GPT-5.6-luna via the Responses API. NOTE: OpenAI's json_object validator requires the word
+    // "json" in the INPUT messages (not `instructions`); the user message carries it. A 400 still
+    // degrades to a tool-free/JSON-mode-free retry (like ai-proxy) — the prompt + client validation
+    // enforce the shape either way, so a request-shape rejection never blanks a report.
+    const build = (jsonMode: boolean) => ({
       model: cfg.model,
       input: [{ role: "user", content: [{ type: "input_text", text: userMsg }] }],
       instructions: AI_SYS,
       max_output_tokens: 3200,
       reasoning: { effort: "low" },
-      text: { format: { type: "json_object" } },
+      ...(jsonMode ? { text: { format: { type: "json_object" } } } : {}),
       store: false,
-    };
-    const r = await fetchWithTimeout("https://api.openai.com/v1/responses", {
-      method: "POST", headers: { "Content-Type": "application/json", "Authorization": "Bearer " + cfg.key }, body: JSON.stringify(body),
     });
+    const post = (b: Record<string, unknown>) => fetchWithTimeout("https://api.openai.com/v1/responses", {
+      method: "POST", headers: { "Content-Type": "application/json", "Authorization": "Bearer " + cfg.key }, body: JSON.stringify(b),
+    });
+    let r = await post(build(true));
+    if (!r.ok && r.status === 400) r = await post(build(false));   // (#R141) degrade: drop JSON mode on a 400
     if (!r.ok) throw new Error("openai " + r.status + " " + (await r.text().catch(() => "")).slice(0, 200));
     const j = await r.json();
     if (typeof j?.output_text === "string" && j.output_text) return j.output_text;
@@ -335,7 +341,9 @@ async function processMonitor(db: DB, monitor: Record<string, unknown>, aiCfg: {
     const userMsg =
       "AREA: " + String(monitor.area_label || monitor.name || "the monitored area") + "\n" +
       "CHANGE SUMMARY (authoritative): " + JSON.stringify(diffOut) + "\n" +
-      "EVIDENCE (new items in the area; cite ids exactly):\n" + JSON.stringify(aiEvidence);
+      "EVIDENCE (new items in the area; cite ids exactly):\n" + JSON.stringify(aiEvidence) + "\n\n" +
+      // OpenAI's json_object mode requires the literal word "json" in the input message.
+      "Respond with ONLY a single JSON object: {severity, headline, summary, changes:[{claim, evidence_ids}], unchanged, data_gaps, limitations}.";
 
     let aiText = "", aiOk = false, aiErr = "";
     try { aiText = await callAI(aiCfg!, userMsg); aiOk = !!aiText; }

--- a/supabase/functions/monitor-run/index.ts
+++ b/supabase/functions/monitor-run/index.ts
@@ -1,0 +1,477 @@
+// ============================================================================
+//  IntMap · monitor-run  —  Supabase Edge Function (Deno)
+// ----------------------------------------------------------------------------
+//  The server-side runner for AREA MONITORS (#R141). It runs whether or not the
+//  user's browser is open. Two entry modes, both auth-gated, both fail-closed:
+//
+//   1. CRON  — pg_cron (via pg_net) POSTs with header `x-monitor-secret:<secret>`.
+//              Claims up to N DUE monitors atomically (monitor_claim_due →
+//              FOR UPDATE SKIP LOCKED, so two ticks never process the same one),
+//              processes each, updates next_run_at. Fail-closed: MONITOR_SECRET
+//              MUST be set or every request is refused (503).
+//   2. USER  — the UI's "Run now" POSTs with the user's JWT + {monitorId}. We
+//              verify the JWT, confirm the monitor belongs to that user, enforce
+//              a short manual-run cooldown, then run just that one.
+//
+//  PER-MONITOR PIPELINE (the core rule: CODE decides "changed?", AI only explains)
+//    collect (news from current_news within the geometry) → normalize + dedup →
+//    snapshot → load baseline (previous run / window) → MECHANICAL diff
+//    (new/gone/continuing) → change score → decideAI() → (only on meaningful
+//    change) call the AI with the evidence + diff → VALIDATE every evidence id →
+//    persist run + evidence + (maybe) report → schedule next_run_at → prune.
+//
+//  The AI never decides whether something changed, never sees data outside the
+//  area, and every factual claim it returns is dropped unless it cites a real
+//  ev_key from THIS run's evidence. A source-fetch failure is NEVER "no change".
+//
+//  Deploy:   supabase functions deploy monitor-run --no-verify-jwt --project-ref vpekfwdpurzejrrmacac
+//  Secrets:  supabase secrets set MONITOR_SECRET=<random>          (REQUIRED — fail-closed)
+//            # AI reuses the SAME server-held key/provider as ai-proxy:
+//            supabase secrets set AI_PROVIDER=openai   AI_MODEL=gpt-5.6-luna   OPENAI_API_KEY=sk-...
+//            supabase secrets set MONITOR_AI=off        (optional kill-switch → mechanical only)
+//  (SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY are injected automatically.)
+// ============================================================================
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.4";
+import {
+  normalizeNewsRow, dedupeEvidence, pointInMonitorArea, bboxOfGeometry, validGeometry,
+  buildNewsSnapshot, diffKeys, clusterPoints, computeChangeScore, severityFromScore,
+  decideAI, validateAndCleanReport,
+} from "./logic.mjs";
+
+const cors = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-monitor-secret",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { ...cors, "Content-Type": "application/json" } });
+
+const PROMPT_VERSION = "monitor-r141-1";
+
+// ---- Bounds / cost guards -------------------------------------------------
+const CLAIM_LIMIT = 5;            // due monitors grabbed per cron tick
+const GLOBAL_DEADLINE_MS = 110_000; // stop starting new monitors past this (wall-clock guard)
+const MAX_EVIDENCE = 60;          // evidence rows stored per run
+const MAX_AI_EVIDENCE = 40;       // NEW items sent to the AI
+const MANUAL_COOLDOWN_MS = 30_000; // min gap between manual "run now"s per monitor
+const NEWS_WINDOW_MS = 72 * 3600 * 1000; // current_news only holds ~72 h
+const RETAIN_RUNS = 100;          // keep the newest N runs per monitor
+const RETAIN_EVIDENCE_RUNS = 12;  // keep evidence only for the newest N runs (bulk data)
+const KEEP_RUNS_PER_MONITOR = RETAIN_RUNS;
+
+// (#R138-style) constant-time compare so MONITOR_SECRET can't be recovered byte-by-byte.
+function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a), bb = enc.encode(b);
+  let diff = ab.length ^ bb.length;
+  const n = Math.max(ab.length, bb.length);
+  for (let i = 0; i < n; i++) diff |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+  return diff === 0;
+}
+
+// ---------------------------------------------------------------------------
+//  AI provider (server-held key; same env convention as ai-proxy / refresh-news).
+//  OpenAI goes through the Responses API (works with gpt-5.6-luna, JSON mode, no
+//  web tools — the report is grounded ONLY in the evidence we pass). Anthropic &
+//  Gemini kept as selectable fallbacks.
+// ---------------------------------------------------------------------------
+function aiProviderConfig(): { provider: string; key: string; model: string } | null {
+  if ((Deno.env.get("MONITOR_AI") || "").toLowerCase() === "off") return null;
+  let provider = (Deno.env.get("AI_PROVIDER") || "").toLowerCase();
+  if (!provider) {
+    if (Deno.env.get("OPENAI_API_KEY")) provider = "openai";
+    else if (Deno.env.get("ANTHROPIC_API_KEY")) provider = "anthropic";
+    else if (Deno.env.get("GEMINI_API_KEY")) provider = "gemini";
+  }
+  const model = Deno.env.get("MONITOR_AI_MODEL") || Deno.env.get("AI_MODEL") || "";
+  if (provider === "openai") { const key = Deno.env.get("OPENAI_API_KEY"); if (key) return { provider, key, model: model || "gpt-4o-mini" }; }
+  else if (provider === "anthropic") { const key = Deno.env.get("ANTHROPIC_API_KEY"); if (key) return { provider, key, model: model || "claude-3-5-haiku-latest" }; }
+  else if (provider === "gemini") { const key = Deno.env.get("GEMINI_API_KEY"); if (key) return { provider, key, model: model || "gemini-2.0-flash" }; }
+  return null;
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit, ms = 55_000): Promise<Response> {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), ms);
+  try { return await fetch(url, { ...init, signal: ctl.signal }); }
+  finally { clearTimeout(t); }
+}
+
+const AI_SYS =
+  "You are IntMap's area-monitoring analyst. You receive: (1) a monitored AREA, (2) a machine-computed CHANGE SUMMARY " +
+  "(exact new/continuing/gone counts and cluster counts — these numbers are AUTHORITATIVE, do not recompute or contradict them), " +
+  "and (3) an EVIDENCE list where each item has an id (like \"ev_3\"), source, title, url, date and place. Write a factual CHANGE report as JSON.\n" +
+  "HARD RULES: (a) EVERY factual claim in `changes` MUST cite one or more evidence ids that appear verbatim in the EVIDENCE list. " +
+  "Never invent an id, a number, a source, a place or an event that is not in the evidence. (b) Report ONLY on the monitored area — " +
+  "the evidence is already filtered to it. (c) Use the CHANGE SUMMARY numbers for any counts. (d) `severity` reflects the significance of the CHANGE " +
+  "(none|low|medium|high|critical). (e) Put honest caveats in `data_gaps` (e.g. a source was unavailable) and `limitations` " +
+  "(e.g. article locations are the reported subject, not confirmed positions). (f) If the change is minor, say so plainly and keep severity low.\n" +
+  "Return ONLY JSON: {\"severity\":string,\"headline\":string,\"summary\":string,\"changes\":[{\"claim\":string,\"evidence_ids\":[string]}]," +
+  "\"unchanged\":[string],\"data_gaps\":[string],\"limitations\":[string]}. No prose, no code fences.";
+
+async function callAI(cfg: { provider: string; key: string; model: string }, userMsg: string): Promise<string> {
+  if (cfg.provider === "openai") {
+    const body = {
+      model: cfg.model,
+      input: [{ role: "user", content: [{ type: "input_text", text: userMsg }] }],
+      instructions: AI_SYS,
+      max_output_tokens: 3200,
+      reasoning: { effort: "low" },
+      text: { format: { type: "json_object" } },
+      store: false,
+    };
+    const r = await fetchWithTimeout("https://api.openai.com/v1/responses", {
+      method: "POST", headers: { "Content-Type": "application/json", "Authorization": "Bearer " + cfg.key }, body: JSON.stringify(body),
+    });
+    if (!r.ok) throw new Error("openai " + r.status + " " + (await r.text().catch(() => "")).slice(0, 200));
+    const j = await r.json();
+    if (typeof j?.output_text === "string" && j.output_text) return j.output_text;
+    const parts = (Array.isArray(j?.output) ? j.output : [])
+      .filter((it: { type?: string }) => it?.type === "message")
+      .flatMap((it: { content?: unknown[] }) => (Array.isArray(it.content) ? it.content : []))
+      .filter((p: { type?: string }) => p?.type === "output_text")
+      .map((p: { text?: string }) => p.text || "");
+    return parts.join("");
+  }
+  if (cfg.provider === "gemini") {
+    const r = await fetchWithTimeout("https://generativelanguage.googleapis.com/v1beta/models/" + encodeURIComponent(cfg.model) + ":generateContent", {
+      method: "POST", headers: { "Content-Type": "application/json", "x-goog-api-key": cfg.key },
+      body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: userMsg }] }], systemInstruction: { parts: [{ text: AI_SYS }] }, generationConfig: { maxOutputTokens: 3200, responseMimeType: "application/json", thinkingConfig: { thinkingLevel: "low" } } }),
+    });
+    if (!r.ok) throw new Error("gemini " + r.status + " " + (await r.text().catch(() => "")).slice(0, 200));
+    const j = await r.json();
+    return (j?.candidates?.[0]?.content?.parts || []).filter((p: { thought?: boolean }) => p?.thought !== true).map((p: { text?: string }) => p.text || "").join("");
+  }
+  // anthropic
+  const r = await fetchWithTimeout("https://api.anthropic.com/v1/messages", {
+    method: "POST", headers: { "Content-Type": "application/json", "x-api-key": cfg.key, "anthropic-version": "2023-06-01" },
+    body: JSON.stringify({ model: cfg.model, max_tokens: 3200, system: AI_SYS, messages: [{ role: "user", content: userMsg }] }),
+  });
+  if (!r.ok) throw new Error("anthropic " + r.status + " " + (await r.text().catch(() => "")).slice(0, 200));
+  const j = await r.json();
+  return (j?.content || []).map((b: { text?: string }) => b.text || "").join("");
+}
+
+function parseJson(txt: string): Record<string, unknown> | null {
+  try {
+    const t = (txt || "").replace(/```json/gi, "").replace(/```/g, "");
+    const lo = t.indexOf("{"), hi = t.lastIndexOf("}");
+    if (lo < 0 || hi < lo) return null;
+    return JSON.parse(t.slice(lo, hi + 1));
+  } catch { return null; }
+}
+
+// deno-lint-ignore no-explicit-any
+type DB = any;
+
+// ---------------------------------------------------------------------------
+//  Collect the NEWS source: rows from current_news whose SUBJECT falls inside the
+//  monitor's area and within the news window. Returns {ok, items} — ok=false means
+//  the source itself failed (→ never treated as "no change").
+// ---------------------------------------------------------------------------
+async function collectNews(db: DB, monitor: Record<string, unknown>, sinceISO: string) {
+  try {
+    const bbox = (Array.isArray(monitor.bbox) ? monitor.bbox : bboxOfGeometry(monitor.geometry)) as number[] | null;
+    let q = db.from("current_news")
+      .select("id,lang,topic,title,publisher,link,pub_date,description,subject_lng,subject_lat,subject_name_en,subject_name_jp,pub_label")
+      .not("subject_lng", "is", null).not("subject_lat", "is", null)
+      .gte("pub_date", sinceISO).limit(1500);
+    if (bbox) q = q.gte("subject_lng", bbox[0]).lte("subject_lng", bbox[2]).gte("subject_lat", bbox[1]).lte("subject_lat", bbox[3]);
+    const { data, error } = await q;
+    if (error) return { ok: false, items: [] as Record<string, unknown>[] };
+    const items = (data || [])
+      .filter((r: Record<string, number>) => pointInMonitorArea(r.subject_lng as number, r.subject_lat as number, monitor as never))
+      .map(normalizeNewsRow);
+    return { ok: true, items: dedupeEvidence(items).slice(0, MAX_EVIDENCE) };
+  } catch { return { ok: false, items: [] as Record<string, unknown>[] }; }
+}
+
+// The registry of collectors — add earthquake/weather/fire here later; each is an
+// independent async function returning {ok, items}. This is the generic seam the
+// spec asks for (no news-only coupling).
+const COLLECTORS: Record<string, (db: DB, m: Record<string, unknown>, sinceISO: string) => Promise<{ ok: boolean; items: Record<string, unknown>[] }>> = {
+  news: collectNews,
+};
+
+// ---------------------------------------------------------------------------
+//  Process ONE monitor end-to-end. Always leaves a run row + releases the lock.
+// ---------------------------------------------------------------------------
+async function processMonitor(db: DB, monitor: Record<string, unknown>, aiCfg: { provider: string; key: string; model: string } | null, trigger: string, nowMs: number) {
+  const start = nowMs;
+  const monId = monitor.id as string;
+  const userId = monitor.user_id as string;
+  const nowISO = new Date(nowMs).toISOString();
+  const sources: string[] = Array.isArray(monitor.sources) && (monitor.sources as string[]).length ? (monitor.sources as string[]) : ["news"];
+  const sensitivity = (monitor.sensitivity && typeof monitor.sensitivity === "object") ? monitor.sensitivity as Record<string, unknown> : {};
+  const comparison = (monitor.comparison && typeof monitor.comparison === "object") ? monitor.comparison as Record<string, unknown> : {};
+  const intervalMin = Number(monitor.interval_minutes) || 360;
+
+  // Scaffold the run row FIRST so snapshot/diff/evidence survive even a late crash.
+  let runId = "";
+  const { data: runIns } = await db.from("monitor_runs").insert({
+    monitor_id: monId, user_id: userId, status: "internal_error", trigger,
+    started_at: nowISO, sources_attempted: sources,
+  }).select("id").single();
+  runId = runIns?.id;
+
+  const finalizeRun = async (patch: Record<string, unknown>) => {
+    patch.finished_at = new Date().toISOString();
+    patch.duration_ms = Date.now() - start;
+    if (runId) await db.from("monitor_runs").update(patch).eq("id", runId);
+  };
+  const scheduleNext = async (extra: Record<string, unknown> = {}) => {
+    const next = new Date(Date.now() + intervalMin * 60_000).toISOString();
+    await db.from("area_monitors").update({
+      running_since: null, last_run_at: nowISO, next_run_at: next,
+      run_count: (Number(monitor.run_count) || 0) + 1, ...extra,
+    }).eq("id", monId);
+  };
+
+  try {
+    if (monitor.enabled === false) {
+      await finalizeRun({ status: "disabled" });
+      await db.from("area_monitors").update({ running_since: null }).eq("id", monId);
+      return "disabled";
+    }
+    if (!validGeometry(monitor.geometry) && monitor.geometry_kind !== "circle") {
+      await finalizeRun({ status: "invalid_geometry", error_category: "invalid_geometry", error_detail: "geometry is not a valid Polygon/MultiPolygon", retryable: false });
+      await scheduleNext({ last_status: "invalid_geometry" });
+      return "invalid_geometry";
+    }
+
+    // 1) COLLECT every selected source. Track availability per source.
+    const sinceISO = new Date(nowMs - NEWS_WINDOW_MS).toISOString();
+    const okSources: string[] = [], failSources: string[] = [];
+    let items: Record<string, unknown>[] = [];
+    for (const src of sources) {
+      const collector = COLLECTORS[src];
+      if (!collector) { failSources.push(src); continue; }
+      const res = await collector(db, monitor, sinceISO);
+      if (res.ok) { okSources.push(src); items = items.concat(res.items); }
+      else failSources.push(src);
+    }
+    items = dedupeEvidence(items).slice(0, MAX_EVIDENCE);
+
+    // All sources down → source_unavailable (NEVER "no change"). Keep the run row.
+    if (okSources.length === 0) {
+      await finalizeRun({ status: "source_unavailable", sources_ok: okSources, sources_failed: failSources, error_category: "source_unavailable", retryable: true });
+      await scheduleNext({ last_status: "source_unavailable" });
+      return "source_unavailable";
+    }
+
+    // 2) SNAPSHOT (per-source + overall).
+    const snapshot = { news: buildNewsSnapshot(items.filter((i) => i.source_type === "news")), sources_ok: okSources, sources_failed: failSources } as Record<string, unknown>;
+    const curKeys = items.map((i) => i.dedup_key as string);
+
+    // 3) BASELINE — previous run's snapshot, or the accumulated window of evidence.
+    const { data: prevRun } = await db.from("monitor_runs")
+      .select("id,snapshot").eq("monitor_id", monId).not("snapshot", "is", null).neq("id", runId)
+      .order("started_at", { ascending: false }).limit(1).maybeSingle();
+    const isFirstRun = !prevRun;
+    const baselineSnap = (prevRun?.snapshot?.news) || null;
+    let baselineKeys: string[] = baselineSnap?.keys || [];
+    if (String(comparison.mode || "previous_run") === "baseline_window") {
+      const windowDays = Number(comparison.window_days) || 30;
+      const winStart = new Date(nowMs - windowDays * 86400000).toISOString();
+      const { data: evrows } = await db.from("monitor_evidence").select("dedup_key").eq("monitor_id", monId).neq("run_id", runId).gte("fetched_at", winStart);
+      baselineKeys = Array.from(new Set((evrows || []).map((r: { dedup_key: string }) => r.dedup_key)));
+    }
+
+    // 4) MECHANICAL DIFF + change score (CODE decides "changed?", not the AI).
+    const diff = diffKeys(curKeys, baselineKeys);
+    const newItems = items.filter((i) => diff.new.includes(i.dedup_key as string));
+    const clusters = clusterPoints(newItems.map((i) => ({ lng: i.lng as number, lat: i.lat as number })), 60);
+    const newClusters = clusters.length;
+    const corroboratedClusters = clusters.filter((members) => {
+      const pubs = new Set(members.map((idx) => String((newItems[idx].source_name as string) || "").toLowerCase()).filter(Boolean));
+      return pubs.size >= 2;
+    }).length;
+    const changeScore = computeChangeScore({ diff, current: snapshot.news as never, baseline: baselineSnap, newClusters, corroboratedClusters });
+    const diffOut = { new: diff.new.length, gone: diff.gone.length, continuing: diff.continuing.length, new_clusters: newClusters, corroborated_clusters: corroboratedClusters, prev_count: baselineSnap?.count || 0, cur_count: (snapshot.news as { count: number }).count };
+
+    // 5) Persist evidence with per-run ev_key ids (ev_1…). Tag change_kind.
+    const evRows = items.slice(0, MAX_EVIDENCE).map((it, i) => ({
+      run_id: runId, monitor_id: monId, user_id: userId, ev_key: "ev_" + (i + 1),
+      source_type: it.source_type, source_name: it.source_name, source_url: it.source_url, external_id: it.external_id,
+      title: it.title, observed_at: it.observed_at, fetched_at: nowISO, lng: it.lng, lat: it.lat,
+      payload: it.payload, dedup_key: it.dedup_key,
+      change_kind: diff.new.includes(it.dedup_key as string) ? "new" : (diff.continuing.includes(it.dedup_key as string) ? "continuing" : null),
+    }));
+    if (evRows.length) await db.from("monitor_evidence").insert(evRows);
+    // Map dedup_key → ev_key and → coords/label (for evidence-id validation + change points).
+    const keyToEv = new Map(evRows.map((e) => [e.dedup_key, e.ev_key]));
+    const validKeys = new Set(evRows.map((e) => e.ev_key));
+    const evByKey = new Map(evRows.map((e) => [e.ev_key, { lng: e.lng as number, lat: e.lat as number, label: (e.title as string) || "" }]));
+
+    const partial = failSources.length > 0;
+    const mechGaps = failSources.map((s) => `The ${s} source was unavailable this run.`);
+    const baseStatus = partial ? "partial" : "success";
+
+    // 6) DECIDE whether to call the AI. Only a real, code-detected change qualifies.
+    const decision = decideAI({ isFirstRun, hasData: items.length > 0, newCount: diff.new.length, changeScore, sensitivity: sensitivity as never });
+
+    if (!aiCfg && decision.call) decision.call = false, decision.skip = "not_configured";
+
+    if (!decision.call) {
+      // No report. Record a run-only outcome honestly. success_no_change unless the
+      // run also had a partial source failure (then keep the partial signal).
+      const status = partial ? "partial" : "success_no_change";
+      await finalizeRun({
+        status, sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
+        report_generated: false, ai_used: false, ai_skip_reason: decision.skip, evidence_count: evRows.length,
+      });
+      await scheduleNext({ last_status: status, last_change_severity: "none" });
+      await prune(db, monId);
+      return status;
+    }
+
+    // 7) CALL AI — build the evidence + change summary message (NEW items only).
+    const aiEvidence = newItems.slice(0, MAX_AI_EVIDENCE).map((it) => ({
+      id: keyToEv.get(it.dedup_key as string), source: it.source_name, title: it.title,
+      url: it.source_url, date: it.observed_at, place: (it.payload as { subject?: string })?.subject || null,
+      lng: it.lng, lat: it.lat,
+    }));
+    const userMsg =
+      "AREA: " + String(monitor.area_label || monitor.name || "the monitored area") + "\n" +
+      "CHANGE SUMMARY (authoritative): " + JSON.stringify(diffOut) + "\n" +
+      "EVIDENCE (new items in the area; cite ids exactly):\n" + JSON.stringify(aiEvidence);
+
+    let aiText = "", aiOk = false, aiErr = "";
+    try { aiText = await callAI(aiCfg!, userMsg); aiOk = !!aiText; }
+    catch (e) { aiErr = String((e as Error)?.message || e).slice(0, 160); }
+
+    const parsed = aiOk ? parseJson(aiText) : null;
+    const valid = parsed ? validateAndCleanReport(parsed, validKeys, evByKey) : { ok: false, cleaned: null, invalidRefs: [] };
+
+    if (!valid.ok || !valid.cleaned) {
+      // AI attempted but failed/hallucinated → ai_failed, but KEEP snapshot+diff+evidence.
+      await finalizeRun({
+        status: "ai_failed", sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
+        report_generated: false, ai_used: true, ai_provider: aiCfg!.provider, ai_model: aiCfg!.model,
+        error_category: "ai_failed", error_detail: (aiErr || "AI output had no evidence-grounded claim").slice(0, 200), retryable: true, evidence_count: evRows.length,
+      });
+      await scheduleNext({ last_status: "ai_failed" });
+      await prune(db, monId);
+      return "ai_failed";
+    }
+
+    // 8) Build + persist the validated report. Merge mechanical gaps/limitations.
+    const cleaned = valid.cleaned;
+    const severity = cleaned.severity || severityFromScore(changeScore);
+    const dataGaps = Array.from(new Set([...(cleaned.data_gaps || []), ...mechGaps]));
+    const limitations = Array.from(new Set([...(cleaned.limitations || []), "Locations represent the reported subject of each article, not a confirmed on-the-ground position."]));
+    const metrics = { articles: { prev: baselineSnap?.count || 0, cur: (snapshot.news as { count: number }).count, delta: (snapshot.news as { count: number }).count - (baselineSnap?.count || 0) }, new_items: diff.new.length, new_clusters: newClusters, publishers: { prev: baselineSnap?.publishers || 0, cur: (snapshot.news as { publishers: number }).publishers } };
+
+    const { data: repIns } = await db.from("monitor_reports").insert({
+      monitor_id: monId, run_id: runId, user_id: userId, severity,
+      headline: cleaned.headline, summary: cleaned.summary,
+      changes: cleaned.changes, unchanged: cleaned.unchanged, data_gaps: dataGaps, limitations,
+      metrics, change_points: cleaned.change_points,
+      ai_provider: aiCfg!.provider, ai_model: aiCfg!.model, prompt_version: PROMPT_VERSION,
+    }).select("id").single();
+    const reportId = repIns?.id;
+
+    await finalizeRun({
+      status: baseStatus, sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
+      report_generated: true, report_id: reportId, ai_used: true, ai_provider: aiCfg!.provider, ai_model: aiCfg!.model,
+      ai_skip_reason: null, evidence_count: evRows.length,
+    });
+    await scheduleNext({ last_status: baseStatus, last_change_severity: severity, last_report_id: reportId });
+    await prune(db, monId);
+    return baseStatus + "+report";
+  } catch (e) {
+    await finalizeRun({ status: "internal_error", error_category: "internal_error", error_detail: String((e as Error)?.message || e).slice(0, 200), retryable: true });
+    // Always release the lock + reschedule so a crash never wedges a monitor.
+    try { await scheduleNext({ last_status: "internal_error" }); } catch (_) { await db.from("area_monitors").update({ running_since: null }).eq("id", monId); }
+    return "internal_error";
+  }
+}
+
+// Retention: keep the newest RETAIN_RUNS runs; drop evidence for runs older than
+// the newest RETAIN_EVIDENCE_RUNS (evidence is the bulk). Reports are kept with runs.
+async function prune(db: DB, monId: string) {
+  try {
+    const { data: runs } = await db.from("monitor_runs").select("id").eq("monitor_id", monId).order("started_at", { ascending: false }).limit(500);
+    const ids: string[] = (runs || []).map((r: { id: string }) => r.id);
+    if (ids.length > KEEP_RUNS_PER_MONITOR) {
+      const old = ids.slice(KEEP_RUNS_PER_MONITOR);
+      await db.from("monitor_runs").delete().in("id", old);   // cascades evidence + reports
+    }
+    const keepEv = ids.slice(0, RETAIN_EVIDENCE_RUNS);
+    if (ids.length > RETAIN_EVIDENCE_RUNS && keepEv.length) {
+      // delete evidence whose run is not among the newest RETAIN_EVIDENCE_RUNS
+      await db.from("monitor_evidence").delete().eq("monitor_id", monId).not("run_id", "in", "(" + keepEv.map((x) => `"${x}"`).join(",") + ")");
+    }
+  } catch (_) { /* best-effort */ }
+}
+
+// ---------------------------------------------------------------------------
+//  HTTP entry.
+// ---------------------------------------------------------------------------
+Deno.serve(async (req) => {
+ try {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
+  if (req.method !== "POST") return json({ error: "method_not_allowed" }, 405);
+
+  const url = Deno.env.get("SUPABASE_URL")!;
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const anon = Deno.env.get("SUPABASE_ANON_KEY") || "";
+  const db = createClient(url, serviceKey, { auth: { persistSession: false } });
+  const aiCfg = aiProviderConfig();
+  const nowMs = Date.now();
+
+  let payload: { monitorId?: string } = {};
+  try { payload = await req.json(); } catch (_) { payload = {}; }
+
+  const secret = Deno.env.get("MONITOR_SECRET") || "";
+  const gotSecret = req.headers.get("x-monitor-secret") || "";
+  const authHeader = req.headers.get("Authorization") || "";
+
+  // ── MODE 1: CRON (shared-secret). Fail-closed: no secret set → refuse everything.
+  if (gotSecret) {
+    if (!secret) return json({ error: "not_configured", message: "monitor-run disabled: MONITOR_SECRET is not set." }, 503);
+    if (!timingSafeEqual(gotSecret, secret)) return json({ error: "unauthorized" }, 401);
+
+    const { data: claimed, error: claimErr } = await db.rpc("monitor_claim_due", { p_limit: CLAIM_LIMIT, p_stale_minutes: 15 });
+    if (claimErr) return json({ error: "claim_failed", message: claimErr.message }, 500);
+    const monitors: Record<string, unknown>[] = claimed || [];
+    const results: Record<string, string> = {};
+    for (const m of monitors) {
+      if (Date.now() - nowMs > GLOBAL_DEADLINE_MS) {
+        // Out of wall-clock budget — release the rest so the next tick re-claims them.
+        await db.from("area_monitors").update({ running_since: null }).eq("id", m.id as string);
+        results[m.id as string] = "deferred";
+        continue;
+      }
+      results[m.id as string] = await processMonitor(db, m, aiCfg, "schedule", Date.now());
+    }
+    return json({ ok: true, mode: "cron", claimed: monitors.length, results });
+  }
+
+  // ── MODE 2: USER "run now" (JWT + {monitorId}). Verify ownership + cooldown.
+  if (!authHeader) return json({ error: "unauthorized", message: "Send x-monitor-secret (cron) or a user JWT + monitorId." }, 401);
+  const userClient = createClient(url, anon, { global: { headers: { Authorization: authHeader } }, auth: { persistSession: false } });
+  const { data: userData } = await userClient.auth.getUser();
+  const user = userData?.user;
+  if (!user) return json({ error: "auth", message: "Login required." }, 401);
+  const monitorId = String(payload.monitorId || "");
+  if (!monitorId) return json({ error: "bad_request", message: "monitorId required." }, 400);
+
+  const { data: monitor } = await db.from("area_monitors").select("*").eq("id", monitorId).maybeSingle();
+  if (!monitor || monitor.user_id !== user.id) return json({ error: "not_found" }, 404);   // don't leak existence
+  if (monitor.running_since && (nowMs - new Date(monitor.running_since).getTime()) < 15 * 60_000) return json({ error: "already_running" }, 409);
+
+  // Manual cooldown — the newest run must be older than MANUAL_COOLDOWN_MS.
+  const { data: lastRun } = await db.from("monitor_runs").select("started_at").eq("monitor_id", monitorId).order("started_at", { ascending: false }).limit(1).maybeSingle();
+  if (lastRun && (nowMs - new Date(lastRun.started_at).getTime()) < MANUAL_COOLDOWN_MS) return json({ error: "cooldown", message: "Please wait a moment before running again." }, 429);
+
+  // Claim (lock) then process just this one.
+  await db.from("area_monitors").update({ running_since: new Date(nowMs).toISOString() }).eq("id", monitorId);
+  const status = await processMonitor(db, monitor, aiCfg, "manual", Date.now());
+  return json({ ok: true, mode: "manual", monitorId, status });
+ } catch (topErr) {
+  try { console.error("monitor-run UNCAUGHT", String((topErr as Error)?.message || topErr).slice(0, 200)); } catch (_) { /* */ }
+  return json({ error: "internal_error", message: "monitor-run hit an unexpected error." }, 500);
+ }
+});

--- a/supabase/functions/monitor-run/logic.mjs
+++ b/supabase/functions/monitor-run/logic.mjs
@@ -1,0 +1,343 @@
+// ============================================================================
+//  IntMap · monitor-run · logic.mjs  —  PURE, runtime-agnostic comparison engine
+// ----------------------------------------------------------------------------
+//  The heart of the "don't let the AI decide whether something changed" rule.
+//  Everything mechanical — point-in-area, normalization, dedup, the diff of
+//  new/gone/continuing, the change score, the AI call/skip decision, and the
+//  evidence-id validation that gates every AI claim — lives here as PURE
+//  functions with NO Deno/Node/network APIs. That means:
+//    • the Deno Edge Function (index.ts) imports it, and
+//    • the Node test (tests/monitor-logic.test.mjs) imports the SAME code,
+//  so the logic that runs in production is exactly the logic under test.
+//
+//  Nothing here reaches the network or a clock unless a timestamp is passed in.
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+//  Geometry — point-in-area (ray casting for polygons, haversine for circles).
+// ---------------------------------------------------------------------------
+
+export function haversineKm(aLng, aLat, bLng, bLat) {
+  const R = 6371.0088;
+  const toRad = (d) => (d * Math.PI) / 180;
+  const dLat = toRad(bLat - aLat);
+  const dLng = toRad(bLng - aLng);
+  const s =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(aLat)) * Math.cos(toRad(bLat)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(s)));
+}
+
+// Ray-casting point-in-ring. ring = [[lng,lat],…] (first!=last tolerated).
+export function pointInRing(lng, lat, ring) {
+  let inside = false;
+  const n = ring.length;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const xi = ring[i][0], yi = ring[i][1];
+    const xj = ring[j][0], yj = ring[j][1];
+    const intersect =
+      (yi > lat) !== (yj > lat) &&
+      lng < ((xj - xi) * (lat - yi)) / ((yj - yi) || 1e-12) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+// A GeoJSON Polygon ring set: outer ring includes, holes exclude.
+function pointInPolygonRings(lng, lat, rings) {
+  if (!rings || !rings.length) return false;
+  if (!pointInRing(lng, lat, rings[0])) return false;
+  for (let k = 1; k < rings.length; k++) {
+    if (pointInRing(lng, lat, rings[k])) return false; // in a hole
+  }
+  return true;
+}
+
+export function pointInGeometry(lng, lat, geom) {
+  if (!geom || typeof geom !== "object") return false;
+  if (geom.type === "Polygon") return pointInPolygonRings(lng, lat, geom.coordinates || []);
+  if (geom.type === "MultiPolygon") {
+    for (const poly of geom.coordinates || []) {
+      if (pointInPolygonRings(lng, lat, poly)) return true;
+    }
+    return false;
+  }
+  return false;
+}
+
+export function bboxOfGeometry(geom) {
+  let w = Infinity, s = Infinity, e = -Infinity, n = -Infinity;
+  const scan = (ring) => {
+    for (const p of ring) {
+      if (p[0] < w) w = p[0];
+      if (p[0] > e) e = p[0];
+      if (p[1] < s) s = p[1];
+      if (p[1] > n) n = p[1];
+    }
+  };
+  if (!geom) return null;
+  if (geom.type === "Polygon") (geom.coordinates || []).forEach(scan);
+  else if (geom.type === "MultiPolygon") (geom.coordinates || []).forEach((poly) => (poly || []).forEach(scan));
+  else return null;
+  if (!isFinite(w)) return null;
+  return [w, s, e, n];
+}
+
+// The one place "is this point in the monitored area?" is decided. A monitor is
+// either a circle (center+radius_km — exact haversine) or a polygon/region.
+export function pointInMonitorArea(lng, lat, monitor) {
+  if (!isFinite(lng) || !isFinite(lat)) return false;
+  if (
+    monitor &&
+    monitor.geometry_kind === "circle" &&
+    isFinite(monitor.center_lng) &&
+    isFinite(monitor.center_lat) &&
+    isFinite(monitor.radius_km) &&
+    monitor.radius_km > 0
+  ) {
+    return haversineKm(monitor.center_lng, monitor.center_lat, lng, lat) <= monitor.radius_km;
+  }
+  // bbox pre-filter, then precise ray-cast.
+  const bbox = Array.isArray(monitor && monitor.bbox) ? monitor.bbox : bboxOfGeometry(monitor && monitor.geometry);
+  if (bbox && (lng < bbox[0] || lng > bbox[2] || lat < bbox[1] || lat > bbox[3])) return false;
+  return pointInGeometry(lng, lat, monitor && monitor.geometry);
+}
+
+// Validate a stored/collected geometry is a real, non-degenerate Polygon/MultiPolygon.
+export function validGeometry(geom) {
+  if (!geom || typeof geom !== "object") return false;
+  const ringOk = (r) => Array.isArray(r) && r.length >= 4 && r.every((p) => Array.isArray(p) && p.length >= 2 && isFinite(p[0]) && isFinite(p[1]) && Math.abs(p[0]) <= 180 && Math.abs(p[1]) <= 90);
+  if (geom.type === "Polygon") return Array.isArray(geom.coordinates) && geom.coordinates.length >= 1 && geom.coordinates.every(ringOk);
+  if (geom.type === "MultiPolygon") return Array.isArray(geom.coordinates) && geom.coordinates.length >= 1 && geom.coordinates.every((poly) => Array.isArray(poly) && poly.length >= 1 && poly.every(ringOk));
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+//  URL safety — the ONLY urls we ever store are the ones providers give us; we
+//  never fetch arbitrary urls (no SSRF surface). Still, validate the scheme so a
+//  javascript:/data: url can never reach the UI as a source link.
+// ---------------------------------------------------------------------------
+export function isSafeHttpUrl(u) {
+  if (typeof u !== "string" || !u) return false;
+  return /^https?:\/\/[^\s]+$/i.test(u.trim());
+}
+
+// ---------------------------------------------------------------------------
+//  Normalization — turn a raw source row into a canonical evidence candidate.
+//  dedup_key is what dedup + diff work on; keep it stable & source-scoped.
+// ---------------------------------------------------------------------------
+function canonUrl(link) {
+  return String(link || "").trim().replace(/[#?].*$/, "").replace(/\/+$/, "").toLowerCase();
+}
+
+// A `current_news` row → evidence candidate. Locations are the reported SUBJECT
+// of the article (subject_lng/lat), which is exactly what "in this area" means.
+export function normalizeNewsRow(row) {
+  const link = String(row.link || "");
+  const lng = row.subject_lng, lat = row.subject_lat;
+  const name = row.subject_name_en || row.subject_name_jp || row.pub_label || "";
+  return {
+    source_type: "news",
+    source_name: String(row.publisher || "").slice(0, 120) || null,
+    source_url: isSafeHttpUrl(link) ? link : null,
+    external_id: canonUrl(link) || null,
+    title: String(row.title || "").slice(0, 300) || null,
+    observed_at: row.pub_date || null,
+    lng: isFinite(lng) ? lng : null,
+    lat: isFinite(lat) ? lat : null,
+    payload: {
+      lang: row.lang || null,
+      topic: row.topic || null,
+      subject: name || null,
+      description: String(row.description || "").slice(0, 400) || null,
+    },
+    dedup_key: "news:" + (canonUrl(link) || String(row.id || Math.abs(hashStr(String(row.title || ""))))),
+  };
+}
+
+// Small stable string hash (djb2) — deterministic, no crypto dependency.
+export function hashStr(s) {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return h;
+}
+
+// Dedup a list of evidence candidates by dedup_key (keep the first / freshest).
+export function dedupeEvidence(list) {
+  const seen = new Set();
+  const out = [];
+  for (const e of list) {
+    if (!e || !e.dedup_key) continue;
+    if (seen.has(e.dedup_key)) continue;
+    seen.add(e.dedup_key);
+    out.push(e);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+//  Diff — the mechanical new / gone / continuing split against a baseline set of
+//  dedup_keys. This is where "changed?" is decided BY CODE, not the AI.
+// ---------------------------------------------------------------------------
+export function diffKeys(currentKeys, baselineKeys) {
+  const cur = new Set(currentKeys);
+  const base = new Set(baselineKeys);
+  const isNew = [], gone = [], cont = [];
+  for (const k of cur) (base.has(k) ? cont : isNew).push(k);
+  for (const k of base) if (!cur.has(k)) gone.push(k);
+  return { new: isNew, gone, continuing: cont };
+}
+
+// Greedy spatial clustering of points (km radius). Returns clusters of indices.
+export function clusterPoints(points, radiusKm = 60) {
+  const clusters = [];
+  const used = new Array(points.length).fill(false);
+  for (let i = 0; i < points.length; i++) {
+    if (used[i]) continue;
+    const p = points[i];
+    if (!isFinite(p.lng) || !isFinite(p.lat)) continue;
+    const members = [i];
+    used[i] = true;
+    for (let j = i + 1; j < points.length; j++) {
+      if (used[j]) continue;
+      const q = points[j];
+      if (!isFinite(q.lng) || !isFinite(q.lat)) continue;
+      if (haversineKm(p.lng, p.lat, q.lng, q.lat) <= radiusKm) {
+        members.push(j);
+        used[j] = true;
+      }
+    }
+    clusters.push(members);
+  }
+  return clusters;
+}
+
+export function distinctPublishers(items) {
+  const s = new Set();
+  for (const it of items) if (it && it.source_name) s.add(String(it.source_name).toLowerCase());
+  return s.size;
+}
+
+// ---------------------------------------------------------------------------
+//  Snapshot + change score.
+// ---------------------------------------------------------------------------
+// Build a compact, storable snapshot of what a source found this run.
+export function buildNewsSnapshot(items) {
+  return {
+    count: items.length,
+    publishers: distinctPublishers(items),
+    keys: items.map((i) => i.dedup_key),
+    topics: Array.from(new Set(items.map((i) => (i.payload && i.payload.topic) || "").filter(Boolean))).slice(0, 20),
+  };
+}
+
+const clamp01 = (x) => Math.max(0, Math.min(1, x));
+
+// Weighted change score in [0,1]. Deliberately NOT "article count went up":
+// new *clusters* and multi-publisher *corroboration* dominate, so 11 rewrites of
+// one story score far lower than 3 genuinely new, independently-reported events.
+export function computeChangeScore({ diff, current, baseline, newClusters, corroboratedClusters }) {
+  const newCount = diff.new.length;
+  const curPub = current.publishers || 0;
+  const basePub = (baseline && baseline.publishers) || 0;
+  const curCount = current.count || 0;
+  const baseCount = (baseline && baseline.count) || 0;
+
+  const cNew = clamp01(newCount / 8);
+  const cClusters = clamp01((newClusters || 0) / 3);
+  const cCorro = clamp01((corroboratedClusters || 0) / 2);
+  const cDiversity = clamp01(Math.max(0, curPub - basePub) / 4);
+  const cVolume = clamp01(Math.max(0, curCount - baseCount) / 10);
+
+  const score =
+    0.35 * cNew + 0.25 * cClusters + 0.2 * cCorro + 0.1 * cDiversity + 0.1 * cVolume;
+  return clamp01(score);
+}
+
+// Map a change score → severity bucket (a fallback; the AI may refine within bounds).
+export function severityFromScore(score) {
+  if (score >= 0.75) return "critical";
+  if (score >= 0.55) return "high";
+  if (score >= 0.35) return "medium";
+  if (score > 0) return "low";
+  return "none";
+}
+
+// The AI call/skip decision. AI is called ONLY when a meaningful, code-detected
+// change exists — never to decide whether a change happened.
+//   isFirstRun            → skip 'insufficient_baseline' (this run establishes it)
+//   no data at all        → caller handles as source_unavailable (skip 'no_data')
+//   newCount === 0        → skip 'no_change'
+//   score < threshold     → skip 'below_threshold'
+//   else                  → call
+export function decideAI({ isFirstRun, hasData, newCount, changeScore, sensitivity }) {
+  if (!hasData) return { call: false, skip: "no_data" };
+  if (isFirstRun) return { call: false, skip: "insufficient_baseline" };
+  if (!newCount) return { call: false, skip: "no_change" };
+  const minNew = sensitivity && isFinite(sensitivity.min_new) ? sensitivity.min_new : 1;
+  if (newCount < minNew) return { call: false, skip: "below_threshold" };
+  const minScore = sensitivity && isFinite(sensitivity.min_score) ? sensitivity.min_score : 0.3;
+  if (changeScore < minScore) return { call: false, skip: "below_threshold" };
+  return { call: true, skip: null };
+}
+
+// ---------------------------------------------------------------------------
+//  Evidence-id validation — the anti-fabrication gate. EVERY evidence_id an AI
+//  report cites MUST be a real ev_key from THIS run's evidence. Claims that cite
+//  a nonexistent id are dropped; a report with no surviving grounded claim is
+//  rejected entirely (caller then records ai_failed and keeps snapshot+diff).
+// ---------------------------------------------------------------------------
+export function validateAndCleanReport(report, validKeySet, changePointsByKey) {
+  const invalid = new Set();
+  const arr = (v) => (Array.isArray(v) ? v : []);
+  const strArr = (v) => arr(v).map((x) => String(x)).filter(Boolean).slice(0, 40);
+
+  const changes = arr(report && report.changes)
+    .map((c) => {
+      const ids = arr(c && c.evidence_ids).map((x) => String(x));
+      const good = ids.filter((id) => {
+        const ok = validKeySet.has(id);
+        if (!ok) invalid.add(id);
+        return ok;
+      });
+      return { claim: String((c && c.claim) || "").slice(0, 500), evidence_ids: good, metric: c && c.metric ? String(c.metric).slice(0, 120) : undefined };
+    })
+    // A factual claim with NO surviving evidence id is not allowed to stand.
+    .filter((c) => c.claim && c.evidence_ids.length > 0);
+
+  // change_points: keep only points whose evidence_id is real.
+  const points = arr(report && report.change_points)
+    .map((p) => ({ lng: Number(p && p.lng), lat: Number(p && p.lat), label: String((p && p.label) || "").slice(0, 120), evidence_id: p && p.evidence_id ? String(p.evidence_id) : null }))
+    .filter((p) => isFinite(p.lng) && isFinite(p.lat) && (!p.evidence_id || validKeySet.has(p.evidence_id)));
+
+  // If the AI gave no change_points but cited evidence, synthesize points from the cited keys' coords.
+  let finalPoints = points;
+  if (!finalPoints.length && changePointsByKey) {
+    const seen = new Set();
+    finalPoints = [];
+    for (const c of changes) {
+      for (const id of c.evidence_ids) {
+        if (seen.has(id)) continue;
+        seen.add(id);
+        const pt = changePointsByKey.get(id);
+        if (pt && isFinite(pt.lng) && isFinite(pt.lat)) finalPoints.push({ lng: pt.lng, lat: pt.lat, label: pt.label || "", evidence_id: id });
+      }
+    }
+  }
+
+  const severity = ["none", "low", "medium", "high", "critical"].includes(report && report.severity) ? report.severity : null;
+
+  const cleaned = {
+    severity,
+    headline: String((report && report.headline) || "").slice(0, 200),
+    summary: String((report && report.summary) || "").slice(0, 2000),
+    changes,
+    unchanged: strArr(report && report.unchanged).map((s) => s.slice(0, 300)),
+    data_gaps: strArr(report && report.data_gaps).map((s) => s.slice(0, 300)),
+    limitations: strArr(report && report.limitations).map((s) => s.slice(0, 300)),
+    change_points: finalPoints.slice(0, 60),
+  };
+
+  const ok = !!cleaned.headline && changes.length > 0;
+  return { ok, cleaned, invalidRefs: Array.from(invalid) };
+}

--- a/supabase/migrations/20260721090000_area_monitors.sql
+++ b/supabase/migrations/20260721090000_area_monitors.sql
@@ -1,0 +1,409 @@
+-- ============================================================================
+--  IntMap — AREA MONITORS migration (#R141)
+-- ----------------------------------------------------------------------------
+--  WHAT THIS IS
+--    The "area monitoring / change-detection / evidence-backed report" feature.
+--    A logged-in user saves a MONITOR over a geographic area (a radius circle, a
+--    drawn polygon, or a resolved region) and a set of data SOURCES (news first,
+--    more later). A server-side runner (Edge Function `monitor-run`, scheduled by
+--    pg_cron — same pattern as refresh-news) periodically:
+--      collect → normalize/dedup → snapshot → mechanical diff vs the baseline →
+--      change-score → (only when the change is meaningful) call the AI → validate
+--      every evidence id → persist a run + evidence + (maybe) a report.
+--
+--    Four tables model this, deliberately separated so future data collectors
+--    (earthquakes/weather/fires/…) plug in without schema churn:
+--      • area_monitors    — the monitor definition (owner, geometry, sources, …)
+--      • monitor_runs     — one row per execution attempt (status, snapshot, diff)
+--      • monitor_evidence — the structured evidence rows a run gathered
+--      • monitor_reports  — the AI/mechanical report a run generated (if any)
+--
+--  IDEMPOTENT & NON-DESTRUCTIVE
+--    Every statement uses IF NOT EXISTS / CREATE OR REPLACE / DROP POLICY IF EXISTS.
+--    No DROP TABLE / DROP COLUMN / DELETE anywhere. Additive on top of the baseline.
+--
+--  SECURITY MODEL (mirrors the baseline's defense-in-depth)
+--    • RLS on all four tables; a user sees ONLY their own monitors/runs/evidence/
+--      reports (user_id = auth.uid()).
+--    • A user may CREATE/EDIT/DELETE their own MONITORS, but CANNOT write runs,
+--      evidence or reports at all (no grant) — so run results cannot be FORGED.
+--      Those are written only by the service_role runner (which bypasses RLS).
+--    • Column-level UPDATE grant on area_monitors excludes the run-state columns
+--      (running_since / last_* / run_count), so a user cannot tamper with the
+--      execution lock or fabricate "last run" metadata on their own row either.
+--    • PKs are random UUIDs (gen_random_uuid) — never guessable sequential ids.
+--    • monitor_claim_due() is SECURITY DEFINER, service_role-only: the atomic,
+--      lock-based claim (FOR UPDATE SKIP LOCKED) that prevents double execution.
+--    • monitor_limit() is the per-plan cap (the billing connection point). A
+--      BEFORE INSERT trigger enforces it — a user cannot exceed their quota.
+--    • Geometry text size and name length are constrained at the DB.
+-- ============================================================================
+
+begin;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  1. TABLES  (FK dependency order: monitors → runs → evidence/reports).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- 1.1 area_monitors — the monitor definition. One row per saved watch.
+create table if not exists public.area_monitors (
+  id              uuid primary key default gen_random_uuid(),
+  user_id         uuid not null references auth.users(id) on delete cascade,
+  name            text not null,
+  -- Geometry: a normalized GeoJSON Polygon/MultiPolygon (a circle is stored ALSO
+  -- as center+radius_km for a lossless, compact round-trip; the polygon is what
+  -- the server tests points against). geometry_kind records provenance.
+  geometry        jsonb not null,
+  geometry_kind   text  not null default 'polygon',   -- 'circle'|'polygon'|'multipolygon'|'region'
+  center_lng      double precision,
+  center_lat      double precision,
+  radius_km       double precision,
+  bbox            jsonb,                               -- [w,s,e,n] fast pre-filter
+  area_label      text,                                -- human label ("200 km around Rotterdam")
+  -- Selected collectors. Extensible — not CHECK-constrained to a closed set so a
+  -- new collector ('earthquake','weather','fire',…) needs no migration.
+  sources         text[] not null default array['news'],
+  -- Comparison config: {"mode":"previous_run"|"baseline_window","window_days":30}
+  comparison      jsonb not null default '{"mode":"previous_run","window_days":30}'::jsonb,
+  -- Per-source sensitivity/thresholds, e.g. {"news":{"min_new":2,"min_score":0.35}}
+  sensitivity     jsonb not null default '{}'::jsonb,
+  interval_minutes integer not null default 360,       -- how often it may run
+  enabled         boolean not null default true,
+  -- Denormalized run state (written by the runner; read for the list UI).
+  running_since   timestamptz,                          -- claim lock (NULL = idle)
+  last_run_at     timestamptz,
+  next_run_at     timestamptz not null default now(),   -- due when <= now()
+  last_status     text,                                 -- last run status (see run status set)
+  last_change_severity text,                            -- 'none'|'low'|'medium'|'high'|'critical'
+  last_report_id  uuid,                                 -- soft ref to the latest report (no FK: set post-insert)
+  run_count       integer not null default 0,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  constraint area_monitors_name_len       check (char_length(name) between 1 and 120),
+  constraint area_monitors_interval_min   check (interval_minutes >= 30),
+  constraint area_monitors_sources_nonempty check (array_length(sources, 1) >= 1),
+  constraint area_monitors_geom_size      check (char_length(geometry::text) <= 400000),
+  constraint area_monitors_geom_object    check (jsonb_typeof(geometry) = 'object')
+);
+comment on table public.area_monitors is
+  '(#R141) A user''s saved area watch: geometry + sources + comparison/sensitivity + schedule. Owner-only RLS; run-state columns are not user-updatable (see grants).';
+
+-- 1.2 monitor_runs — one row per execution attempt (scheduled or manual).
+create table if not exists public.monitor_runs (
+  id              uuid primary key default gen_random_uuid(),
+  monitor_id      uuid not null references public.area_monitors(id) on delete cascade,
+  user_id         uuid not null references auth.users(id) on delete cascade,  -- denormalized for RLS
+  started_at      timestamptz not null default now(),
+  finished_at     timestamptz,
+  -- Status taxonomy. success | success_no_change | partial | source_unavailable |
+  -- ai_failed | timed_out | invalid_geometry | quota_exceeded | disabled | internal_error
+  status          text not null default 'internal_error',
+  trigger         text not null default 'schedule',     -- 'schedule'|'manual'|'initial'
+  sources_attempted text[] not null default array[]::text[],
+  sources_ok      text[] not null default array[]::text[],
+  sources_failed  text[] not null default array[]::text[],
+  snapshot        jsonb,                                 -- normalized snapshot (counts/keys/per-source)
+  diff            jsonb,                                 -- mechanical diff (new/gone/continuing + numeric deltas)
+  change_score    numeric,                               -- computed change score (0..1)
+  report_generated boolean not null default false,
+  report_id       uuid,                                  -- soft ref (reports.run_id is the hard FK)
+  ai_used         boolean not null default false,
+  ai_skip_reason  text,                                  -- why AI was NOT called (no_change|insufficient_baseline|source_unavailable|below_threshold|disabled|not_needed)
+  ai_provider     text,
+  ai_model        text,
+  ai_tokens_in    integer,
+  ai_tokens_out   integer,
+  error_category  text,                                  -- when failed (no secrets/PII)
+  error_detail    text,
+  retryable       boolean not null default false,
+  duration_ms     integer,
+  evidence_count  integer not null default 0,
+  created_at      timestamptz not null default now()
+);
+comment on table public.monitor_runs is
+  '(#R141) One execution attempt of a monitor. Written only by the service_role runner; users read their own. Preserves snapshot+diff even when only the AI step failed.';
+
+-- 1.3 monitor_evidence — structured evidence gathered by a run. Every report claim
+--     references these by ev_key; the runner validates that mapping before saving.
+create table if not exists public.monitor_evidence (
+  id              uuid primary key default gen_random_uuid(),
+  run_id          uuid not null references public.monitor_runs(id) on delete cascade,
+  monitor_id      uuid not null references public.area_monitors(id) on delete cascade,
+  user_id         uuid not null references auth.users(id) on delete cascade,  -- denormalized for RLS
+  ev_key          text not null,                         -- stable per-run id ("ev_1"…) referenced by the report
+  source_type     text not null,                         -- 'news'|'earthquake'|…
+  source_name     text,                                  -- publisher/provider
+  source_url      text,                                  -- original URL (http/https validated by the runner)
+  external_id     text,                                  -- provider id / link
+  title           text,
+  observed_at     timestamptz,                           -- event / publication time
+  fetched_at      timestamptz not null default now(),
+  lng             double precision,
+  lat             double precision,
+  payload         jsonb,                                 -- normalized data
+  dedup_key       text not null,                         -- dedup hash/key
+  change_kind     text,                                  -- 'new'|'continuing'|'gone' vs baseline
+  created_at      timestamptz not null default now(),
+  unique (run_id, ev_key)
+);
+comment on table public.monitor_evidence is
+  '(#R141) A single piece of structured evidence for a run (source_type/name/url/observed_at/coords/normalized payload/dedup_key). ev_key is what report claims cite.';
+
+-- 1.4 monitor_reports — the report a run generated (AI-authored or mechanical).
+create table if not exists public.monitor_reports (
+  id              uuid primary key default gen_random_uuid(),
+  monitor_id      uuid not null references public.area_monitors(id) on delete cascade,
+  run_id          uuid not null references public.monitor_runs(id) on delete cascade,
+  user_id         uuid not null references auth.users(id) on delete cascade,  -- denormalized for RLS
+  severity        text not null default 'low',           -- 'none'|'low'|'medium'|'high'|'critical'
+  headline        text not null,
+  summary         text,
+  changes         jsonb not null default '[]'::jsonb,     -- [{claim, evidence_ids:[…], metric?}]
+  unchanged       jsonb not null default '[]'::jsonb,     -- ["…"]
+  data_gaps       jsonb not null default '[]'::jsonb,     -- ["…"]
+  limitations     jsonb not null default '[]'::jsonb,     -- ["…"]
+  metrics         jsonb,                                  -- numeric comparisons {articles:{prev,cur,delta},…}
+  change_points   jsonb,                                  -- [{lng,lat,label,evidence_id}] for the map
+  ai_provider     text,
+  ai_model        text,
+  prompt_version  text,
+  read            boolean not null default false,
+  created_at      timestamptz not null default now()
+);
+comment on table public.monitor_reports is
+  '(#R141) A report generated for a run. Every factual claim in `changes` carries evidence_ids that MUST resolve to this run''s monitor_evidence (validated by the runner).';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  2. INDEXES (query paths the runner + UI actually use).
+-- ─────────────────────────────────────────────────────────────────────────────
+create index if not exists idx_monitors_user           on public.area_monitors (user_id);
+-- The due-scan the runner does every tick: enabled monitors ordered by next_run_at.
+create index if not exists idx_monitors_due             on public.area_monitors (next_run_at) where enabled;
+create index if not exists idx_monitors_running         on public.area_monitors (running_since);
+create index if not exists idx_monruns_monitor          on public.monitor_runs (monitor_id, started_at desc);
+create index if not exists idx_monruns_user             on public.monitor_runs (user_id);
+create index if not exists idx_monev_run                on public.monitor_evidence (run_id);
+create index if not exists idx_monev_monitor            on public.monitor_evidence (monitor_id);
+create index if not exists idx_monev_user               on public.monitor_evidence (user_id);
+create index if not exists idx_monev_dedup              on public.monitor_evidence (monitor_id, dedup_key);
+create index if not exists idx_monrep_monitor           on public.monitor_reports (monitor_id, created_at desc);
+create index if not exists idx_monrep_user              on public.monitor_reports (user_id);
+create index if not exists idx_monrep_run               on public.monitor_reports (run_id);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  3. updated_at trigger for area_monitors (keeps it honest on edits).
+-- ─────────────────────────────────────────────────────────────────────────────
+create or replace function public.tg_monitors_touch()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+drop trigger if exists trg_monitors_touch on public.area_monitors;
+create trigger trg_monitors_touch
+  before update on public.area_monitors
+  for each row execute function public.tg_monitors_touch();
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  4. PLAN LIMITS — the per-plan monitor cap. THIS is the billing connection
+--     point: change the numbers here (or read a future billing table) to tier it.
+--     SECURITY DEFINER + empty search_path so the insert trigger can read profiles
+--     without tripping profiles' owner-only RLS.
+-- ─────────────────────────────────────────────────────────────────────────────
+create or replace function public.monitor_limit(p_user uuid)
+returns integer
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_plan  text;
+  v_pro   boolean;
+  v_admin boolean;
+begin
+  select plan, is_pro, is_admin into v_plan, v_pro, v_admin
+    from public.profiles where id = p_user;
+  if v_admin or v_plan = 'unlimited' then return 200; end if;
+  if v_plan in ('pro','plus') or v_pro then return 25; end if;
+  return 5;   -- free
+end;
+$$;
+comment on function public.monitor_limit(uuid) is
+  '(#R141) Max saved monitors for a user by plan (free=5, pro/plus=25, admin/unlimited=200). The single place to tier the feature for billing.';
+
+-- Enforce the cap on insert. A user cannot exceed monitor_limit() for themselves.
+create or replace function public.tg_monitors_enforce_limit()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_count integer;
+  v_limit integer;
+begin
+  select count(*) into v_count from public.area_monitors where user_id = new.user_id;
+  v_limit := public.monitor_limit(new.user_id);
+  if v_count >= v_limit then
+    raise exception 'monitor_limit_reached: % monitors is the limit for this plan', v_limit
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+drop trigger if exists trg_monitors_limit on public.area_monitors;
+create trigger trg_monitors_limit
+  before insert on public.area_monitors
+  for each row execute function public.tg_monitors_enforce_limit();
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  5. CLAIM RPC — the atomic, lock-based "grab the due monitors" the runner calls.
+--     FOR UPDATE SKIP LOCKED means two concurrent cron invocations never process
+--     the same monitor. Stale locks (a crashed run) are reclaimed after
+--     p_stale_minutes. service_role-only (EXECUTE revoked from users below).
+-- ─────────────────────────────────────────────────────────────────────────────
+create or replace function public.monitor_claim_due(p_limit integer default 20, p_stale_minutes integer default 15)
+returns setof public.area_monitors
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  return query
+  update public.area_monitors m
+     set running_since = now()
+   where m.id in (
+     select s.id from public.area_monitors s
+      where s.enabled = true
+        and s.next_run_at <= now()
+        and (s.running_since is null or s.running_since < now() - make_interval(mins => p_stale_minutes))
+      order by s.next_run_at asc
+      limit p_limit
+      for update skip locked
+   )
+  returning m.*;
+end;
+$$;
+comment on function public.monitor_claim_due(integer, integer) is
+  '(#R141) Atomically claim up to p_limit due, enabled, unlocked monitors (FOR UPDATE SKIP LOCKED) and mark them running. service_role only — the runner''s double-execution guard.';
+
+-- Let a user mark ONE of their own reports read, without granting UPDATE on the
+-- table (keeps the report body immutable from the client). SECURITY DEFINER but
+-- scoped to the caller's own row via auth.uid().
+create or replace function public.monitor_mark_read(p_report uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  update public.monitor_reports
+     set read = true
+   where id = p_report and user_id = (select auth.uid());
+end;
+$$;
+comment on function public.monitor_mark_read(uuid) is
+  '(#R141) Mark the caller''s own report read. Owner-scoped via auth.uid(); the report body stays client-immutable (no UPDATE grant).';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  6. ROW LEVEL SECURITY.
+-- ─────────────────────────────────────────────────────────────────────────────
+alter table public.area_monitors    enable row level security;
+alter table public.monitor_runs      enable row level security;
+alter table public.monitor_evidence  enable row level security;
+alter table public.monitor_reports   enable row level security;
+
+-- 6.1 area_monitors — full own-row CRUD (WITH CHECK pins user_id = self so you
+--     cannot create/reassign a monitor to someone else). Column-level UPDATE
+--     grant (§7) additionally blocks tampering with the run-state columns.
+drop policy if exists monitors_select_own on public.area_monitors;
+drop policy if exists monitors_insert_own on public.area_monitors;
+drop policy if exists monitors_update_own on public.area_monitors;
+drop policy if exists monitors_delete_own on public.area_monitors;
+create policy monitors_select_own on public.area_monitors
+  for select to authenticated using (user_id = (select auth.uid()));
+create policy monitors_insert_own on public.area_monitors
+  for insert to authenticated with check (user_id = (select auth.uid()));
+create policy monitors_update_own on public.area_monitors
+  for update to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+create policy monitors_delete_own on public.area_monitors
+  for delete to authenticated using (user_id = (select auth.uid()));
+
+-- 6.2 monitor_runs / monitor_evidence / monitor_reports — READ own only. No
+--     insert/update/delete policy AND no write grant → users cannot write them at
+--     all (only the service_role runner, which bypasses RLS). Run results cannot
+--     be forged, and reports are immutable from the client (read flag flips via
+--     the monitor_mark_read RPC).
+drop policy if exists monruns_select_own on public.monitor_runs;
+create policy monruns_select_own on public.monitor_runs
+  for select to authenticated using (user_id = (select auth.uid()));
+
+drop policy if exists monev_select_own on public.monitor_evidence;
+create policy monev_select_own on public.monitor_evidence
+  for select to authenticated using (user_id = (select auth.uid()));
+
+drop policy if exists monrep_select_own on public.monitor_reports;
+create policy monrep_select_own on public.monitor_reports
+  for select to authenticated using (user_id = (select auth.uid()));
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  7. GRANTS — defense in depth (RLS decides WHICH ROWS; grants decide whether the
+--     role may touch the table/columns AT ALL).
+-- ─────────────────────────────────────────────────────────────────────────────
+-- area_monitors: read + insert + delete own; UPDATE only the user-editable config
+-- columns — NOT the run-state columns (running_since/last_*/run_count/updated_at/
+-- last_report_id/last_change_severity), so a user can't forge run metadata or
+-- release/steal the execution lock on their own row.
+grant select, insert, delete on public.area_monitors to authenticated;
+grant update (name, geometry, geometry_kind, center_lng, center_lat, radius_km,
+              bbox, area_label, sources, comparison, sensitivity, interval_minutes,
+              enabled, next_run_at) on public.area_monitors to authenticated;
+
+-- Child tables: SELECT only (RLS → own rows). No write grant to users.
+grant select on public.monitor_runs     to authenticated;
+grant select on public.monitor_evidence to authenticated;
+grant select on public.monitor_reports  to authenticated;
+
+-- service_role writes everything (explicit for clarity; it also bypasses RLS).
+grant all on public.area_monitors, public.monitor_runs,
+             public.monitor_evidence, public.monitor_reports to service_role;
+
+-- RPC EXECUTE. Claim is service_role-only (a user calling it could grab/lock
+-- monitors). mark_read + limit are safe for users to call about themselves.
+revoke execute on function public.monitor_claim_due(integer, integer) from public, anon, authenticated;
+grant  execute on function public.monitor_claim_due(integer, integer) to service_role;
+revoke execute on function public.tg_monitors_enforce_limit()          from public, anon, authenticated;
+revoke execute on function public.tg_monitors_touch()                  from public, anon, authenticated;
+grant  execute on function public.monitor_mark_read(uuid) to authenticated, service_role;
+grant  execute on function public.monitor_limit(uuid)     to authenticated, service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  8. REALTIME — let the client live-update the monitors list + a report arriving.
+--     (Idempotent: skip any table already in the publication.)
+-- ─────────────────────────────────────────────────────────────────────────────
+do $$
+declare
+  t text;
+  tables text[] := array['area_monitors','monitor_runs','monitor_reports'];
+begin
+  if exists (select 1 from pg_publication where pubname = 'supabase_realtime') then
+    foreach t in array tables loop
+      if not exists (
+        select 1 from pg_publication_tables
+        where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = t
+      ) then
+        execute format('alter publication supabase_realtime add table public.%I', t);
+      end if;
+    end loop;
+  end if;
+end;
+$$;
+
+commit;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -115,3 +115,58 @@ values
   ('en', 'world', 'Synthetic headline EN', 'Test Wire', 'https://example.test/news-en-1', now(), 139.69, 35.68, 'Tokyo', '東京', true, 'dict'),
   ('jp', 'world', '合成見出し JP',        'Test Wire', 'https://example.test/news-jp-1', now(), 2.35, 48.85, 'Paris', 'パリ', true, 'dict')
 on conflict (lang, link) do nothing;
+
+-- 9) AREA MONITORS (#R141) — A owns a monitor with a run + evidence + report; B owns
+--    one monitor. Used by the cross-user isolation tests (04_monitors_test.sql) to
+--    prove A cannot read/forge B's monitor, run, evidence or report and vice versa.
+insert into public.area_monitors
+  (id, user_id, name, geometry, geometry_kind, center_lng, center_lat, radius_km, bbox, area_label, sources, next_run_at)
+values
+  ('10000000-0000-0000-0000-0000000000a1', '11111111-1111-1111-1111-111111111111',
+   'Tokyo watch (A)', '{"type":"Polygon","coordinates":[[[139,35],[140,35],[140,36],[139,36],[139,35]]]}'::jsonb,
+   'circle', 139.69, 35.68, 60, '[139,35,140,36]'::jsonb, '60 km around Tokyo', array['news'], now() + interval '1 hour'),
+  ('20000000-0000-0000-0000-0000000000b1', '22222222-2222-2222-2222-222222222222',
+   'Paris watch (B)', '{"type":"Polygon","coordinates":[[[2,48],[3,48],[3,49],[2,49],[2,48]]]}'::jsonb,
+   'circle', 2.35, 48.85, 60, '[2,48,3,49]'::jsonb, '60 km around Paris', array['news'], now() + interval '1 hour')
+on conflict (id) do nothing;
+
+insert into public.monitor_runs
+  (id, monitor_id, user_id, started_at, finished_at, status, trigger, sources_attempted, sources_ok,
+   snapshot, diff, change_score, report_generated, ai_used, evidence_count)
+values
+  ('10000000-0000-0000-0000-0000000000a2', '10000000-0000-0000-0000-0000000000a1',
+   '11111111-1111-1111-1111-111111111111', now(), now(), 'success', 'initial',
+   array['news'], array['news'], '{"news":{"count":2}}'::jsonb, '{"news":{"new":2}}'::jsonb, 0.5, true, true, 2)
+on conflict (id) do nothing;
+
+insert into public.monitor_evidence
+  (run_id, monitor_id, user_id, ev_key, source_type, source_name, source_url, title, observed_at, lng, lat, payload, dedup_key, change_kind)
+values
+  ('10000000-0000-0000-0000-0000000000a2', '10000000-0000-0000-0000-0000000000a1',
+   '11111111-1111-1111-1111-111111111111', 'ev_1', 'news', 'Test Wire', 'https://example.test/news-en-1',
+   'Synthetic headline EN', now(), 139.69, 35.68, '{"topic":"world"}'::jsonb, 'news:example.test/news-en-1', 'new'),
+  ('10000000-0000-0000-0000-0000000000a2', '10000000-0000-0000-0000-0000000000a1',
+   '11111111-1111-1111-1111-111111111111', 'ev_2', 'news', 'Test Wire', 'https://example.test/news-en-2',
+   'Second synthetic headline', now(), 139.70, 35.69, '{"topic":"world"}'::jsonb, 'news:example.test/news-en-2', 'new')
+on conflict (run_id, ev_key) do nothing;
+
+insert into public.monitor_reports
+  (id, monitor_id, run_id, user_id, severity, headline, summary, changes, unchanged, data_gaps, limitations, metrics)
+values
+  ('10000000-0000-0000-0000-0000000000a3', '10000000-0000-0000-0000-0000000000a1',
+   '10000000-0000-0000-0000-0000000000a2', '11111111-1111-1111-1111-111111111111', 'medium',
+   'Two new reports around Tokyo', 'Two new articles were detected in the monitored area.',
+   '[{"claim":"Two new reports were detected.","evidence_ids":["ev_1","ev_2"]}]'::jsonb,
+   '["No second independent cluster confirmed."]'::jsonb, '[]'::jsonb,
+   '["Locations reflect the reported subject of each article."]'::jsonb,
+   '{"articles":{"prev":0,"cur":2,"delta":2}}'::jsonb)
+on conflict (id) do nothing;
+
+-- Link the monitor's denormalized latest-report pointers (as the runner would).
+update public.area_monitors
+   set last_report_id = '10000000-0000-0000-0000-0000000000a3', last_status = 'success',
+       last_change_severity = 'medium', last_run_at = now(), run_count = 1
+ where id = '10000000-0000-0000-0000-0000000000a1';
+update public.monitor_runs
+   set report_id = '10000000-0000-0000-0000-0000000000a3'
+ where id = '10000000-0000-0000-0000-0000000000a2';

--- a/supabase/tests/00_structure_test.sql
+++ b/supabase/tests/00_structure_test.sql
@@ -4,7 +4,7 @@
 --  Executed by `supabase test db` (see docs/RLS-TESTING.md).
 -- ============================================================================
 begin;
-select plan(38);
+select plan(52);
 
 -- 1) Every expected table exists in public.
 select has_table('public', t, 'table ' || t || ' exists')
@@ -12,8 +12,10 @@ from unnest(array[
   'profiles','ai_usage','user_prefs','favorites','donations','feedback',
   'bug_reports','community_posts','community_comments','community_votes',
   'community_comment_votes','community_reports','geo_pins','dashboard_cards',
-  'current_news'
-]) as t;                                                    -- 15 assertions
+  'current_news',
+  -- (#R141) area-monitoring feature
+  'area_monitors','monitor_runs','monitor_evidence','monitor_reports'
+]) as t;                                                    -- 19 assertions
 
 -- 2) RLS is ENABLED on every one of them (fail-closed: a table with RLS off fails).
 select ok(
@@ -24,8 +26,9 @@ from unnest(array[
   'profiles','ai_usage','user_prefs','favorites','donations','feedback',
   'bug_reports','community_posts','community_comments','community_votes',
   'community_comment_votes','community_reports','geo_pins','dashboard_cards',
-  'current_news'
-]) as t;                                                    -- 15 assertions
+  'current_news',
+  'area_monitors','monitor_runs','monitor_evidence','monitor_reports'
+]) as t;                                                    -- 19 assertions
 
 -- 3) Keys / relationships that the app depends on.
 select has_pk('public', 'profiles', 'profiles has a primary key');
@@ -41,6 +44,16 @@ select hasnt_column('public', 'profiles_public', 'is_admin', 'profiles_public do
 -- 5) Core functions exist.
 select has_function('public','is_admin', 'is_admin() exists');
 select has_function('public','increment_ai_usage', array['uuid','integer'], 'increment_ai_usage(uuid,int) exists');
+
+-- 6) (#R141) Area-monitoring keys, relationships and functions.
+select col_is_pk('public','area_monitors', array['id'], 'area_monitors PK is (id)');
+select fk_ok('public','monitor_runs','monitor_id','public','area_monitors','id',
+             'monitor_runs.monitor_id → area_monitors.id');
+select fk_ok('public','monitor_reports','run_id','public','monitor_runs','id',
+             'monitor_reports.run_id → monitor_runs.id');
+select has_function('public','monitor_claim_due', array['integer','integer'], 'monitor_claim_due(int,int) exists');
+select has_function('public','monitor_limit', array['uuid'], 'monitor_limit(uuid) exists');
+select has_function('public','monitor_mark_read', array['uuid'], 'monitor_mark_read(uuid) exists');
 
 reset role;
 select * from finish();

--- a/supabase/tests/04_monitors_test.sql
+++ b/supabase/tests/04_monitors_test.sql
@@ -1,0 +1,171 @@
+-- ============================================================================
+--  pgTAP · 04 area-monitors RLS/permission matrix (#R141) — prove that a user
+--  sees and controls ONLY their own monitors/runs/evidence/reports, cannot forge
+--  run results, cannot tamper with the run-state (lock/counters) on their own
+--  monitor, cannot exceed their plan's monitor cap, and cannot call the
+--  service-role claim RPC. Same top-level-SET-ROLE technique as 01_rls_matrix.
+--
+--  Seed subjects (supabase/seed.sql §9):
+--    A monitor 1000…a1 (+ run 1000…a2, 2 evidence, report 1000…a3) — user A
+--    B monitor 2000…b1                                              — user B
+-- ============================================================================
+begin;
+select no_plan();
+
+do $$ begin execute format('grant anon, authenticated, service_role to %I', current_user); exception when others then null; end $$;
+
+create table _cap (k text primary key, v text);
+grant insert, select on _cap to anon, authenticated, service_role;
+
+create function _sel(k text, q text) returns void language plpgsql as $$
+declare c text;
+begin
+  execute q into c;
+  insert into _cap values (k, coalesce(c, '<null>'));
+exception
+  when insufficient_privilege then insert into _cap values (k, 'DENIED');
+  when others then insert into _cap values (k, 'ERR:' || sqlstate);
+end;
+$$;
+create function _dml(k text, q text) returns void language plpgsql as $$
+declare n integer;
+begin
+  execute q; get diagnostics n = row_count;
+  insert into _cap values (k, 'ROWS:' || n);
+exception
+  when insufficient_privilege then insert into _cap values (k, 'DENIED');
+  when others then insert into _cap values (k, 'ERR:' || sqlstate);
+end;
+$$;
+
+-- ─────────────────────────── ANON (logged out) ─────────────────────────────
+select set_config('request.jwt.claims', '{"role":"anon"}', true);
+set local role anon;
+select _sel('anon_monitors', 'select count(*) from public.area_monitors');    -- no grant → DENIED
+select _sel('anon_runs',     'select count(*) from public.monitor_runs');      -- DENIED
+select _sel('anon_evidence', 'select count(*) from public.monitor_evidence');  -- DENIED
+select _sel('anon_reports',  'select count(*) from public.monitor_reports');   -- DENIED
+reset role;
+
+-- ─────────────────────────── USER A (authenticated) ────────────────────────
+select set_config('request.jwt.claims', '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}', true);
+set local role authenticated;
+-- reads: own vs B
+select _sel('a_own_mon',   'select count(*) from public.area_monitors where user_id=''11111111-1111-1111-1111-111111111111'''); -- 1
+select _sel('a_all_mon',   'select count(*) from public.area_monitors');                                                        -- 1 (only own)
+select _sel('a_b_mon',     'select count(*) from public.area_monitors where id=''20000000-0000-0000-0000-0000000000b1''');       -- 0
+select _sel('a_own_run',   'select count(*) from public.monitor_runs');                                                         -- 1
+select _sel('a_own_ev',    'select count(*) from public.monitor_evidence');                                                     -- 2
+select _sel('a_own_rep',   'select count(*) from public.monitor_reports');                                                      -- 1
+-- forge run results → DENIED (no write grant on child tables)
+select _dml('a_forge_run', 'insert into public.monitor_runs(monitor_id,user_id,status) values (''10000000-0000-0000-0000-0000000000a1'',''11111111-1111-1111-1111-111111111111'',''success'')');
+select _dml('a_forge_ev',  'insert into public.monitor_evidence(run_id,monitor_id,user_id,ev_key,source_type,dedup_key) values (''10000000-0000-0000-0000-0000000000a2'',''10000000-0000-0000-0000-0000000000a1'',''11111111-1111-1111-1111-111111111111'',''evX'',''news'',''k'')');
+select _dml('a_forge_rep', 'insert into public.monitor_reports(monitor_id,run_id,user_id,headline) values (''10000000-0000-0000-0000-0000000000a1'',''10000000-0000-0000-0000-0000000000a2'',''11111111-1111-1111-1111-111111111111'',''fake'')');
+-- tamper with own monitor's RUN-STATE columns → DENIED (column-level grant excludes them)
+select _dml('a_set_lock',   'update public.area_monitors set running_since=now() where id=''10000000-0000-0000-0000-0000000000a1''');
+select _dml('a_set_count',  'update public.area_monitors set run_count=999 where id=''10000000-0000-0000-0000-0000000000a1''');
+select _dml('a_set_status', 'update public.area_monitors set last_status=''success'' where id=''10000000-0000-0000-0000-0000000000a1''');
+-- edit own monitor's CONFIG columns → allowed
+select _dml('a_edit_name',  'update public.area_monitors set name=''A2'' where id=''10000000-0000-0000-0000-0000000000a1''');   -- ROWS:1
+select _dml('a_toggle',     'update public.area_monitors set enabled=false where id=''10000000-0000-0000-0000-0000000000a1''');-- ROWS:1
+-- cannot touch B's monitor
+select _dml('a_edit_b_mon', 'update public.area_monitors set name=''HACK'' where id=''20000000-0000-0000-0000-0000000000b1''');-- ROWS:0
+select _dml('a_del_b_mon',  'delete from public.area_monitors where id=''20000000-0000-0000-0000-0000000000b1''');             -- ROWS:0
+-- cannot create a monitor owned by B (WITH CHECK)
+select _dml('a_ins_as_b',   'insert into public.area_monitors(user_id,name,geometry) values (''22222222-2222-2222-2222-222222222222'',''spoof'',''{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}''::jsonb)');
+-- cannot call the service-role claim RPC (quota/lock bypass blocked)
+select _sel('a_claim',      'select count(*) from public.monitor_claim_due(5,15)');   -- DENIED
+-- plan limit function about self is readable (free → 5) — the billing hook
+select _sel('a_limit',      'select public.monitor_limit(''11111111-1111-1111-1111-111111111111'')::text'); -- 5
+reset role;
+
+-- ─────────────────────────── USER B (authenticated) ────────────────────────
+select set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}', true);
+set local role authenticated;
+select _sel('b_own_mon',   'select count(*) from public.area_monitors');    -- 1 (only own)
+select _sel('b_a_mon',     'select count(*) from public.area_monitors where id=''10000000-0000-0000-0000-0000000000a1'''); -- 0 (A''s)
+select _sel('b_runs',      'select count(*) from public.monitor_runs');      -- 0 (A''s run invisible)
+select _sel('b_ev',        'select count(*) from public.monitor_evidence');  -- 0
+select _sel('b_reports',   'select count(*) from public.monitor_reports');   -- 0
+reset role;
+
+-- ─────────────────────────── ADMIN — no backdoor into private monitors ─────
+-- (Monitors are private per-user; unlike feedback/donations, admins get NO extra
+--  access. Admin owns no monitors → sees zero.)
+select set_config('request.jwt.claims', '{"sub":"33333333-3333-3333-3333-333333333333","role":"authenticated"}', true);
+set local role authenticated;
+select _sel('admin_mon',   'select count(*) from public.area_monitors');     -- 0 (admin owns none; no backdoor)
+select _sel('admin_rep',   'select count(*) from public.monitor_reports');   -- 0
+select _sel('admin_limit', 'select public.monitor_limit(''33333333-3333-3333-3333-333333333333'')::text'); -- 200 (unlimited plan)
+reset role;
+
+-- ─────────────────────────── SERVICE ROLE (the runner) ─────────────────────
+-- Captured BEFORE the enforcement block below so counts stay deterministic.
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+set local role service_role;
+select _sel('svc_all_mon', 'select count(*) from public.area_monitors');                 -- 2 (bypass RLS)
+select _sel('svc_all_rep', 'select count(*) from public.monitor_reports');               -- 1
+select _dml('svc_ins_run', 'insert into public.monitor_runs(monitor_id,user_id,status,trigger) values (''20000000-0000-0000-0000-0000000000b1'',''22222222-2222-2222-2222-222222222222'',''success_no_change'',''schedule'')'); -- ROWS:1
+select _sel('svc_claim',   'select count(*) from public.monitor_claim_due(5,15)');       -- 0 (seed monitors due in +1h → none claimed)
+reset role;
+
+-- ─────────────────────────── LIMIT ENFORCEMENT (LAST — mutates A''s count) ──
+-- A (free, limit 5) already owns 1. Four more inserts succeed; the fifth insert
+-- (which would be the 6th monitor) is rejected by the enforce-limit trigger.
+select set_config('request.jwt.claims', '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}', true);
+set local role authenticated;
+select _dml('a_ins2', 'insert into public.area_monitors(user_id,name,geometry) values (''11111111-1111-1111-1111-111111111111'',''m2'',''{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}''::jsonb)'); -- ROWS:1
+select _dml('a_ins3', 'insert into public.area_monitors(user_id,name,geometry) values (''11111111-1111-1111-1111-111111111111'',''m3'',''{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}''::jsonb)'); -- ROWS:1
+select _dml('a_ins4', 'insert into public.area_monitors(user_id,name,geometry) values (''11111111-1111-1111-1111-111111111111'',''m4'',''{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}''::jsonb)'); -- ROWS:1
+select _dml('a_ins5', 'insert into public.area_monitors(user_id,name,geometry) values (''11111111-1111-1111-1111-111111111111'',''m5'',''{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}''::jsonb)'); -- ROWS:1 (now at limit 5)
+select _dml('a_ins6', 'insert into public.area_monitors(user_id,name,geometry) values (''11111111-1111-1111-1111-111111111111'',''m6'',''{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}''::jsonb)'); -- ERR:23514 (limit)
+reset role;
+
+-- ─────────────────────────── ASSERTIONS (as superuser) ─────────────────────
+-- anon
+select is((select v from _cap where k='anon_monitors'), 'DENIED', 'anon cannot read area_monitors');
+select is((select v from _cap where k='anon_runs'),     'DENIED', 'anon cannot read monitor_runs');
+select is((select v from _cap where k='anon_evidence'), 'DENIED', 'anon cannot read monitor_evidence');
+select is((select v from _cap where k='anon_reports'),  'DENIED', 'anon cannot read monitor_reports');
+-- user A isolation + capability
+select is((select v from _cap where k='a_own_mon'), '1',      'A reads own monitor');
+select is((select v from _cap where k='a_all_mon'), '1',      'A sees only own monitors');
+select is((select v from _cap where k='a_b_mon'),   '0',      'A cannot read B''s monitor row');
+select is((select v from _cap where k='a_own_run'), '1',      'A reads own run');
+select is((select v from _cap where k='a_own_ev'),  '2',      'A reads own evidence');
+select is((select v from _cap where k='a_own_rep'), '1',      'A reads own report');
+select is((select v from _cap where k='a_forge_run'),'DENIED','A CANNOT forge a run result');
+select is((select v from _cap where k='a_forge_ev'), 'DENIED','A CANNOT forge evidence');
+select is((select v from _cap where k='a_forge_rep'),'DENIED','A CANNOT forge a report');
+select is((select v from _cap where k='a_set_lock'), 'DENIED','A CANNOT touch the run lock (running_since)');
+select is((select v from _cap where k='a_set_count'),'DENIED','A CANNOT forge run_count on its own monitor');
+select is((select v from _cap where k='a_set_status'),'DENIED','A CANNOT forge last_status on its own monitor');
+select is((select v from _cap where k='a_edit_name'),'ROWS:1', 'A can rename its own monitor');
+select is((select v from _cap where k='a_toggle'),   'ROWS:1', 'A can enable/disable its own monitor');
+select is((select v from _cap where k='a_edit_b_mon'),'ROWS:0','A cannot edit B''s monitor');
+select is((select v from _cap where k='a_del_b_mon'),'ROWS:0', 'A cannot delete B''s monitor');
+select is((select v from _cap where k='a_ins_as_b'), 'DENIED', 'A cannot create a monitor owned by B (WITH CHECK)');
+select is((select v from _cap where k='a_claim'),    'DENIED', 'A cannot call monitor_claim_due (runner-only)');
+select is((select v from _cap where k='a_limit'),    '5',      'A (free) monitor limit is 5');
+-- user B isolation
+select is((select v from _cap where k='b_own_mon'), '1', 'B reads own monitor');
+select is((select v from _cap where k='b_a_mon'),   '0', 'B cannot read A''s monitor');
+select is((select v from _cap where k='b_runs'),    '0', 'B cannot read A''s runs');
+select is((select v from _cap where k='b_ev'),      '0', 'B cannot read A''s evidence');
+select is((select v from _cap where k='b_reports'), '0', 'B cannot read A''s reports');
+-- admin: no private-monitor backdoor
+select is((select v from _cap where k='admin_mon'),   '0',   'admin has NO backdoor into private monitors');
+select is((select v from _cap where k='admin_rep'),   '0',   'admin cannot read others'' reports');
+select is((select v from _cap where k='admin_limit'), '200', 'admin/unlimited monitor limit is 200');
+-- service role
+select is((select v from _cap where k='svc_all_mon'), '2',      'service_role sees all monitors (bypass RLS)');
+select is((select v from _cap where k='svc_all_rep'), '1',      'service_role sees all reports');
+select is((select v from _cap where k='svc_ins_run'), 'ROWS:1', 'service_role (runner) can write a run');
+select is((select v from _cap where k='svc_claim'),   '0',      'monitor_claim_due returns nothing when no monitor is due');
+-- limit enforcement
+select is((select v from _cap where k='a_ins2'), 'ROWS:1',    'A insert #2 ok (under limit)');
+select is((select v from _cap where k='a_ins5'), 'ROWS:1',    'A insert #5 ok (reaches limit 5)');
+select is((select v from _cap where k='a_ins6'), 'ERR:23514', 'A insert #6 rejected by the plan limit (check_violation)');
+
+select * from finish();
+rollback;

--- a/tests/monitor-logic.test.mjs
+++ b/tests/monitor-logic.test.mjs
@@ -1,0 +1,200 @@
+// ============================================================================
+//  tests/monitor-logic.test.mjs  (#R141)
+//  Unit tests for the PURE area-monitoring engine that both the Deno Edge
+//  Function (monitor-run) and this test import. Run by `node --test` (npm test).
+//  Covers the spec's required logic: in/out of a circle + polygon, date/window,
+//  dedup, clustering, first-run vs no-change vs real-change, change score, and
+//  the evidence-id validation that gates every AI claim.
+// ============================================================================
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  haversineKm, pointInRing, pointInGeometry, bboxOfGeometry, pointInMonitorArea,
+  validGeometry, isSafeHttpUrl, normalizeNewsRow, dedupeEvidence, diffKeys,
+  clusterPoints, distinctPublishers, buildNewsSnapshot, computeChangeScore,
+  severityFromScore, decideAI, validateAndCleanReport,
+} from "../supabase/functions/monitor-run/logic.mjs";
+
+// Square polygon covering [0,0]..[2,2].
+const SQUARE = { type: "Polygon", coordinates: [[[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]]] };
+
+test("haversineKm — known distance (Tokyo↔Osaka ≈ 400 km)", () => {
+  const d = haversineKm(139.69, 35.68, 135.5, 34.69);
+  assert.ok(d > 380 && d < 420, `got ${d}`);
+});
+
+test("pointInRing / pointInGeometry — inside vs outside a square", () => {
+  assert.equal(pointInGeometry(1, 1, SQUARE), true);
+  assert.equal(pointInGeometry(3, 3, SQUARE), false);
+  assert.equal(pointInGeometry(-0.5, 1, SQUARE), false);
+});
+
+test("pointInGeometry — MultiPolygon + a hole", () => {
+  const holed = { type: "Polygon", coordinates: [[[0, 0], [4, 0], [4, 4], [0, 4], [0, 0]], [[1, 1], [3, 1], [3, 3], [1, 3], [1, 1]]] };
+  assert.equal(pointInGeometry(0.5, 0.5, holed), true);   // in outer, outside hole
+  assert.equal(pointInGeometry(2, 2, holed), false);      // in the hole
+  const multi = { type: "MultiPolygon", coordinates: [SQUARE.coordinates, [[[10, 10], [11, 10], [11, 11], [10, 11], [10, 10]]]] };
+  assert.equal(pointInGeometry(10.5, 10.5, multi), true);
+  assert.equal(pointInGeometry(5, 5, multi), false);
+});
+
+test("pointInMonitorArea — circle uses exact haversine (in vs out)", () => {
+  const m = { geometry_kind: "circle", center_lng: 139.69, center_lat: 35.68, radius_km: 60 };
+  assert.equal(pointInMonitorArea(139.70, 35.69, m), true);       // ~1 km away
+  assert.equal(pointInMonitorArea(135.5, 34.69, m), false);       // ~400 km away
+});
+
+test("pointInMonitorArea — polygon path with bbox pre-filter", () => {
+  const m = { geometry_kind: "polygon", geometry: SQUARE, bbox: bboxOfGeometry(SQUARE) };
+  assert.equal(pointInMonitorArea(1, 1, m), true);
+  assert.equal(pointInMonitorArea(100, 100, m), false);   // rejected by bbox
+});
+
+test("bboxOfGeometry", () => {
+  assert.deepEqual(bboxOfGeometry(SQUARE), [0, 0, 2, 2]);
+});
+
+test("validGeometry — accepts real polygons, rejects junk", () => {
+  assert.equal(validGeometry(SQUARE), true);
+  assert.equal(validGeometry({ type: "Polygon", coordinates: [[[0, 0], [1, 0]]] }), false); // <4 pts
+  assert.equal(validGeometry({ type: "Point", coordinates: [0, 0] }), false);
+  assert.equal(validGeometry(null), false);
+  assert.equal(validGeometry({ type: "Polygon", coordinates: [[[0, 0], [999, 0], [1, 1], [0, 0]]] }), false); // lng>180
+});
+
+test("isSafeHttpUrl — only http/https", () => {
+  assert.equal(isSafeHttpUrl("https://example.test/a"), true);
+  assert.equal(isSafeHttpUrl("http://example.test/a"), true);
+  assert.equal(isSafeHttpUrl("javascript:alert(1)"), false);
+  assert.equal(isSafeHttpUrl("data:text/html,x"), false);
+  assert.equal(isSafeHttpUrl(""), false);
+});
+
+test("normalizeNewsRow — canonical evidence + dedup_key + url scheme guard", () => {
+  const row = { id: 7, lang: "en", topic: "world", title: "Quake near Tokyo", publisher: "Test Wire", link: "https://example.test/News/1?utm=x#frag", pub_date: "2026-07-20T00:00:00Z", subject_lng: 139.7, subject_lat: 35.7, subject_name_en: "Tokyo" };
+  const e = normalizeNewsRow(row);
+  assert.equal(e.source_type, "news");
+  assert.equal(e.source_url, "https://example.test/News/1?utm=x#frag");
+  assert.equal(e.dedup_key, "news:https://example.test/news/1"); // query+frag stripped, lowercased
+  assert.equal(e.lng, 139.7);
+  // unsafe scheme → source_url null, still keyed
+  const bad = normalizeNewsRow({ ...row, link: "javascript:alert(1)" });
+  assert.equal(bad.source_url, null);
+});
+
+test("dedupeEvidence — by dedup_key", () => {
+  const a = { dedup_key: "k1" }, b = { dedup_key: "k1" }, c = { dedup_key: "k2" };
+  assert.equal(dedupeEvidence([a, b, c]).length, 2);
+});
+
+test("diffKeys — new / gone / continuing", () => {
+  const d = diffKeys(["a", "b", "c"], ["b", "c", "d"]);
+  assert.deepEqual(d.new.sort(), ["a"]);
+  assert.deepEqual(d.gone.sort(), ["d"]);
+  assert.deepEqual(d.continuing.sort(), ["b", "c"]);
+});
+
+test("clusterPoints — near merge, far split", () => {
+  const near = [{ lng: 0, lat: 0 }, { lng: 0.1, lat: 0.1 }];    // ~15 km
+  assert.equal(clusterPoints(near, 60).length, 1);
+  const far = [{ lng: 0, lat: 0 }, { lng: 10, lat: 10 }];       // ~1500 km
+  assert.equal(clusterPoints(far, 60).length, 2);
+});
+
+test("computeChangeScore — new independent events beat volume-only churn", () => {
+  const base = { count: 5, publishers: 3 };
+  // 4 new items across 3 clusters, 2 corroborated → meaningful
+  const meaningful = computeChangeScore({ diff: { new: ["a", "b", "c", "d"], gone: [], continuing: [] }, current: { count: 9, publishers: 6 }, baseline: base, newClusters: 3, corroboratedClusters: 2 });
+  // volume rose but 0 new keys, 0 clusters (all continuing rewrites) → near zero
+  const churn = computeChangeScore({ diff: { new: [], gone: [], continuing: ["x", "y"] }, current: { count: 12, publishers: 3 }, baseline: base, newClusters: 0, corroboratedClusters: 0 });
+  assert.ok(meaningful > 0.5, `meaningful=${meaningful}`);
+  assert.ok(churn < 0.2, `churn=${churn}`);
+  assert.ok(meaningful > churn);
+});
+
+test("severityFromScore — buckets", () => {
+  assert.equal(severityFromScore(0), "none");
+  assert.equal(severityFromScore(0.2), "low");
+  assert.equal(severityFromScore(0.4), "medium");
+  assert.equal(severityFromScore(0.6), "high");
+  assert.equal(severityFromScore(0.8), "critical");
+});
+
+test("decideAI — first run establishes baseline (no AI)", () => {
+  const r = decideAI({ isFirstRun: true, hasData: true, newCount: 5, changeScore: 0.9, sensitivity: {} });
+  assert.equal(r.call, false);
+  assert.equal(r.skip, "insufficient_baseline");
+});
+
+test("decideAI — no new items → no_change (no AI)", () => {
+  const r = decideAI({ isFirstRun: false, hasData: true, newCount: 0, changeScore: 0.9, sensitivity: {} });
+  assert.equal(r.call, false);
+  assert.equal(r.skip, "no_change");
+});
+
+test("decideAI — below threshold → skip", () => {
+  const r = decideAI({ isFirstRun: false, hasData: true, newCount: 1, changeScore: 0.1, sensitivity: { min_score: 0.3 } });
+  assert.equal(r.call, false);
+  assert.equal(r.skip, "below_threshold");
+});
+
+test("decideAI — no data → no AI (never 'no change')", () => {
+  const r = decideAI({ isFirstRun: false, hasData: false, newCount: 0, changeScore: 0, sensitivity: {} });
+  assert.equal(r.call, false);
+  assert.equal(r.skip, "no_data");
+});
+
+test("decideAI — real change calls AI", () => {
+  const r = decideAI({ isFirstRun: false, hasData: true, newCount: 4, changeScore: 0.6, sensitivity: {} });
+  assert.equal(r.call, true);
+});
+
+test("validateAndCleanReport — drops claims citing a nonexistent evidence id", () => {
+  const valid = new Set(["ev_1", "ev_2"]);
+  const byKey = new Map([["ev_1", { lng: 1, lat: 1, label: "A" }], ["ev_2", { lng: 2, lat: 2, label: "B" }]]);
+  const report = {
+    severity: "medium", headline: "Two developments", summary: "…",
+    changes: [
+      { claim: "Real claim.", evidence_ids: ["ev_1", "ev_99"] },   // ev_99 dropped, claim survives on ev_1
+      { claim: "Fabricated claim.", evidence_ids: ["ev_77"] },     // no valid id → dropped entirely
+    ],
+    unchanged: ["nothing else"], data_gaps: [], limitations: [],
+  };
+  const { ok, cleaned, invalidRefs } = validateAndCleanReport(report, valid, byKey);
+  assert.equal(ok, true);
+  assert.equal(cleaned.changes.length, 1);
+  assert.deepEqual(cleaned.changes[0].evidence_ids, ["ev_1"]);
+  assert.ok(invalidRefs.includes("ev_99") && invalidRefs.includes("ev_77"));
+  // change_points synthesized from the surviving cited evidence's coords
+  assert.equal(cleaned.change_points.length, 1);
+  assert.deepEqual(cleaned.change_points[0], { lng: 1, lat: 1, label: "A", evidence_id: "ev_1" });
+});
+
+test("validateAndCleanReport — a report with NO grounded claim is rejected", () => {
+  const valid = new Set(["ev_1"]);
+  const report = { headline: "All made up", changes: [{ claim: "x", evidence_ids: ["ev_nope"] }] };
+  const { ok } = validateAndCleanReport(report, valid, new Map());
+  assert.equal(ok, false);
+});
+
+test("validateAndCleanReport — invalid severity is nulled (caller falls back to score)", () => {
+  const valid = new Set(["ev_1"]);
+  const byKey = new Map([["ev_1", { lng: 0, lat: 0, label: "" }]]);
+  const report = { severity: "apocalyptic", headline: "H", changes: [{ claim: "c", evidence_ids: ["ev_1"] }] };
+  const { ok, cleaned } = validateAndCleanReport(report, valid, byKey);
+  assert.equal(ok, true);
+  assert.equal(cleaned.severity, null);
+});
+
+test("buildNewsSnapshot / distinctPublishers", () => {
+  const items = [
+    { dedup_key: "k1", source_name: "BBC", payload: { topic: "world" } },
+    { dedup_key: "k2", source_name: "bbc", payload: { topic: "world" } },
+    { dedup_key: "k3", source_name: "Reuters", payload: { topic: "business" } },
+  ];
+  assert.equal(distinctPublishers(items), 2); // case-insensitive
+  const s = buildNewsSnapshot(items);
+  assert.equal(s.count, 3);
+  assert.equal(s.publishers, 2);
+  assert.deepEqual(s.keys, ["k1", "k2", "k3"]);
+});

--- a/tests/monitors.spec.js
+++ b/tests/monitors.spec.js
@@ -1,0 +1,155 @@
+// (#R141) Area-monitors UI + Atlas-integration browser tests.
+// Hermetic (all external hosts blocked, incl. Supabase — see helpers/network.js), so these
+// exercise DOM/structure, the login gating, the honest Atlas routing, the geometry accessor,
+// and — critically — that a report renders XSS-inert. The logged-in DB round-trip is proven
+// separately by pgTAP (RLS) + the Node logic tests; here we prove the client never lies about
+// success and never injects untrusted report/monitor text as live HTML.
+import { test, expect } from '@playwright/test';
+import { installHermeticRouting, collectPageDiagnostics, isBenign } from './helpers/network.js';
+
+test.describe.configure({ mode: 'serial' });
+
+let page, diags;
+
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext();
+  await installHermeticRouting(context);
+  page = await context.newPage();
+  diags = collectPageDiagnostics(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 45_000 });
+  await page.waitForFunction(() => typeof window.IntMapMonitors !== 'undefined', null, { timeout: 45_000 });
+});
+
+test.afterAll(async () => {
+  await page?.context()?.close();
+});
+
+test('Monitors module + tab are present and the module exposes its API', async () => {
+  const info = await page.evaluate(() => ({
+    hasModule: !!window.IntMapMonitors,
+    fns: window.IntMapMonitors ? Object.keys(window.IntMapMonitors).sort() : [],
+    tab: !!document.getElementById('btn-monitors'),
+    feed: !!document.getElementById('monitors-feed'),
+    atlas: window.IntMapMonitors ? typeof window.IntMapMonitors.atlas : null,
+    drawGetter: !!(window.DrawTool && window.DrawTool.currentGeometry),
+  }));
+  expect(info.hasModule).toBe(true);
+  expect(info.tab).toBe(true);
+  expect(info.feed).toBe(true);
+  expect(info.atlas).toBe('object');
+  expect(info.drawGetter).toBe(true);
+  for (const fn of ['render', 'create', 'openCreateDialog', 'openDetail', 'openReport', 'pause', 'resume', 'remove', 'runNow', 'activeArea']) {
+    expect(info.fns, `missing ${fn}`).toContain(fn);
+  }
+});
+
+test('tab label localizes across languages (EN + JP)', async () => {
+  const en = await page.evaluate(() => { document.getElementById('lang-en')?.click(); return document.getElementById('btn-monitors').textContent.trim(); });
+  expect(en).toBe('Monitors');
+  const jp = await page.evaluate(() => { document.getElementById('lang-jp')?.click(); return document.getElementById('btn-monitors').textContent.trim(); });
+  expect(jp).toBe('モニター');
+  await page.evaluate(() => document.getElementById('lang-en')?.click());
+});
+
+test('opening the Monitors tab (logged out) shows the login prompt, not a fake list', async () => {
+  const html = await page.evaluate(async () => {
+    try { window.IntMapOS.exec('tab.monitors', { source: 'test' }); } catch (e) { return 'exec-err:' + e.message; }
+    await new Promise((r) => setTimeout(r, 300));
+    return document.getElementById('monitors-feed').innerHTML;
+  });
+  expect(html).toContain('mon-empty');
+  expect(html.toLowerCase()).toMatch(/log in/);
+  expect(html).toContain('mon-login-btn');
+});
+
+test('Atlas monitor action is HONEST: never claims success when it cannot', async () => {
+  const res = await page.evaluate(async () => {
+    const out = {};
+    // no area selected → must ask for one, not create
+    const create0 = await window.IntMapConsole.dispatch({ type: 'monitor', op: 'create' });
+    out.createNoArea = { ok: create0.ok, txt: (create0.html || '').replace(/<[^>]+>/g, '') };
+    // list (logged out) → must say login required, not open an empty list as success
+    const list0 = await window.IntMapConsole.dispatch({ type: 'monitor', op: 'list' });
+    out.listLoggedOut = { ok: list0.ok, txt: (list0.html || '').replace(/<[^>]+>/g, '') };
+    // with an area but logged out → login required
+    if (window._radiusFromPoint) window._radiusFromPoint(139.7, 35.68);
+    const create1 = await window.IntMapConsole.dispatch({ type: 'monitor', op: 'create' });
+    out.createLoggedOut = { ok: create1.ok, txt: (create1.html || '').replace(/<[^>]+>/g, '') };
+    return out;
+  });
+  expect(res.createNoArea.ok).toBe(false);
+  expect(res.createNoArea.txt.toLowerCase()).toMatch(/radius|area|region|範囲/);
+  expect(res.listLoggedOut.ok).toBe(false);
+  expect(res.listLoggedOut.txt.toLowerCase()).toMatch(/log in|ログイン/);
+  expect(res.createLoggedOut.ok).toBe(false);
+  expect(res.createLoggedOut.txt.toLowerCase()).toMatch(/log in|ログイン/);
+});
+
+test('activeArea() captures a radius circle as a real Polygon geometry', async () => {
+  const a = await page.evaluate(() => {
+    if (window._radiusFromPoint) window._radiusFromPoint(2.35, 48.85);
+    return window.IntMapMonitors.activeArea();
+  });
+  expect(a).toBeTruthy();
+  expect(a.geometry_kind).toBe('circle');
+  expect(a.geometry.type).toBe('Polygon');
+  expect(a.center_lng).toBeCloseTo(2.35, 2);
+  expect(Array.isArray(a.bbox)).toBe(true);
+  expect(a.radius_km).toBeGreaterThan(0);
+});
+
+test('a report renders XSS-INERT (untrusted headline/claim/evidence are escaped, no script runs)', async () => {
+  const result = await page.evaluate(async () => {
+    window.__xss = 0;
+    const evilReport = {
+      id: 'r1', run_id: 'run1', monitor_id: 'mon1', severity: 'high',
+      headline: '<img src=x onerror="window.__xss=1">PWNED',
+      summary: 'A <script>window.__xss=2<\/script> summary',
+      changes: [{ claim: 'Claim with <img src=y onerror="window.__xss=3"> payload', evidence_ids: ['ev_1'] }],
+      unchanged: ['<b>should be text</b>'], data_gaps: [], limitations: ['loc note'],
+      metrics: { articles: { prev: 0, cur: 2, delta: 2 }, new_clusters: 1, publishers: { prev: 0, cur: 2 } },
+      change_points: [], created_at: new Date().toISOString(),
+    };
+    await window.IntMapMonitors.openReport(evilReport);
+    await new Promise((r) => setTimeout(r, 250));
+    const ov = document.querySelector('.mon-ov-report');
+    const headEl = ov ? ov.querySelector('.mon-h3') : null;
+    const res = {
+      overlay: !!ov,
+      xss: window.__xss,
+      // the payload must appear as TEXT, and there must be NO live <img onerror> node injected from it
+      headlineText: headEl ? headEl.textContent : '',
+      injectedImg: ov ? ov.querySelectorAll('img[onerror]').length : -1,
+      injectedScript: ov ? ov.querySelectorAll('script').length : -1,
+      hasChange: ov ? ov.querySelectorAll('.mon-change').length : 0,
+      hasMetrics: ov ? !!ov.querySelector('.mon-metrics') : false,
+    };
+    if (ov) ov.remove();
+    return res;
+  });
+  expect(result.overlay).toBe(true);
+  expect(result.xss, 'no injected handler/script executed').toBe(0);
+  expect(result.injectedImg, 'no live <img onerror> injected').toBe(0);
+  expect(result.injectedScript, 'no <script> injected into the overlay').toBe(0);
+  expect(result.headlineText).toContain('PWNED');           // shown as text
+  expect(result.headlineText).toContain('<img');            // escaped literal, not a node
+  expect(result.hasChange).toBe(1);
+  expect(result.hasMetrics).toBe(true);
+});
+
+test('the create dialog is login-gated (logged out → auth modal, no create dialog)', async () => {
+  const r = await page.evaluate(async () => {
+    window.IntMapMonitors.openCreateDialog();
+    await new Promise((res) => setTimeout(res, 150));
+    return { createDialog: !!document.querySelector('.mon-ov-create'), authModalShown: !!document.getElementById('auth-modal') };
+  });
+  expect(r.createDialog).toBe(false);   // never opens the create form when logged out
+  expect(r.authModalShown).toBe(true);  // it routes to login instead
+});
+
+test('no uncaught page errors and no non-benign console errors', async () => {
+  await page.evaluate(() => new Promise((r) => setTimeout(r, 200)));
+  expect(diags.pageErrors, `page errors:\n${diags.pageErrors.join('\n')}`).toHaveLength(0);
+  const real = diags.consoleErrors.filter((t) => !isBenign(t));
+  expect(real, `console errors:\n${real.join('\n')}`).toHaveLength(0);
+});


### PR DESCRIPTION
## What

Implements the **Area Monitors** feature: a logged-in user saves a monitor over a selected area (radius circle, drawn polygon, resolved region, or the current map view). A Supabase Edge Function (`monitor-run`), scheduled by **pg_cron**, re-checks the area **even when the page is closed** and generates an **evidence-backed change report only when a real change is detected**.

## Core principle — code decides "changed?", the AI only explains

`collect → normalize + dedup → snapshot → mechanical diff (new/gone/continuing, counts, clusters, publisher diversity) → change score → decideAI() → (only on a real change) AI with the evidence → validate every cited evidence id → persist`.

- A source-fetch failure is **never** "no change" (→ `source_unavailable` / `partial`).
- The AI is called **only** on a meaningful, code-detected change above the monitor's sensitivity.
- Every factual claim must cite a real `ev_key` from that run's evidence; ungrounded claims are dropped, a report with no grounded claim is rejected (`ai_failed`, snapshot/diff/evidence kept).

## Database (`supabase/migrations/20260721090000_area_monitors.sql`)

- `area_monitors` / `monitor_runs` / `monitor_evidence` / `monitor_reports` — UUID PKs (not guessable).
- **RLS owner-only** on all four. Users write **only** monitors; runs/evidence/reports are **service_role-write, user read-only** → run results cannot be forged. Column-level UPDATE on `area_monitors` excludes the run-state columns → the lock/metadata cannot be tampered with.
- `monitor_limit()` per-plan cap (the **billing connection point**) enforced by an insert trigger; `monitor_claim_due()` uses `FOR UPDATE SKIP LOCKED` (no double execution); `monitor_mark_read()` RPC.
- pgTAP `04_monitors_test.sql`: cross-user isolation, no-forge, no-lock-tamper, plan-limit, service-role claim.

## Edge Function (`supabase/functions/monitor-run/`, Deno)

- Fail-closed **cron** path (`x-monitor-secret`, constant-time) + **user "Run now"** path (JWT + `monitorId`, ownership + cooldown).
- Generic collector registry (news first, via `current_news` filtered to the geometry); 10-status taxonomy; AI failure keeps snapshot/diff/evidence.
- Pure logic in `logic.mjs` (runtime-agnostic ESM) shared with the Node test.

## Frontend (`index.html`, additive — single file, no build)

- **Monitors tab** in normal / mobile / Workspace, all **5 languages**.
- `IntMapMonitors`: list, create dialog, detail (config + run history), report (conclusion, key changes → evidence chips, numeric comparison, evidence list with source links, change points on the map, data gaps, limitations, timestamps, status). All rendered via `IntMapSafe`.
- `DrawTool.currentGeometry()` getter; Atlas `{type:"monitor",op:…}` that only reports **real DB results** (never a false "created/ran").

## Tests / CI

- **26 Playwright** (incl. a report rendering **XSS-inert**), **Node logic** (23), **pgTAP 180**, drift gate empty. `npm test` green; `ci.yml` runs the monitor logic test, `db.yml` runs the pgTAP.

## Deploy (post-merge, see `docs/AREA-MONITORS.md`)

`supabase functions deploy monitor-run --no-verify-jwt`, `supabase secrets set MONITOR_SECRET=…`, apply the migration, and schedule pg_cron (the exact SQL is in the doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)