### PR TITLE
R143: Atlas geographic-target resolver — UN M49 country sets, multi-region colour+legend, geometry validation

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -5,7 +5,7 @@
 > 時系列の経緯・根本原因の記録は `DEV-NOTES.md`、標準指示（やってはいけないこと等）は `CONSTITUTION.md` を参照。
 > 実装を変えたら、この仕様書も更新すること。
 >
-> Last reviewed: 2026-07-18 (R134 — データ保護基盤 §16 追加：Supabase migrations・RLS/権限pgTAP・バックアップ/復元)
+> Last reviewed: 2026-07-20 (R143 — Atlas地理対象解決の汎用基盤：UN M49国集合＝実国境／多地域グループ別色＋凡例／描画前ジオメトリ検証／実状態検証／正直返答。§R143補足 参照)
 >
 > **R41 の要点**：`whenStyleReady()` が永久ハングし得た問題を修正（idle/loadのみ待機→ポーリング＋ハード解決）＋自己修復をハートビート化（「チェックしても出ない／消したのに残る・再読込で治る」の真因）。相関/散布図の残差マップを再実装（先にモーダルを閉じる＋RdBu連続配色＋指標33→51）。ウェブカムを**実装**（検証済みの24時間ライブYouTube配信25件をポップアップ内に埋め込み再生。検索リンクのハリボテを廃止）。**タイムゾーンレイヤー**新設（Natural Earth境界＋各ゾーンの現在時刻を毎分更新）。GIBSラスターに色スケール凡例。鉄道線を濃色＋白枕木で視認性向上。水域/地形ラベルを別チェック（`cb-geolabels`）化＋河川ラベルを `waterway` 由来に修正（位置ズレ解消）。天気ポップアップの華氏完全対応＋移動可能化。ウィジェット36→41。i18n：RUのレイヤーグループ見出し欠落＋国詳細(Stats)のES欠落を修正、非AIニュース地点辞書を多言語強化。
 
@@ -979,6 +979,20 @@ supabase/
 - **昔年代クリック（再々報告）**: `IntMapTime.setYear()`実ロードで 1919〜1938 全年 Poznań→Poland（Warsaw/Kraków/上シレジア/回廊も POL）を turf-PIP+`resolveHist` で**実測＝正答**。Wrocław/Szczecin→Germany・Danzig→Free City は**史実どおり正しい**（1920年代独領）。残る理論的穴＝era解決失敗時の現代 `countryGeo` フォールバックを封鎖し、**旅行中はフォールバックせず** `{eraLoading}`/`{code:''}`＋「読込中—もう一度」トースト（`resolveAt`・`_pickResolve` 両ピッカー）。
 - **FS中ハイライト非表示**: `_fsStashLayers` の `typeof clearHl==='function'` は別クロージャの関数で恒久 no-op だった。`_fsHideHl`/`_fsShowHl` で overlay 群（`place-hl-*/nlq-fill/nlq-line/nlq-poly-*/nlq-choro/pl-outline-*`）を `visibility:none` 退避→着陸で復元（start/stop の stash/restore へ結線）。
 - **歴史Wiki拡充**: `_ERA_WIKI` に HRV(独立国1941-45)・SGP/BLZ/GUY/SUR/ZMB/MWI/BWA/LSO/SWZ/UGA の植民地期実記事（全て新規キー・ポップアップが存在プローブ）。実測: 1943 Zagreb→`Independent_State_of_Croatia`。
+
+---
+
+## #R143 補足（Atlas地理対象解決の汎用基盤：UN M49国集合＝実国境／多地域＝グループ別色＋凡例／描画前ジオメトリ検証／実状態検証／正直返答）
+
+「東西南北欧をハイライトして」で **西欧未描画・4地域同色・南欧が巨大な三角形・国境でなく雑な近似図形・未完了なのに完了報告・曖昧性の長文説明が地図操作を妨害** が同時発生。**真因＝ヨーロッパのサブ地域（西欧/東欧/南欧/北欧）が「国集合」なのにコードは `REGION_BBOX` の粗い矩形/AIポリゴンでしか解決できず**、多地域の色分け・凡例・描画前検証も無かったこと。Europe専用ハックではなく**Atlas全体の汎用基盤**として、パイプラインを **解釈→地理対象解決→実行計画→描画→実状態検証→返答** に統一。全て `index.html` 加算（単一HTML温存）。`npm test` 緑（静的＋security/monitor logic＋**Playwright 44/44**、内 `IntMapRegionResolverTest` に純検証~30件・新 `tests/r143.spec.js` 10件）。
+
+- **① UN M49 国集合（地理対象解決）**: `REGION_GROUPS` に **UN M49 のサブ地域を実 ISO3 リストで追加**（western/eastern/southern/northern europe＝**互いに素な4分割**、north/south america・caribbean・north/west/east/central/southern africa・western asia・oceania サブ地域…）＋ `europe`/`oceania` は下位の和。`regionGroup` は既存の `GROUP_ALIASES` に加え **5言語 `REGION_ALIASES` も参照**（西欧/Westeuropa/западная европа… が自動で国集合へ。国集合でない自然地域＝Sahara/Alps 等は null で従来のポリゴン経路へ）。→ `resolveHlTarget` の**グループ段（国コード）で確定**し、Nominatim/AI/矩形の不安定経路を回避＝**正式な国境 GeoJSON で描画**。標準定義があるので**不要な確認をしない**（曖昧性の壁は出ない）。
+- **② 複数地域＝グループ別色＋凡例**: highlight dispatch に**多地域分岐**（2つ以上の対象・明示単色なし・河川/流域でない・かつ少なくとも1つが国集合/地域）。各対象を**カテゴリ配色 `_HL_PALETTE` の別色**で `nlq-poly-src` に描画（国集合は `_codesGeo(codes)` で **`window.countryGeo` の実国境から MultiPolygon** 構築・内部境界は `comp:1` で淡く）、返信に**色スウォッチ凡例**（`_hlLegendHtml`：地域名＋か国数＋根拠）。単一対象/単色指定/純国リストは従来の単色 feature-state 経路（無変更）。表示名は **`M49_LABELS`（5言語）で localize**（`_hlPolys` 内部名は正準英語キー＝安定・テスト可）。
+- **③ 描画前ジオメトリ検証（ハリボテ拒否）**: `_validGeo(geo,{trusted})` が **未閉リング・退化した少頂点「巨大三角形」・異常な長辺・自己交差・全世界blob・極小スライバー・非ポリゴン**を描画前に拒否。実国境/OSM/構成境界は `trusted` で粗近似ヒューリスティックを免除、AI/派生/ソフト箱は全検査。多地域・単地域の**両経路**で適用（拒否は正直に「不正な形状のため未描画」）。`_bboxSoftPoly` も**厳密閉リング化**（`sin(2π)≠0` の隙間を解消）。
+- **④ 実状態検証＋正直返答**: 描画後に `_verifyPolyPaint(n)` で **source/layer/feature数** を確認。返信は**実行結果から合成**＝描画できた対象（凡例＋根拠）と **失敗（見つからず／不正形状で拒否／曖昧）を明確に分離**、部分失敗は `meta.partial` で**プランナーの実行前 `say` を抑止**（R140/R142 の say-gate）。
+- **⑤ 堅牢性（style待機・遅延上書き・再描画）**: 世代トークン `_hlGen`＝**新しいハイライトが古い非同期解決の上書きを阻止**、描画は最大 8×0.7s のバウンド再試行、`styledata` 再描画は既存の `paintPolys` ハンドラが継続。
+- **⑥ 複合展開（頑健化）**: `_expandRegionCompound` が **「東西南北欧」→4 M49 キー**、「南北アメリカ」→2、を決定的に展開。さらに**方向欧の2語以上の共起時は M49 に正準化**（＝「北欧」は単独では北欧5国だが、四方位欧の集合内では M49 Northern Europe＝隙間なし4分割）。
+- **公開/テストAPI**: `IntMapAtlasDebug.{regionGroup,validGeo,codesGeo,expandCompound,paletteColor,legendHtml,polyState}`（純関数＝mapなしでCI検証可）。データソース変更なし（既存 `window.countryGeo` の再利用）。
 
 ---
 

--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -5,6 +5,31 @@
 
 ---
 
+## R143 — Atlas地理対象解決の汎用基盤：UN M49 国集合＝実国境／多地域＝グループ別色＋凡例／描画前ジオメトリ検証／実状態検証／正直返答 (tag `#R143`)
+
+**業務委託**：「東西南北欧をハイライトして」で **西欧未描画・4地域同色・南欧が巨大な三角形・国境でなく雑な近似図形・未完了なのに完了報告・曖昧性の長文説明が地図操作を妨害**。このケース専用でなく **Atlas全体の汎用基盤** として、`解釈→地理対象解決→実行計画→描画→実状態検証→返答` に統一すること。
+
+### 根本原因（コード読解で確定）
+`resolveHlTarget` の解決ラダーは `resolveCountrySync → regionGroup(国集合) → regionCompose → Nominatim admin poly → 方向スライス → IntMapRegionResolver(要ログイン・web) → aiRegionUnits/aiRegionPoly → regionBox(ソフト超楕円) → 国フォールバック`。**西欧/東欧/南欧/北欧 は `REGION_GROUPS` に無く（`REGION_BBOX` の粗い矩形にしか無い）**、`regionGroup` を素通り→ Nominatim(junk)／`_rrResolve`(web由来ハル＝地域ごとに不一致＝**西欧が null で未描画・南欧が少頂点ハル＝巨大三角形**)／AIポリゴン(粗い)／`_bboxSoftPoly`(矩形の超楕円＝重なり合う近似)へ落ちていた。加えて **`paintPolys` は色未指定ポリを全て `_hlColor`（単色）で塗り**＝4地域同色、多地域のグループ管理・凡例・**描画前のジオメトリ検証が皆無**。`_rrResolve` の `ambiguous` 返却が長文clarificationで地図描画を止めていた（標準定義がある地域には不適切）。
+
+### 修正（全て `index.html` 加算・単一HTML温存）
+- **① UN M49 国集合を第一級に**（地理対象解決・「国集合は正式な国境 GeoJSON を使う」「UN M49 標準を自動採用」）: `REGION_GROUPS` に M49 サブ地域を**実 ISO3 リスト**で追加（western/eastern/southern/northern europe＝**互いに素な4分割**、north/south america・caribbean・north/west/east/central/southern africa・western asia・oceania 4サブ地域…）＋ `europe`/`oceania` は和。`regionGroup._look` が **5言語 `REGION_ALIASES` も参照**（`GROUP_ALIASES` の後・故に JP「北欧」は既存の nordics override を維持）→ 西欧/Westeuropa/западная европа 等が国集合へ。自然地域（Sahara/Alps/Patagonia）は `REGION_GROUPS` に無いので null＝従来のポリゴン経路を温存。
+- **② 多地域＝グループ別色＋凡例**（「グループ別に管理し異なる色と凡例で識別可能に」）: highlight dispatch に**多地域分岐**（`rawX.length>=2 && !明示色 && !河川/流域 && G に国集合/地域が1つ以上`）。各対象を `_HL_PALETTE` の別色で `nlq-poly-src` に描画（国集合は `_codesGeo(codes)` で `window.countryGeo` の**実国境**から MultiPolygon 構築・`comp:1` で内部境界を淡く）。返信に `_hlLegendHtml`（色スウォッチ＋地域名＋か国数＋根拠）。単一対象/単色指定/純国リストは従来の**単色 feature-state 経路**（無変更＝回帰なし）。表示名は `M49_LABELS`（5言語）で localize（`_hlPolys` 内部名は正準英語キー＝安定・テスト可）。
+- **③ 描画前ジオメトリ検証**（「未閉鎖リング・自己交差・異常な長辺・巨大な三角形を描画前に拒否」）: `_validGeo(geo,{trusted,autoclose})`。実国境/OSM/構成境界は `trusted`＝粗近似ヒューリスティック免除、AI/派生/ソフト箱は**全検査**（`degenerate-triangle`＝少頂点×大スパン／`long-edge`／`self-intersecting`＝proper crossing／`whole-world`／`too-tiny`／`unclosed-ring`）。多地域・単地域の両経路に適用（拒否は正直表示）。`_bboxSoftPoly` を**厳密閉リング化**（`sin(2π)≠0` の隙間で検証に落ちる潜在バグを是正）。
+- **④ 実状態検証＋正直返答**（「描画後に source/layer/feature数/色/対象数を確認」「Plannerの成功文を無条件表示せず実行結果から返答」「部分失敗は成功/失敗を明確に分ける」）: `_verifyPolyPaint(n)`。返信は実行結果から合成し、描画成功（凡例＋根拠）と失敗（`Not found`／`Rejected — invalid/degenerate`／`Ambiguous`）を分離。部分失敗は `meta.partial`＝プランナーの実行前 `say` を抑止（R140/R142 say-gate 継承）。
+- **⑤ 堅牢性**（「style待機・古い処理の遅延上書き・再描画に耐える」）: 世代トークン `_hlGen`＝新ハイライトが古い非同期解決の上書きを阻止、`8×0.7s` バウンド再試行、`styledata` 再描画は既存 `paintPolys` ハンドラが継続。
+- **⑥ 複合展開**: `_expandRegionCompound`＝「東西南北欧」→4 M49 キー・「南北アメリカ」→2 を決定的展開＋**方向欧2語以上の共起で M49 正準化**（＝四方位欧の集合内では「北欧」＝M49 Northern Europe＝隙間なし4分割／単独「北欧」は北欧5国のまま）。
+
+### テスト・検証
+- **純関数（map/network不要・CI）**: `IntMapRegionResolverTest`（`_rrSelfTest`）に ~30 件追加＝M49解決（5言語別名・4分割の互いに素性・単独北欧=Nordic維持）／`_expandRegionCompound`／`_validGeo` バッテリ（三角形/未閉/自己交差/全世界/極小/長辺 拒否・trusted実国境 受理）／パレット distinct／凡例／`_codesGeo`。公開 `IntMapAtlasDebug.{regionGroup,validGeo,codesGeo,expandCompound,paletteColor,legendHtml,polyState}`。
+- **E2E（実 Chromium・Playwright `tests/r143.spec.js` 10件）**: `dispatch({type:'highlight',countries:'東西南北欧'})` → **4 M49 地域・実 MultiPolygon 国境・4色 distinct・凡例スウォッチ4・西欧実在・全 `valid`・partial なし**。AI分割形・英/独/露 入力・部分失敗（実地域描画＋未知は Not found＋`meta.partial`）・`validGeo` 拒否・連続コマンドで前回残らず・単一地域は単色経路。**実ブラウザ確認**：Playwis で map実在（`__imap`・`countryGeo`）だが WebGL は headless で `isStyleLoaded()=false`＝**ピクセルは非描画**→パイプライン出力（解決グループ・実国境ジオメトリ・別色・凡例・正直な部分失敗）をデータで検証。返信 HTML のスクリーンショット（`test-results/r143-atlas-reply.png`）で凡例UI（Western/Eastern/Southern/Northern Europe＋別色＋か国数9/10/16/11＋national borders）を実視認。
+- `npm test` 緑（静的＋security-logic＋monitor-logic＋**Playwright 44/44**、pageerror 0）。
+
+### 未検証事項
+- 実本番（GitHub Pages）でのログイン状態＋ライブ Nominatim/AI 併用時の非M49地域（河川流域・通称地域）の多地域混在描画は E2E hermetic では未網羅（M49国集合経路は完全網羅）。地図ピクセルの目視は headless 制約で未（プロジェクト従来通りデータ整合＋返信スクショで代替）。西ベルリン級の飛地・M49に無い係争地の帰属は対象外。
+
+---
+
 ## R142 — UX/正直化バッチ17件：SV実Coverageスナップ／Atlas嘘報告根絶・全幅・Stop／モバイルシート同期／Companies順位・時間・比較・拡充／ワークスペース読込・レイヤー復帰／東西独国境／Radius整理／ニュース媒体Wikipedia (tag `#R142`)
 
 ユーザー指摘**17件**を根本原因から修正。全て `index.html`（＋データ `data/cshapes.js`）の**加算的/微修正**（単一HTML・ビルド無し温存）。着手前に**並列サブエージェント6本**で SV/Atlas正直化/Companies/モバイルシート/Atlas UI/ワークスペース+国境+Radius+News を実地調査。`npm test` 緑（静的+security-logic+monitor-logic+**Playwright 26/26**、pageerror 0）。ヘッドレスは `document.hidden`（map未描画）だが、DOM/データは**localhostプレビューで実測**：Companies順位（mcap降順=1,2,3／昇順=147,146,145 と実反転）・比較ビュー（6指標×N社バー）・Radius開示・SV `nearestCoverage` 実スナップ（Times Square drift 0.00005°）・東西独 共有頂点60・overlap 0 を確認。

--- a/index.html
+++ b/index.html
@@ -26782,7 +26782,125 @@ window.addEventListener('DOMContentLoaded', () => {
           const line=el.geometry.map(g=>[g.lon,g.lat]); pts+=line.length; coords.push(line); }
         if(!coords.length) return null;
         return {geo:{type:'MultiLineString',coordinates:coords},n:coords.length,truncated:saturated||clientCut}; }catch(_){ return null; } }
-    function _bboxSoftPoly(box){ const cx=(box[0][0]+box[1][0])/2, cy=(box[0][1]+box[1][1])/2, rx=Math.max(0.05,(box[1][0]-box[0][0])/2), ry=Math.max(0.05,(box[1][1]-box[0][1])/2); const ring=[]; for(let i=0;i<=40;i++){ const a=i/40*2*Math.PI, co=Math.cos(a), si=Math.sin(a); ring.push([cx+rx*Math.sign(co)*Math.pow(Math.abs(co),0.62), cy+ry*Math.sign(si)*Math.pow(Math.abs(si),0.62)]); } return {type:'Polygon',coordinates:[ring]}; }
+    function _bboxSoftPoly(box){ const cx=(box[0][0]+box[1][0])/2, cy=(box[0][1]+box[1][1])/2, rx=Math.max(0.05,(box[1][0]-box[0][0])/2), ry=Math.max(0.05,(box[1][1]-box[0][1])/2); const ring=[]; for(let i=0;i<40;i++){ const a=i/40*2*Math.PI, co=Math.cos(a), si=Math.sin(a); ring.push([cx+rx*Math.sign(co)*Math.pow(Math.abs(co),0.62), cy+ry*Math.sign(si)*Math.pow(Math.abs(si),0.62)]); } ring.push([ring[0][0],ring[0][1]]); return {type:'Polygon',coordinates:[ring]}; }   /* (#R143) close the ring EXACTLY (sin(2π)≠0 left a hairline-open ring that failed the validity gate) */
+    /* ===== (#R143) GEOMETRY-VALIDATION GATE + multi-region grouping for the highlight pipeline.
+       The reported "南欧が巨大な三角形 / 西欧が未描画 / 4地域が同色 / 国境データではなく雑な近似図形" all trace to ONE gap:
+       region names that ARE country sets were resolved as bbox/AI approximations, drawn with no per-group colour,
+       no legend, and with no shape-sanity check before painting. These pure helpers (no map/network → run in the
+       CI QA harness) add (a) a pre-draw validity gate that REJECTS unclosed rings, degenerate few-vertex "giant
+       triangles", abnormal long edges, self-intersections, whole-world blobs and tiny slivers; (b) a real-border
+       geometry builder for country-set groups; (c) a categorical palette + legend so multiple regions in one
+       command are individually identifiable. ===== */
+    let _hlGen=0;   /* (#R143) generation token — a slow async resolution can't overwrite a newer highlight (古い処理の遅延上書き対策) */
+    function _ringSignedArea(r){ let a=0; for(let i=0,n=r.length-1;i<n;i++){ a+=(r[i][0]*r[i+1][1]-r[i+1][0]*r[i][1]); } return a/2; }
+    function _ringBbox(r){ let a=180,b=90,c=-180,d=-90; for(const p of r){ if(p[0]<a)a=p[0]; if(p[0]>c)c=p[0]; if(p[1]<b)b=p[1]; if(p[1]>d)d=p[1]; } return [a,b,c,d]; }
+    function _orient3(p,q,r){ return (q[1]-p[1])*(r[0]-q[0])-(q[0]-p[0])*(r[1]-q[1]); }
+    /* proper crossing of two OPEN segments — shared endpoints (adjacent ring edges) do NOT count as a crossing */
+    function _segProperCross(p1,p2,p3,p4){ const d1=_orient3(p3,p4,p1), d2=_orient3(p3,p4,p2), d3=_orient3(p1,p2,p3), d4=_orient3(p1,p2,p4);
+      return (((d1>0&&d2<0)||(d1<0&&d2>0))&&((d3>0&&d4<0)||(d3<0&&d4>0))); }
+    function _ringSelfIntersects(r){ const n=r.length-1; if(n<4) return false;
+      for(let i=0;i<n;i++){ for(let j=i+2;j<n;j++){ if(i===0&&j===n-1) continue;   /* the closing edge is adjacent to edge 0 */
+        if(_segProperCross(r[i],r[i+1],r[j],r[j+1])) return true; } } return false; }
+    /* the gate. opts.trusted = geometry from REAL national/OSM borders → skip the crude-approximation heuristics
+       (a dense real coastline can legitimately look "spiky"); untrusted (AI/derived/soft box) gets the full battery.
+       opts.autoclose closes an open ring in place instead of rejecting it. Returns {ok, reason, area, points}. */
+    function _validGeo(gm,opts){ opts=opts||{}; try{
+      if(!gm||typeof gm!=='object') return {ok:false,reason:'no-geometry'};
+      const t=gm.type; if(t!=='Polygon'&&t!=='MultiPolygon') return {ok:false,reason:'not-polygon'};
+      const polys=(t==='Polygon')?[gm.coordinates]:gm.coordinates; if(!polys||!polys.length) return {ok:false,reason:'empty'};
+      const trusted=!!opts.trusted; let area=0, any=false, maxPts=0;
+      for(const poly of polys){ if(!poly||!poly.length) continue;
+        for(let ri=0; ri<poly.length; ri++){ const ring=poly[ri]; if(!Array.isArray(ring)||!ring.length) return {ok:false,reason:'bad-ring'};
+          if(ring.length<4) return {ok:false,reason:'ring-too-small'};
+          const a=ring[0], z=ring[ring.length-1]; if(!a||!z||a.length<2) return {ok:false,reason:'bad-vertex'};
+          if(a[0]!==z[0]||a[1]!==z[1]){ if(opts.autoclose) ring.push([a[0],a[1]]); else return {ok:false,reason:'unclosed-ring'}; }
+          any=true; maxPts=Math.max(maxPts,ring.length);
+          if(ri===0){ area+=Math.abs(_ringSignedArea(ring));
+            if(!trusted){ const bb=_ringBbox(ring), diag=Math.hypot(bb[2]-bb[0],bb[3]-bb[1]);
+              const distinct=(()=>{ const s=new Set(); for(let i=0;i<ring.length-1;i++) s.add(ring[i][0].toFixed(3)+','+ring[i][1].toFixed(3)); return s.size; })();
+              if(distinct<=4 && diag>3) return {ok:false,reason:'degenerate-triangle'};              /* a 3–4 point shape spanning >~330 km = crude blob */
+              if(ring.length<=12 && diag>2){ let me=0; for(let i=1;i<ring.length;i++){ const e=Math.hypot(ring[i][0]-ring[i-1][0],ring[i][1]-ring[i-1][1]); if(e>me) me=e; } if(me>diag*0.7) return {ok:false,reason:'long-edge'}; }
+              if(ring.length<=80 && _ringSelfIntersects(ring)) return {ok:false,reason:'self-intersecting'}; } } } }
+      if(!any) return {ok:false,reason:'empty'};
+      const bb=fbbox(gm); if(bb && (bb[2]-bb[0])>350 && (bb[3]-bb[1])>150) return {ok:false,reason:'whole-world'};
+      if(!opts.allowTiny && area < (opts.minArea!=null?opts.minArea:1e-4)) return {ok:false,reason:'too-tiny'};
+      return {ok:true, area, points:maxPts}; }catch(e){ return {ok:false,reason:'threw:'+((e&&e.message)||e)}; } }
+    /* MultiPolygon of the REAL national borders for a set of ISO3 codes (from window.countryGeo). Fill renders the
+       whole set; internal member borders are kept faint by the comp:1 flag on the paint layer. */
+    function _codesGeo(codes){ try{ const g=geo(); const list=(codes||[]).map(String);
+      if(!g||!g.features) return {geo:null,hit:[],miss:list.slice()};
+      const want=new Set(list); const hit=[]; const polys=[];
+      g.features.forEach(f=>{ const p=f.properties||{}; const id=String(p.__code!=null?p.__code:(f.id!=null?f.id:'')); if(!want.has(id)) return; const gm=f.geometry; if(!gm) return;
+        if(gm.type==='Polygon') polys.push(gm.coordinates); else if(gm.type==='MultiPolygon') gm.coordinates.forEach(pp=>polys.push(pp)); if(hit.indexOf(id)<0) hit.push(id); });
+      return {geo:polys.length?{type:'MultiPolygon',coordinates:polys}:null, hit, miss:list.filter(c=>hit.indexOf(c)<0)}; }catch(_){ return {geo:null,hit:[],miss:(codes||[]).map(String)}; } }
+    /* categorical palette — distinct, reasonably colour-blind-aware, muted enough to sit on the basemap */
+    const _HL_PALETTE=['#e6550d','#3182bd','#31a354','#756bb1','#d6616b','#17a2b8','#bd9e39','#8c6d31','#e377c2','#637939','#843c39','#5254a3'];
+    function _hlPaletteColor(i){ const n=_HL_PALETTE.length; return _HL_PALETTE[((i%n)+n)%n]; }
+    /* directional-Europe aliases (5 languages) → the UN M49 English sub-region key */
+    const _DIR_EU_ALIAS={ '東欧':'eastern europe','西欧':'western europe','南欧':'southern europe','北欧':'northern europe',
+      '東ヨーロッパ':'eastern europe','西ヨーロッパ':'western europe','南ヨーロッパ':'southern europe','北ヨーロッパ':'northern europe',
+      'eastern europe':'eastern europe','western europe':'western europe','southern europe':'southern europe','northern europe':'northern europe',
+      'east europe':'eastern europe','west europe':'western europe','south europe':'southern europe','north europe':'northern europe',
+      'osteuropa':'eastern europe','westeuropa':'western europe','südeuropa':'southern europe','sudeuropa':'southern europe','nordeuropa':'northern europe',
+      'восточная европа':'eastern europe','западная европа':'western europe','южная европа':'southern europe','северная европа':'northern europe',
+      'europa oriental':'eastern europe','europa occidental':'western europe','europa del sur':'southern europe','europa meridional':'southern europe','europa del norte':'northern europe','europa septentrional':'northern europe' };
+    /* expand compound directional forms ("東西南北欧" → 4 regions, "南北アメリカ" → 2) and, when TWO OR MORE of the
+       four directional-Europe regions are named together, canonicalise them to the M49 partition (so 北欧 — which
+       alone means the Nordic countries — becomes M49 Northern Europe HERE → a gap-free, non-overlapping 4-way split). */
+    function _expandRegionCompound(list){ try{
+      const out=[]; const push=v=>{ v=String(v||'').trim(); if(v) out.push(v); };
+      (list||[]).forEach(tok=>{ const t=String(tok||'').trim();
+        if(/^東西南北(欧|ヨーロッパ)$/.test(t)){ push('western europe'); push('eastern europe'); push('southern europe'); push('northern europe'); return; }
+        if(/^東西(欧|ヨーロッパ)$/.test(t)){ push('western europe'); push('eastern europe'); return; }
+        if(/^南北(欧|ヨーロッパ)$/.test(t)){ push('southern europe'); push('northern europe'); return; }
+        if(/^南北(アメリカ|米)$/.test(t)){ push('north america'); push('south america'); return; }
+        push(t); });
+      const named=out.filter(t=>_DIR_EU_ALIAS[_lnorm(t)]);
+      if(named.length>=2) return out.map(t=>{ const k=_DIR_EU_ALIAS[_lnorm(t)]; return k||t; });
+      return out; }catch(_){ return (list||[]).slice(); } }
+    /* localized display labels for the M49 region keys (the resolver works in lowercase English keys; the reply
+       should read in the user's language — 「西ヨーロッパ」 not "western europe"). Non-M49 names pass through unchanged. */
+    const M49_LABELS={
+      'western europe':['Western Europe','西ヨーロッパ','Westeuropa','Западная Европа','Europa Occidental'],
+      'eastern europe':['Eastern Europe','東ヨーロッパ','Osteuropa','Восточная Европа','Europa Oriental'],
+      'southern europe':['Southern Europe','南ヨーロッパ','Südeuropa','Южная Европа','Europa Meridional'],
+      'northern europe':['Northern Europe','北ヨーロッパ','Nordeuropa','Северная Европа','Europa Septentrional'],
+      'europe':['Europe','ヨーロッパ','Europa','Европа','Europa'],
+      'north america':['Northern America','北アメリカ','Nordamerika','Северная Америка','América del Norte'],
+      'south america':['South America','南アメリカ','Südamerika','Южная Америка','América del Sur'],
+      'caribbean':['Caribbean','カリブ','Karibik','Карибский бассейн','Caribe'],
+      'north africa':['Northern Africa','北アフリカ','Nordafrika','Северная Африка','África del Norte'],
+      'west africa':['Western Africa','西アフリカ','Westafrika','Западная Африка','África Occidental'],
+      'east africa':['Eastern Africa','東アフリカ','Ostafrika','Восточная Африка','África Oriental'],
+      'central africa':['Middle Africa','中部アフリカ','Zentralafrika','Центральная Африка','África Central'],
+      'southern africa':['Southern Africa','南部アフリカ','Südliches Afrika','Южная Африка','África Austral'],
+      'western asia':['Western Asia','西アジア','Vorderasien','Западная Азия','Asia Occidental'],
+      'oceania':['Oceania','オセアニア','Ozeanien','Океания','Oceanía'],
+      'melanesia':['Melanesia','メラネシア','Melanesien','Меланезия','Melanesia'],
+      'micronesia':['Micronesia','ミクロネシア','Mikronesien','Микронезия','Micronesia'],
+      'polynesia':['Polynesia','ポリネシア','Polynesien','Полинезия','Polinesia'],
+      'australia and new zealand':['Australia & New Zealand','オーストラリア・ニュージーランド','Australien & Neuseeland','Австралия и Новая Зеландия','Australia y Nueva Zelanda'] };
+    function _regionLabel(nm){ try{ const e=M49_LABELS[_lnorm(nm)]; return e?L(e[0],e[1],e[2],e[3],e[4]):String(nm||''); }catch(_){ return String(nm||''); } }
+    /* colour-swatch legend for a multi-region highlight (凡例) */
+    function _hlLegendHtml(groups){ try{ if(!groups||!groups.length) return '';
+      const rows=groups.map(g=>{ const sw='<span style="display:inline-block;width:11px;height:11px;border-radius:2px;vertical-align:-1px;margin-right:6px;background:'+esc(g.color||_hlColor)+';"></span>';
+        const meta=[]; if(g.nCountries) meta.push(g.nCountries+' '+L('countries','か国','Länder','стран','países')); if(g.basisShort) meta.push(g.basisShort);
+        return '<div style="display:flex;align-items:center;font-size:11.5px;margin:2px 0;line-height:1.5;">'+sw+'<b>'+esc(g.displayName||g.name||'')+'</b>'+(meta.length?('<span style="color:var(--text-muted);margin-left:6px;">— '+esc(meta.join(' · '))+'</span>'):'')+'</div>'; });
+      return '<div style="margin:4px 0 2px;">'+rows.join('')+'</div>'; }catch(_){ return ''; } }
+    /* (#R143) POST-DRAW verification — the pipeline's "実状態検証" step: confirm the source + layer exist and the
+       source actually carries the expected feature count before the reply may claim success. */
+    function _verifyPolyPaint(expected){ try{ if(typeof map==='undefined'||!map) return {ok:false,reason:'no-map',n:0};
+      if(!map.getLayer||!map.getLayer('nlq-poly-fill')) return {ok:false,reason:'no-layer',n:0};
+      const src=map.getSource&&map.getSource('nlq-poly-src'); if(!src) return {ok:false,reason:'no-source',n:0};
+      let n=-1; try{ let d=src._data; if(d&&d.geojson) d=d.geojson; if(d&&Array.isArray(d.features)) n=d.features.length; else if(src.serialize){ const s=src.serialize(); if(s&&s.data&&Array.isArray(s.data.features)) n=s.data.features.length; } }catch(_){}
+      /* n===-1 → couldn't introspect the source (older maplibre) → trust our own _hlPolys bookkeeping instead */
+      const cnt=(n>=0)?n:_hlPolys.length;
+      return {ok:(cnt>=expected), n:cnt, expected, layer:true, source:true}; }catch(e){ return {ok:false,reason:'threw',n:0}; } }
+    /* fit to a set of drawn group features, dropping any single group whose own bbox wraps the antimeridian
+       (e.g. Eastern Europe includes Russia) so the fit still frames the rest instead of silently not moving. */
+    function _fitGroups(feats){ try{ let a=180,b=90,c=-180,d=-90,any=false;
+      (feats||[]).forEach(f=>{ const bb=fbbox(f.geo); if(!bb) return; if((bb[2]-bb[0])>180) return; any=true; a=Math.min(a,bb[0]);b=Math.min(b,bb[1]);c=Math.max(c,bb[2]);d=Math.max(d,bb[3]); });
+      if(any&&isFinite(a)&&(c-a)<350){ try{ map.fitBounds([[a,b],[c,d]],{padding:60,maxZoom:6.5,duration:900}); return true; }catch(_){} } }catch(_){} return false; }
     /* ==== (#R64) REAL region composition ("こんなカクカクポリゴンで許されると思うなよ。実際の範囲に忠実に、正確で
        高精細なポリゴンを引け"). A fuzzy/regional name is now resolved to a UNION OF REAL BOUNDARIES instead of a
        hand-waved outline: (a) country GROUPS (旧ソ連諸国, EU, NATO…) → the exact national polygons the map already
@@ -26891,7 +27009,34 @@ window.addEventListener('DOMContentLoaded', () => {
       'south asia':['IND','PAK','BGD','LKA','NPL','BTN','MDV','AFG'],
       'central asia':['KAZ','KGZ','TJK','TKM','UZB'],
       'latin america':['MEX','GTM','BLZ','SLV','HND','NIC','CRI','PAN','CUB','DOM','HTI','JAM','COL','VEN','ECU','PER','BOL','PRY','CHL','ARG','URY','BRA','GUY','SUR'],
-      'scandinavia':['DNK','NOR','SWE'] };
+      'scandinavia':['DNK','NOR','SWE'],
+      /* (#R143) UN M49 geoscheme sub-regions → REAL national boundaries. These are the STANDARD country-set
+         definitions ("東西南北欧", "Western Europe", "Sub-Saharan sub-regions"…): a region that IS a country set
+         must draw from official borders, not a bbox/AI blob. Keys reuse the REGION_BBOX macro-region names so the
+         5-language REGION_ALIASES already defined below bridge the localized names automatically (see regionGroup).
+         M49 Europe is a clean DISJOINT partition (every European country in exactly one) → the four highlight as
+         four distinct, gap-free, non-overlapping colour groups. */
+      'western europe':['AUT','BEL','FRA','DEU','LIE','LUX','MCO','NLD','CHE'],
+      'eastern europe':['BLR','BGR','CZE','HUN','POL','MDA','ROU','RUS','SVK','UKR'],
+      'southern europe':['ALB','AND','BIH','HRV','GIB','GRC','VAT','ITA','MLT','MNE','MKD','PRT','SMR','SRB','SVN','ESP'],
+      'northern europe':['DNK','EST','FIN','ISL','IRL','LVA','LTU','NOR','SWE','GBR','FRO'],
+      'north america':['BMU','CAN','GRL','USA','SPM'],
+      'south america':['ARG','BOL','BRA','CHL','COL','ECU','FLK','GUF','GUY','PRY','PER','SUR','URY','VEN'],
+      'caribbean':['ATG','BHS','BRB','CUB','DMA','DOM','GRD','HTI','JAM','KNA','LCA','VCT','TTO','PRI'],
+      'north africa':['DZA','EGY','LBY','MAR','SDN','TUN','ESH'],
+      'west africa':['BEN','BFA','CPV','CIV','GMB','GHA','GIN','GNB','LBR','MLI','MRT','NER','NGA','SEN','SLE','TGO'],
+      'east africa':['BDI','COM','DJI','ERI','ETH','KEN','MDG','MWI','MUS','MOZ','RWA','SYC','SOM','SSD','TZA','UGA','ZMB','ZWE'],
+      'central africa':['AGO','CMR','CAF','TCD','COG','COD','GNQ','GAB','STP'],
+      'southern africa':['BWA','SWZ','LSO','NAM','ZAF'],
+      'western asia':['ARM','AZE','BHR','CYP','GEO','IRQ','ISR','JOR','KWT','LBN','OMN','QAT','SAU','PSE','SYR','TUR','ARE','YEM'],
+      'australia and new zealand':['AUS','NZL'],
+      'melanesia':['FJI','NCL','PNG','SLB','VUT'],
+      'micronesia':['FSM','GUM','KIR','MHL','NRU','MNP','PLW'],
+      'polynesia':['ASM','COK','PYF','NIU','WSM','TON','TUV','TKL','WLF'] };
+    /* whole-Europe as a country set = the union of the four M49 sub-regions (so "ヨーロッパをハイライト" draws every
+       European country, not a rectangle). Assigned after the literal since an object literal can't self-reference. */
+    try{ REGION_GROUPS['europe']=[].concat(REGION_GROUPS['western europe'],REGION_GROUPS['eastern europe'],REGION_GROUPS['southern europe'],REGION_GROUPS['northern europe']);
+      REGION_GROUPS['oceania']=[].concat(REGION_GROUPS['australia and new zealand'],REGION_GROUPS['melanesia'],REGION_GROUPS['micronesia'],REGION_GROUPS['polynesia']); }catch(_){}
     const GROUP_ALIASES={
       '旧ソ連':'former ussr','旧ソ連諸国':'former ussr','旧ソビエト連邦':'former ussr','ソ連':'ussr','ソビエト連邦':'ussr','旧ソ連構成国':'former ussr',
       'ehemalige sowjetunion':'former ussr','ehemalige udssr':'former ussr','udssr':'ussr','postsowjetische staaten':'former ussr',
@@ -26915,7 +27060,22 @@ window.addEventListener('DOMContentLoaded', () => {
       'レバント':'levant','レヴァント':'levant','levante':'levant','левант':'levant',
       'アフリカの角':'horn of africa','horn von afrika':'horn of africa','африканский рог':'horn of africa','рог африки':'horn of africa','cuerno de áfrica':'horn of africa',
       '中東諸国':'middle east','東アジア諸国':'east asia','東南アジア諸国':'southeast asia','南アジア諸国':'south asia','中央アジア諸国':'central asia','ラテンアメリカ諸国':'latin america','中南米':'latin america',
-      'スカンジナビア諸国':'scandinavia','スカンディナヴィア':'scandinavia' };
+      'スカンジナビア諸国':'scandinavia','スカンディナヴィア':'scandinavia',
+      /* (#R143) 5-language names for the new M49 country-set groups (the European four are already in REGION_ALIASES) */
+      '北アメリカ':'north america','北米諸国':'north america','nordamerika':'north america','северная америка':'north america','américa del norte':'north america','norteamérica':'north america',
+      '南アメリカ':'south america','南米諸国':'south america','südamerika':'south america','sudamerika':'south america','южная америка':'south america','américa del sur':'south america','sudamérica':'south america','suramérica':'south america',
+      'カリブ諸国':'caribbean','karibik':'caribbean','карибский бассейн':'caribbean','карибы':'caribbean','caribe':'caribbean',
+      '西アフリカ':'west africa','westafrika':'west africa','западная африка':'west africa','áfrica occidental':'west africa',
+      '東アフリカ':'east africa','ostafrika':'east africa','восточная африка':'east africa','áfrica oriental':'east africa',
+      '中央アフリカ':'central africa','中部アフリカ':'central africa','zentralafrika':'central africa','центральная африка':'central africa','áfrica central':'central africa',
+      '南部アフリカ':'southern africa','das südliche afrika':'southern africa','южная африка':'southern africa','áfrica austral':'southern africa','áfrica meridional':'southern africa',
+      '西アジア':'western asia','vorderasien':'western asia','westasien':'western asia','западная азия':'western asia','asia occidental':'western asia',
+      'オセアニア':'oceania','ozeanien':'oceania','океания':'oceania','oceanía':'oceania',
+      'メラネシア':'melanesia','melanesien':'melanesia','меланезия':'melanesia',
+      'ミクロネシア':'micronesia','mikronesien':'micronesia','микронезия':'micronesia',
+      'ポリネシア':'polynesia','polynesien':'polynesia','полинезия':'polynesia',
+      'オーストラリアとニュージーランド':'australia and new zealand','australia and nz':'australia and new zealand','anzac':'australia and new zealand',
+      'europa del sur':'southern europe','europa meridional':'southern europe','europa del norte':'northern europe','europa septentrional':'northern europe' };
     /* (#R118) BASIS metadata for groups whose membership is HISTORICAL (dissolved orgs / former states): the reply
        and the working context state explicitly what the highlight means — "members of the 1955–1991 alliance shown
        as today's successor territories" — so a follow-up "それは何年のもの？" has a real answer instead of the
@@ -26929,7 +27089,13 @@ window.addEventListener('DOMContentLoaded', () => {
                'члены объединения '+meta.era+' — показаны как территории нынешних государств-преемников',
                'miembros de la entidad de '+meta.era+', mostrados como territorios sucesores actuales (fronteras de hoy)'); }
     function regionGroup(nm){ const k0=_lnorm(nm);
-      const _look=(k)=>{ if(!k) return null; const key=REGION_GROUPS[k]?k:GROUP_ALIASES[k]; return (key&&REGION_GROUPS[key])?key:null; };
+      /* (#R143) resolve a name to a country-set key via: exact group key → GROUP_ALIASES → the 5-language
+         REGION_ALIASES gazetteer (declared below; consulted at CALL time). The REGION_ALIASES rung means every
+         localized macro-region name already registered there (西欧 / Westeuropa / западная европа / …) resolves to
+         its M49 country-set when that key is a REGION_GROUPS entry — and harmlessly returns null for the natural
+         regions (Sahara / Alps / Patagonia) that are NOT country sets, so they still fall through to the poly path.
+         GROUP_ALIASES is tried BEFORE REGION_ALIASES so a deliberate override (e.g. JP 北欧 → nordics) still wins. */
+      const _look=(k)=>{ if(!k) return null; let key=REGION_GROUPS[k]?k:GROUP_ALIASES[k]; if(!key){ try{ const ra=REGION_ALIASES[k]; if(ra&&REGION_GROUPS[ra]) key=ra; }catch(_){} } return (key&&REGION_GROUPS[key])?key:null; };
       let key=_look(k0);
       if(!key){
         /* (#R123) strip a trailing collective suffix so group PHRASINGS resolve to the member set instead of an
@@ -27760,6 +27926,47 @@ window.addEventListener('DOMContentLoaded', () => {
         ok('refuse antimeridian span', _rrDerive({boundaryAnchors:[{lat:0,lng:-170},{lat:10,lng:-170},{lat:10,lng:170},{lat:0,lng:170}]})===null);
         ok('cache fresh check pos', _rrFresh({algo:_RR_ALGO,ts:_rrNow(),r:{status:'exact'}}));
         ok('cache stale algo rejected', !_rrFresh({algo:_RR_ALGO+9,ts:_rrNow(),r:{status:'exact'}}));
+        /* ===== (#R143) geographic-target resolution + geometry-validation gate + multi-region grouping (pure) ===== */
+        /* UN M49 country-set resolution — region names → REAL national borders (not a bbox/AI blob) */
+        const _rg=n=>{ const r=regionGroup(n); return r&&r.codes?r.codes:null; };
+        const _WE=_rg('western europe'), _EE=_rg('eastern europe'), _SE=_rg('southern europe'), _NE=_rg('northern europe');
+        ok('M49 西欧 → Western Europe set (FRA/DEU/NLD, ~9)', !!_WE&&_WE.indexOf('FRA')>=0&&_WE.indexOf('DEU')>=0&&_WE.indexOf('NLD')>=0&&_WE.length>=8);
+        ok('M49 alias 西欧===western europe', JSON.stringify(_rg('西欧'))===JSON.stringify(_WE));
+        ok('M49 alias Westeuropa (DE)===western europe', JSON.stringify(_rg('Westeuropa'))===JSON.stringify(_WE));
+        ok('M49 alias западная европа (RU)===western europe', JSON.stringify(_rg('западная европа'))===JSON.stringify(_WE));
+        ok('M49 東欧 → Eastern Europe (POL/RUS/UKR)', !!_EE&&_EE.indexOf('POL')>=0&&_EE.indexOf('RUS')>=0&&_EE.indexOf('UKR')>=0);
+        ok('M49 南欧 → Southern Europe (ITA/ESP/GRC)', !!_SE&&_SE.indexOf('ITA')>=0&&_SE.indexOf('ESP')>=0&&_SE.indexOf('GRC')>=0);
+        ok('M49 Europe four are DISJOINT (clean partition)', (()=>{ const all=[].concat(_WE,_EE,_SE,_NE); return all.length===new Set(all).size; })());
+        ok('standalone 北欧 stays the Nordic set (ISL yes, GBR no)', (()=>{ const n=_rg('北欧'); return !!n&&n.indexOf('ISL')>=0&&n.indexOf('GBR')<0&&n.length<=6; })());
+        ok('M49 north america (USA/CAN)', (()=>{ const n=_rg('north america'); return !!n&&n.indexOf('USA')>=0&&n.indexOf('CAN')>=0; })());
+        ok('M49 western asia (SAU/TUR/IRQ)', (()=>{ const n=_rg('western asia'); return !!n&&n.indexOf('SAU')>=0&&n.indexOf('TUR')>=0&&n.indexOf('IRQ')>=0; })());
+        ok('europe union built (>30 countries)', (()=>{ const n=_rg('europe'); return !!n&&n.length>30; })());
+        ok('a natural region (Sahara) is NOT a country set → null', _rg('Sahara')===null&&_rg('サハラ')===null);
+        /* compound expansion — "東西南北欧" → the four M49 sub-regions; the co-occurrence rule canonicalises 北欧→M49 */
+        const _ex1=_expandRegionCompound(['東西南北欧']);
+        ok('expand 東西南北欧 → 4 M49 europe keys', _ex1.length===4&&_ex1.indexOf('western europe')>=0&&_ex1.indexOf('eastern europe')>=0&&_ex1.indexOf('southern europe')>=0&&_ex1.indexOf('northern europe')>=0);
+        const _ex2=_expandRegionCompound(['西欧','東欧','南欧','北欧']);
+        ok('expand [西欧,東欧,南欧,北欧] → M49 (北欧→northern europe in the set)', _ex2.length===4&&_ex2.indexOf('northern europe')>=0&&_ex2.indexOf('western europe')>=0);
+        ok('single 北欧 NOT canonicalised (stays Nordic)', (()=>{ const e=_expandRegionCompound(['北欧']); return e.length===1&&e[0]==='北欧'; })());
+        ok('expand 南北アメリカ → north+south america', (()=>{ const e=_expandRegionCompound(['南北アメリカ']); return e.length===2&&e.indexOf('north america')>=0&&e.indexOf('south america')>=0; })());
+        /* geometry-validation gate — the "巨大な三角形など描画前に拒否" requirement */
+        const _softBox=_bboxSoftPoly([[0,0],[10,8]]);
+        ok('validGeo accepts a real soft outline (41-pt)', _validGeo(_softBox,{}).ok===true);
+        ok('validGeo REJECTS a giant triangle', (()=>{ const r=_validGeo({type:'Polygon',coordinates:[[[0,0],[20,0],[10,20],[0,0]]]},{}); return !r.ok&&r.reason==='degenerate-triangle'; })());
+        ok('validGeo REJECTS an unclosed ring', !_validGeo({type:'Polygon',coordinates:[[[0,0],[0,5],[5,5],[5,0]]]},{}).ok);
+        ok('validGeo autocloses when asked', _validGeo({type:'Polygon',coordinates:[[[0,0],[0,0.5],[0.5,0.5],[0.4,0.2],[0.3,0.1],[0.2,0.05],[0.1,0.02]]]},{autoclose:true,allowTiny:true}).ok===true);
+        ok('validGeo REJECTS a self-intersecting bowtie', (()=>{ const r=_validGeo({type:'Polygon',coordinates:[[[0,0],[1,1],[1,0],[0,1],[0,0]]]},{}); return !r.ok&&r.reason==='self-intersecting'; })());
+        ok('validGeo REJECTS a whole-world blob', !_validGeo({type:'Polygon',coordinates:[[[-179,-85],[-179,85],[179,85],[179,-85],[-179,-85]]]},{}).ok);
+        ok('validGeo REJECTS a tiny sliver', !_validGeo({type:'Polygon',coordinates:[[[0,0],[0,0.0002],[0.0002,0.0002],[0.0002,0],[0,0]]]},{}).ok);
+        ok('validGeo REJECTS an abnormal long edge (crude quad)', (()=>{ const r=_validGeo({type:'Polygon',coordinates:[[[0,0],[10,0.2],[10.1,0.4],[0.1,0.3],[0,0]]]},{}); return !r.ok; })());
+        ok('validGeo TRUSTS real borders (few-vertex heuristics skipped)', _validGeo({type:'Polygon',coordinates:[[[0,0],[20,0],[10,20],[0,0]]]},{trusted:true}).ok===true);
+        ok('validGeo rejects non-polygon', !_validGeo({type:'LineString',coordinates:[[0,0],[1,1]]},{}).ok);
+        /* palette + legend — multiple regions get distinct colours + a legend */
+        ok('palette gives 4 distinct colours', new Set([0,1,2,3].map(_hlPaletteColor)).size===4);
+        ok('legend lists each group with a colour swatch', (()=>{ const h=_hlLegendHtml([{name:'A',color:'#111111',nCountries:3},{name:'B',color:'#222222',nCountries:5}]); return h.indexOf('>A<')>=0&&h.indexOf('>B<')>=0&&h.indexOf('#111111')>=0&&h.indexOf('#222222')>=0; })());
+        /* real-border group geometry (only when countryGeo is loaded in this context) */
+        ok('codesGeo empty input → null geo', (()=>{ const r=_codesGeo([]); return r&&r.geo===null; })());
+        ok('codesGeo builds a MultiPolygon from real borders (if data loaded)', (()=>{ const g=geo(); if(!g||!g.features) return true; const r=_codesGeo(_WE); return !!r.geo&&r.geo.type==='MultiPolygon'&&r.hit.length>=6&&_validGeo(r.geo,{trusted:true}).ok; })());
       }catch(e){ res.push({name:'threw:'+String(e&&e.message||e),pass:false}); }
       const pass=res.filter(r=>r.pass).length; const out={pass,total:res.length,ok:pass===res.length,results:res};
       try{ console.log('[IntMapRegionResolverTest]', out.pass+'/'+out.total, out.ok?'ALL PASS':'FAIL', res.filter(r=>!r.pass).map(r=>r.name)); }catch(_){} return out; }
@@ -28329,7 +28536,17 @@ window.addEventListener('DOMContentLoaded', () => {
         if(t.code) return {kind:'country',code:t.code,name:t.name,verified:!!t.verified};
         if(t.codes) return {kind:'group',n:t.codes.length,name:t.name};
         if(t.poly){ let bb=null; try{ bb=fbbox(t.poly.geo); }catch(_){} return {kind:'poly',name:t.poly.name,method:t.rrMethod||(t.composed?'admin_union':(t.soft?'gazetteer':(t.approx?'derived':'osm'))),verified:!!t.verified,bbox:bb}; }
-        return {kind:'other'}; }catch(e){ return {kind:'err',msg:e&&e.message}; } } }; }catch(_){}
+        return {kind:'other'}; }catch(e){ return {kind:'err',msg:e&&e.message}; } },
+      /* (#R143) PURE (no map/network) building blocks of the highlight pipeline — exposed so the CI QA harness and
+         Playwright specs can assert the geographic-target resolution, geometry validation, palette, compound
+         expansion and real-border group geometry deterministically without a rendered map. */
+      regionGroup:function(nm){ try{ return regionGroup(String(nm==null?'':nm)); }catch(_){ return null; } },
+      validGeo:function(g,o){ try{ return _validGeo(g,o); }catch(e){ return {ok:false,reason:'threw'}; } },
+      codesGeo:function(c){ try{ return _codesGeo(c); }catch(_){ return {geo:null,hit:[],miss:[]}; } },
+      expandCompound:function(l){ try{ return _expandRegionCompound(Array.isArray(l)?l:[l]); }catch(_){ return l; } },
+      paletteColor:function(i){ try{ return _hlPaletteColor(i); }catch(_){ return null; } },
+      legendHtml:function(g){ try{ return _hlLegendHtml(g); }catch(_){ return ''; } },
+      polyState:function(){ try{ return { polys:_hlPolys.map(p=>{ let bb=null,gt=(p.geo&&p.geo.type)||null,vd=false; try{ bb=fbbox(p.geo); }catch(_){} try{ vd=_validGeo(p.geo,{trusted:true}).ok; }catch(_){} return {name:p.name,color:p.color,comp:p.comp,geoType:gt,valid:vd,bbox:bb}; }), n:_hlPolys.length }; }catch(_){ return {polys:[],n:0}; } } }; }catch(_){}
     async function _leaderData(codes){ try{
       const iso=(codes||[]).filter(Boolean).slice(0,4); if(!iso.length) return null;
       const langQ=(currentLang==='jp'?'ja':currentLang)+',en';
@@ -29550,7 +29767,8 @@ window.addEventListener('DOMContentLoaded', () => {
            highlight named countries, look up ONE country's actual figure, all-layers-off, SELECTIVE clear,
            fullscreen and real GPS locate — plus relative opacity ("delta"), compass-direction bearing and
            date-based timeTravel handled in their existing cases above. Every branch runs REAL engine code. */
-        case 'highlight': { if(a.on===false||/^(off|clear|none|解除)$/i.test(String(Array.isArray(a.countries)?'':(a.countries||a.country||'')))){ clearHl(); clearPolyHl(); clearLineHl(); return R(true, note('✓ '+L('Highlights cleared','ハイライトを消去しました','Hervorhebungen gelöscht','Выделение снято','Resaltado quitado'))); }
+        case 'highlight': { const _hlMyGen=++_hlGen;   /* (#R143) a newer highlight supersedes this one → stale async paints bail */
+          if(a.on===false||/^(off|clear|none|解除)$/i.test(String(Array.isArray(a.countries)?'':(a.countries||a.country||'')))){ clearHl(); clearPolyHl(); clearLineHl(); return R(true, note('✓ '+L('Highlights cleared','ハイライトを消去しました','Hervorhebungen gelöscht','Выделение снято','Resaltado quitado'))); }
           /* (#R61) COLOR is honoured for real ("赤でハイライトしてといっても色が変わらない") — parse it, apply it to
              the live paint, and if we cannot parse it SAY SO instead of silently claiming success. */
           let cwarn=''; if(a.color!=null&&String(a.color).trim()!==''){ const pc=parseColor(a.color); if(pc) setHlColor(pc); else cwarn=warn('⚠ '+L('Unknown color','色を認識できません','Unbekannte Farbe','Неизвестный цвет','Color desconocido')+': '+esc(a.color)); }
@@ -29595,12 +29813,62 @@ window.addEventListener('DOMContentLoaded', () => {
           if(!raw.length){ if(a.color&&!cwarn&&(_hl.size||_hlPolys.length)){ if(pc2&&_hlPolys.length){ _hlPolys.forEach(p=>{ p.color=pc2; }); paintPolys(); } return R(true, note('🎨 '+L('Recolored the current highlights','ハイライトの色を変更しました','Hervorhebungen umgefärbt','Цвет выделения изменён','Resaltado recoloreado'))); }
             if(a.color&&!cwarn) return R(false, warn('⚠ '+L('Nothing is highlighted yet — name the countries or regions','ハイライト中の対象がありません。国名や地域名を指定してください','Noch nichts hervorgehoben — Länder oder Regionen nennen','Ничего не выделено — укажите страны или регионы','Nada resaltado aún — indica países o regiones')));
             return R(false, warn('⚠ '+L('Which countries or regions?','どの国・地域をハイライトしますか？','Welche Länder oder Regionen?','Какие страны или регионы?','¿Qué países o regiones?'))+cwarn); }
+          /* (#R143) MULTI-REGION grouping: expand compound directional forms ("東西南北欧" → the four M49 sub-regions)
+             and, when the command names 2+ distinct targets, NO single explicit colour is given, none is a river/basin,
+             AND at least one target is a country-SET or a REGION, draw each target as its OWN colour group with a
+             legend (凡例). Country sets resolve to REAL national borders (UN M49 where applicable); every shape is
+             VALIDATED before drawing; the reply is composed from what actually painted, with successes and failures
+             kept separate. Anything else falls through to the single-colour path below. */
+          const rawX=_expandRegionCompound(raw);
+          if(rawX.length>=2 && !pc2 && !rawX.some(n=>basinIntent(n)||riverIntent(n))){
+            const G=[], gMiss=[], gAmbig=[], gRej=[]; const gSeen=new Set();
+            for(const nm3 of rawX){ let t3=null; try{ t3=await resolveHlTarget(nm3); }catch(_){}
+              if(t3&&t3.ambiguous&&Array.isArray(t3.candidates)&&t3.candidates.length){ gAmbig.push({name:t3.name||nm3,candidates:t3.candidates}); continue; }
+              let kind='',codes=null,gj=null; const nm4=(t3&&((t3.poly&&t3.poly.name)||t3.name))||nm3; let composed=false,osm=false,derived=false,approx=false,verified=false,basis='';
+              if(t3&&t3.code){ codes=[t3.code]; kind='country'; }
+              else if(t3&&t3.codes){ codes=t3.codes.slice(); kind='set'; basis=t3.basis||''; }
+              else if(t3&&t3.poly&&t3.poly.geo){ gj=t3.poly.geo; kind='region'; composed=!!t3.composed; osm=(t3.rrMethod==='osm_polygon'); derived=(t3.rrMethod==='derived_anchors'); approx=!!(t3.soft||t3.approx); verified=!!t3.verified; }
+              else { gMiss.push(nm3); continue; }
+              let nC=0; if(codes){ const cg=_codesGeo(codes); gj=cg.geo; nC=cg.hit.length; if(!gj){ gMiss.push(nm4); continue; } }
+              const trusted=(kind==='country'||kind==='set'||osm||composed);
+              const vg=_validGeo(gj,{trusted,autoclose:true});
+              if(!vg.ok){ gRej.push({name:nm4,reason:vg.reason}); continue; }
+              const key=(kind==='region')?('poly:'+nm4):('codes:'+codes.join(',')); if(gSeen.has(key)) continue; gSeen.add(key);
+              const basisShort = composed?L('admin borders','行政界','Verwalt.-grenzen','адм. границы','límites adm.')
+                : osm?'OpenStreetMap' : derived?('⬡ '+L('web-derived','Web由来','Web-abgeleitet','из веба','de la web'))
+                : approx?('⬡ '+L('approx.','近似','ca.','прибл.','aprox.'))
+                : (kind==='country'||kind==='set')?L('national borders','国境','Staatsgrenzen','госграницы','fronteras'):'';
+              G.push({name:nm4,displayName:_regionLabel(nm4),kind,geo:gj,codes,nCountries:nC,composed,osm,derived,approx,verified,basis,basisShort}); }
+            if(G.length>=2 && G.some(g=>g.kind==='set'||g.kind==='region')){
+              if(_hlMyGen!==_hlGen) return R(true,'');   /* superseded by a newer highlight → don't overwrite it */
+              clearHl(); clearLineHl(); _hlLines=[]; clearPolyHl();
+              _hlPolys=G.map((g,i)=>{ g.color=_hlPaletteColor(i); return {name:g.name,geo:g.geo,color:g.color,comp:(g.kind!=='region'||g.composed)?1:0,op:0.42}; });
+              let paintedP=paintPolys();
+              for(let i4=0;i4<8&&!paintedP;i4++){ await new Promise(r4=>setTimeout(r4,700)); if(_hlMyGen!==_hlGen) return R(true,''); paintedP=paintPolys(); }
+              if(!paintedP) return R(false, warn('⚠ '+L('Could not paint the highlight (map still loading) — try again','ハイライトを描画できませんでした（地図読込中）。もう一度お試しください','Hervorhebung konnte nicht gezeichnet werden (Karte lädt) — bitte erneut','Не удалось нарисовать выделение (карта загружается) — повторите','No se pudo dibujar el resaltado (mapa cargando) — reintenta'))+cwarn);
+              const ver=_verifyPolyPaint(G.length);
+              if(!_fitGroups(_hlPolys)){ try{ if(map.getZoom()>2.6) map.flyTo({center:[map.getCenter().lng,30],zoom:1.6,duration:1000}); }catch(_){} }
+              let hh=note('✦ '+G.map(g=>esc(g.displayName||g.name)).join(', '))+_hlLegendHtml(G);
+              if(G.some(g=>g.kind==='set'||g.kind==='country')) hh+=note(L('Country sets drawn from real national borders (UN M49 standard where applicable)','国集合は実際の国境データから描画（該当時はUN M49標準）','Ländergruppen aus realen Staatsgrenzen (ggf. UN-M49-Standard)','Наборы стран построены по реальным госграницам (при наличии — стандарт UN M49)','Conjuntos de países con fronteras reales (estándar UN M49 cuando aplica)'));
+              if(G.some(g=>g.composed)) hh+=note(L('Some regions built from member administrative boundaries','一部の地域は構成行政区画の境界から構築','Einige Regionen aus Verwaltungsgrenzen der Teilgebiete','Некоторые регионы построены из адм. границ','Algunas regiones a partir de límites administrativos'));
+              if(G.some(g=>g.osm)) hh+=note(L('Some regions from real OpenStreetMap boundaries','一部の地域は実際のOpenStreetMap境界','Einige Regionen aus realen OpenStreetMap-Grenzen','Некоторые регионы — реальные границы OSM','Algunas regiones de límites reales de OpenStreetMap'));
+              if(G.some(g=>g.derived||g.approx)) hh+=note(L('⬡ = approximate extent (no official boundary exists)','⬡ = 近似範囲（公式境界が存在しない）','⬡ = ungefähre Ausdehnung (keine offizielle Grenze)','⬡ = приблизительный контур (нет офиц. границы)','⬡ = extensión aproximada (sin límite oficial)'));
+              if(gRej.length) hh+=warn('⚠ '+L('Rejected — invalid/degenerate shape (not drawn)','不正・退化した形状のため未描画','Abgelehnt — ungültige/entartete Form','Отклонено — некорректная форма','Rechazado — forma inválida')+': '+esc(gRej.map(r=>r.name).join(', ')));
+              if(gAmbig.length) hh+=warn('⚠ '+L('Ambiguous (not drawn) — clarify','曖昧なため未描画 — 指定してください','Mehrdeutig (nicht gezeichnet)','Неоднозначно (не нарисовано)','Ambiguo (no dibujado)')+': '+esc(gAmbig.map(a2=>a2.name).join(', ')));
+              if(gMiss.length) hh+=warn('⚠ '+L('Not found','見つからず','Nicht gefunden','Не найдено','No encontrado')+': '+esc(gMiss.join(', ')));
+              if(ver&&!ver.ok) hh+=warn('⚠ '+L('Could not verify the drawn shapes on the map','描画結果を地図上で確認できませんでした','Gezeichnete Formen nicht verifizierbar','Не удалось проверить фигуры на карте','No se pudieron verificar las formas'));
+              try{ _wctx.highlight={ name:G.map(g=>g.displayName||g.name).join(', ').slice(0,160), n:G.length, basis:(G.map(g=>g.basis).filter(Boolean).join(' / ')||null) }; }catch(_){}
+              const partial=!!(gRej.length||gAmbig.length||gMiss.length||(ver&&!ver.ok));
+              return R(true, hh+cwarn, partial?{meta:{partial:true}}:undefined);
+            }
+            /* not multi-region-eligible (1 shape drew, or a plain country list) → single-colour path below */
+          }
           /* (#R62) countries AND subdivisions AND fuzzy regions, freely mixed.
              (#R64) + country GROUPS (旧ソ連諸国, EU…) and real-boundary COMPOSITIONS (東海地方, 肥沃な三日月帯…).
              (#R65) + RIVERS as their real course (line) and BASINS (tributaries + faint basin fill) — judged
              BEFORE any admin-unit logic. */
-          const found=[],polys=[],lines=[],lineNames=[],miss=[],ambig=[],seen=new Set(),grpNames=[],grpBases=[]; let anyApprox=false,anyComposed=false,anyPartial=false,basinInfo=null,anyVerified=false,anyOsm=false,anyDerived=false;
-          for(const nm2 of raw){
+          const found=[],polys=[],lines=[],lineNames=[],miss=[],ambig=[],rejected=[],seen=new Set(),grpNames=[],grpBases=[]; let anyApprox=false,anyComposed=false,anyPartial=false,basinInfo=null,anyVerified=false,anyOsm=false,anyDerived=false;
+          for(const nm2 of rawX){
             const bi=basinIntent(nm2);
             if(bi){ let B=null; try{ B=await buildBasin(bi.base); }catch(_){}
               if(!B||(!B.river&&!B.basin)){ miss.push(nm2); continue; }
@@ -29616,20 +29884,30 @@ window.addEventListener('DOMContentLoaded', () => {
             if(t2&&t2.verified) anyVerified=true;   /* (#R130) at least one target's location was web-search-verified */
             if(t2&&t2.ambiguous&&Array.isArray(t2.candidates)&&t2.candidates.length){ ambig.push({name:t2.name||nm2, candidates:t2.candidates}); }   /* (#R132) ambiguous → ask instead of guessing */
             else if(t2&&t2.code){ if(!seen.has(t2.code)){ seen.add(t2.code); found.push(t2); } }
-            else if(t2&&t2.codes){ let nAdd=0; t2.codes.forEach(cd=>{ if(!seen.has(cd)){ seen.add(cd); found.push({code:cd,_grp:1}); nAdd++; } }); grpNames.push((t2.name||nm2)+' ('+nAdd+')'); if(t2.basis) grpBases.push(t2.basis); }
-            else if(t2&&t2.poly){ if(pc2) t2.poly.color=pc2; if(t2.composed) t2.poly.comp=true; polys.push(t2.poly); if(t2.composed) anyComposed=true; if(t2.partial) anyPartial=true;
-              /* (#R132) precise BASIS per method — real OSM boundary vs web-anchor-derived vs curated gazetteer/AI outline */
-              if(t2.rrMethod==='osm_polygon') anyOsm=true; else if(t2.rrMethod==='derived_anchors') anyDerived=true; else if(t2.soft||t2.approx) anyApprox=true; }
+            else if(t2&&t2.codes){ let nAdd=0; t2.codes.forEach(cd=>{ if(!seen.has(cd)){ seen.add(cd); found.push({code:cd,_grp:1}); nAdd++; } }); grpNames.push(_regionLabel(t2.name||nm2)+' ('+nAdd+')'); if(t2.basis) grpBases.push(t2.basis); }
+            else if(t2&&t2.poly&&t2.poly.geo){
+              /* (#R143) VALIDATE before drawing — reject unclosed rings, degenerate "giant triangles", abnormal long
+                 edges, self-intersections, whole-world blobs, tiny slivers. Real OSM/admin/composed borders are trusted
+                 (skip the crude-approximation heuristics); AI/derived/soft outlines get the full battery. A rejected
+                 shape is reported honestly (never drawn as a "close enough" blob). */
+              const _tr=!(t2.soft||t2.approx||t2.rrMethod==='derived_anchors'); const _vg=_validGeo(t2.poly.geo,{trusted:_tr,autoclose:true});
+              if(!_vg.ok){ rejected.push({name:t2.poly.name||nm2,reason:_vg.reason}); }
+              else { if(pc2) t2.poly.color=pc2; if(t2.composed) t2.poly.comp=true; polys.push(t2.poly); if(t2.composed) anyComposed=true; if(t2.partial) anyPartial=true;
+                /* (#R132) precise BASIS per method — real OSM boundary vs web-anchor-derived vs curated gazetteer/AI outline */
+                if(t2.rrMethod==='osm_polygon') anyOsm=true; else if(t2.rrMethod==='derived_anchors') anyDerived=true; else if(t2.soft||t2.approx) anyApprox=true; } }
             else miss.push(nm2); }
           /* (#R132) if the ONLY results were ambiguous, ask which one — never paint a guess */
           const _ambHtml=arr=>arr.map(t=>'<b>'+esc(t.name)+'</b>:<br>• '+(t.candidates||[]).slice(0,4).map(c=>esc(String(c.name||'')+(c.country?(' — '+c.country):'')+(c.note?(' ('+c.note+')'):''))).join('<br>• ')).join('<br>');
           if(!found.length&&!polys.length&&!lines.length&&ambig.length) return R(false, warn('⚠ '+L('That name is ambiguous — which did you mean?','その名称には複数の候補があります。どれを指しますか？','Der Name ist mehrdeutig — welchen meinen Sie?','Название неоднозначно — какой вариант?','Ese nombre es ambiguo — ¿cuál quiere decir?'))+note(_ambHtml(ambig))+cwarn);
-          if(!found.length&&!polys.length&&!lines.length) return R(false, warn('⚠ '+L('Nothing found for','見つかりません','Nichts gefunden für','Ничего не найдено','Nada encontrado para')+': '+esc(raw.join(', ')))+cwarn);
+          if(!found.length&&!polys.length&&!lines.length){
+            if(rejected.length) return R(false, warn('⚠ '+L('The shape resolved for that region was invalid (degenerate/self-intersecting) and was not drawn','その地域の形状が不正（退化・自己交差）なため描画しませんでした','Die aufgelöste Form dieser Region war ungültig (entartet/selbstschneidend)','Форма региона оказалась недействительной (вырожденная/самопересекающаяся)','La forma resuelta para esa región no era válida (degenerada/autointersecante)')+': '+esc(rejected.map(r=>r.name).join(', ')))+cwarn);
+            return R(false, warn('⚠ '+L('Nothing found for','見つかりません','Nichts gefunden für','Ничего не найдено','Nada encontrado para')+': '+esc(raw.join(', ')))+cwarn); }
           /* (#R61) VERIFY the paint really happened (style may still be loading) — bounded retry, then honesty. */
+          if(_hlMyGen!==_hlGen) return R(true,'');   /* (#R143) superseded by a newer highlight */
           clearPolyHl(); _hlPolys=polys; clearLineHl(); _hlLines=lines;
           const codes2=found.map(c=>c.code);
           let painted=(codes2.length?highlight(codes2):(clearHl(),true)); let paintedP=paintPolys(); let paintedL=paintLines();
-          for(let i2=0;i2<8&&((codes2.length&&!painted)||(polys.length&&!paintedP)||(lines.length&&!paintedL));i2++){ await new Promise(r2=>setTimeout(r2,700)); if(codes2.length&&!painted) painted=highlight(codes2); if(polys.length&&!paintedP) paintedP=paintPolys(); if(lines.length&&!paintedL) paintedL=paintLines(); }
+          for(let i2=0;i2<8&&((codes2.length&&!painted)||(polys.length&&!paintedP)||(lines.length&&!paintedL));i2++){ await new Promise(r2=>setTimeout(r2,700)); if(_hlMyGen!==_hlGen) return R(true,''); if(codes2.length&&!painted) painted=highlight(codes2); if(polys.length&&!paintedP) paintedP=paintPolys(); if(lines.length&&!paintedL) paintedL=paintLines(); }
           const ub=unionBox(codes2,polys.concat(lines)); if(ub){ try{ map.fitBounds(ub,{padding:60,maxZoom:7.5,duration:900}); }catch(_){} } else if(codes2.length){ const fitOk=fitTo(codes2);
             /* (#R64) antimeridian-spanning sets (旧ソ連諸国: Chukotka wraps the date line) defeat a bbox fit —
                zoom out to the planet so the highlight is actually visible instead of silently not moving. */
@@ -29658,10 +29936,11 @@ window.addEventListener('DOMContentLoaded', () => {
           if(anyVerified) hh+=note('✓ '+L('location web-verified','位置をWeb検索で照合','Standort per Websuche geprüft','местоположение проверено веб-поиском','ubicación verificada con búsqueda web'));
           if(ambig.length) hh+=warn('⚠ '+L('Ambiguous (not drawn) — clarify','曖昧なため未描画 — 指定してください','Mehrdeutig (nicht gezeichnet)','Неоднозначно (не нарисовано)','Ambiguo (no dibujado)')+':<br>'+_ambHtml(ambig));
           if(miss.length) hh+=warn('⚠ '+L('Not found','見つからず','Nicht gefunden','Не найдено','No encontrado')+': '+esc(miss.join(', ')));
+          if(rejected.length) hh+=warn('⚠ '+L('Rejected — invalid/degenerate shape (not drawn)','不正・退化した形状のため未描画','Abgelehnt — ungültige/entartete Form','Отклонено — некорректная форма','Rechazado — forma inválida')+': '+esc(rejected.map(r=>r.name).join(', ')));   /* (#R143) */
           /* (#R142) PARTIAL result → the planner's pre-written "…をハイライトしました" over-claims the targets that were NOT
              drawn. Flag partial so runActions suppresses that say (#3) and lets this honest body — which lists exactly what
              WAS drawn plus "Not found: X" / "Ambiguous: Y" — lead. (Total miss already returns ok:false above.) */
-          return R(true,hh+cwarn, (miss.length||ambig.length)?{meta:{partial:true}}:undefined); }
+          return R(true,hh+cwarn, (miss.length||ambig.length||rejected.length)?{meta:{partial:true}}:undefined); }
         case 'value': case 'stat': case 'lookup': { await ensureData(); const c=await resolveCountry(a.country||a.place||a.name);
           if(!c||!c.code||!countryStats[c.code]) return R(false, warn('⚠ '+L('Country not found','国が見つかりません','Land nicht gefunden','Страна не найдена','País no encontrado')+': '+esc(a.country||a.place||a.name||'')));
           const s=countryStats[c.code]; const mk=String(a.metric||a.what||'').trim();

--- a/tests/r143.spec.js
+++ b/tests/r143.spec.js
@@ -1,0 +1,161 @@
+// R143 regression tests — Atlas geographic-target resolution + multi-region highlight pipeline.
+//
+// The commission's failure ("東西南北欧をハイライトして" → West undrawn, 4 regions one colour, South Europe a
+// giant triangle, crude non-border shapes, false "done", ambiguity wall-of-text). The general fix: region names
+// that ARE country sets resolve to REAL national borders (UN M49 standard), several regions in one command get
+// distinct colours + a legend, every shape is validated before drawing, and the reply is composed from what
+// actually painted. Hermetic routing blocks all external hosts → the M49/country-set path (no network) is what
+// runs, so these assertions are deterministic. The map's WebGL never fully paints headlessly, so we verify the
+// PIPELINE OUTPUT (resolved groups, real-border geometry, distinct colours, legend, honest partials) via the
+// dispatch result + IntMapAtlasDebug bookkeeping rather than pixels.
+import { test, expect } from '@playwright/test';
+import { installHermeticRouting, collectPageDiagnostics } from './helpers/network.js';
+
+const CRITICAL_GLOBALS = ['IntMapConsole', 'IntMapAtlasDebug', 'IntMapRegionResolver'];
+
+test.describe.configure({ mode: 'serial' });
+
+let page, diag;
+
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext();
+  await installHermeticRouting(context);
+  page = await context.newPage();
+  diag = collectPageDiagnostics(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 45_000 });
+  await page.waitForFunction(
+    (g) => g.every((k) => typeof window[k] !== 'undefined') && !!(window.countryGeo && window.countryGeo.features),
+    CRITICAL_GLOBALS, { timeout: 45_000 },
+  );
+  await page.waitForTimeout(2500);
+});
+
+test.afterAll(async () => { await page?.context()?.close(); });
+
+// Dispatch a highlight and return the pipeline output (dispatch result + the drawn poly groups).
+async function hl(countries) {
+  return page.evaluate(async (c) => {
+    const r = await window.IntMapConsole.dispatch({ type: 'highlight', countries: c });
+    return { ok: r && r.ok, html: (r && r.html) || '', meta: (r && r.meta) || null, poly: window.IntMapAtlasDebug.polyState() };
+  }, countries);
+}
+
+// THE headline regression: "東西南北欧をハイライトして" as a single compound token expands to the four UN M49
+// European sub-regions, each drawn from real national borders in its own colour, with a legend — no giant triangle,
+// no missing West, no shared colour.
+test('東西南北欧 (compound) → 4 M49 regions, real borders, distinct colours, legend', async () => {
+  const r = await hl('東西南北欧');
+  expect(r.ok).toBe(true);
+  const names = r.poly.polys.map((p) => p.name);
+  expect(names).toEqual(['western europe', 'eastern europe', 'southern europe', 'northern europe']);
+  // 4 distinct colours (the "4地域が同色" bug)
+  const colours = r.poly.polys.map((p) => p.color);
+  expect(new Set(colours).size).toBe(4);
+  // every shape is a real MultiPolygon built from country borders (not a bbox/AI blob) AND passes the validity gate
+  for (const p of r.poly.polys) {
+    expect(p.geoType).toBe('MultiPolygon');   // real national borders, not a soft box (Polygon)
+    expect(p.valid).toBe(true);               // no giant triangle / self-intersection / unclosed ring
+  }
+  // West Europe is actually present and spans western Europe (the "西欧が未描画" bug)
+  const west = r.poly.polys[0];
+  expect(west.bbox[0]).toBeLessThan(10);   // reaches the Atlantic side
+  expect(west.bbox[2]).toBeGreaterThan(10);
+  // legend with a colour swatch per region
+  expect(/background:#e6550d/i.test(r.html)).toBe(true);
+  expect((r.html.match(/border-radius:2px;vertical-align/g) || []).length).toBe(4);
+  expect(r.meta).toBeNull();   // full success → no partial flag → the honest body leads (no over-claim to suppress)
+});
+
+// The AI-split form ["西欧","東欧","南欧","北欧"] resolves identically (北欧 canonicalises to M49 Northern Europe
+// inside the directional-Europe set → a gap-free 4-way partition).
+test('["西欧","東欧","南欧","北欧"] (AI-split) → same 4 M49 regions', async () => {
+  const r = await hl(['西欧', '東欧', '南欧', '北欧']);
+  expect(r.ok).toBe(true);
+  expect(r.poly.polys.map((p) => p.name)).toEqual(['western europe', 'eastern europe', 'southern europe', 'northern europe']);
+  expect(new Set(r.poly.polys.map((p) => p.color)).size).toBe(4);
+  expect(r.poly.polys.every((p) => p.geoType === 'MultiPolygon' && p.valid)).toBe(true);
+});
+
+// English input.
+test('English "Western/Eastern/Southern/Northern Europe" → 4 M49 regions', async () => {
+  const r = await hl(['Western Europe', 'Eastern Europe', 'Southern Europe', 'Northern Europe']);
+  expect(r.ok).toBe(true);
+  expect(r.poly.n).toBe(4);
+  expect(new Set(r.poly.polys.map((p) => p.color)).size).toBe(4);
+  expect(r.poly.polys.every((p) => p.valid)).toBe(true);
+});
+
+// German input.
+test('German "Westeuropa/Osteuropa/Südeuropa/Nordeuropa" → 4 M49 regions', async () => {
+  const r = await hl(['Westeuropa', 'Osteuropa', 'Südeuropa', 'Nordeuropa']);
+  expect(r.ok).toBe(true);
+  expect(r.poly.n).toBe(4);
+  expect(new Set(r.poly.polys.map((p) => p.color)).size).toBe(4);
+});
+
+// Russian input.
+test('Russian "западную/восточную/южную/северную европу" → 4 M49 regions', async () => {
+  const r = await hl(['западная европа', 'восточная европа', 'южная европа', 'северная европа']);
+  expect(r.ok).toBe(true);
+  expect(r.poly.n).toBe(4);
+  expect(new Set(r.poly.polys.map((p) => p.color)).size).toBe(4);
+});
+
+// Partial failure: a real region + a nonexistent one → the real region draws, the failure is reported
+// separately, and meta.partial is set so the planner's "…をハイライトしました" is suppressed.
+test('partial failure: real region drawn, unknown reported, partial flagged', async () => {
+  const r = await hl(['西欧', '南欧', 'Zzyzxland']);
+  expect(r.ok).toBe(true);
+  expect(r.poly.n).toBe(2);   // only the two real regions painted
+  expect(r.poly.polys.map((p) => p.name)).toEqual(['western europe', 'southern europe']);
+  expect(/Zzyzxland/.test(r.html)).toBe(true);        // the unknown is named in the reply
+  expect(/Not found|見つから/i.test(r.html)).toBe(true);
+  expect(r.meta && r.meta.partial).toBe(true);        // → runActions suppresses the over-claiming "say"
+});
+
+// The validity gate (pure) — rejects exactly the degenerate shapes the commission called out.
+test('validGeo rejects giant triangle / unclosed / self-intersecting / whole-world; trusts real borders', async () => {
+  const v = await page.evaluate(() => {
+    const D = window.IntMapAtlasDebug;
+    return {
+      triangle: D.validGeo({ type: 'Polygon', coordinates: [[[0, 0], [20, 0], [10, 20], [0, 0]]] }, {}),
+      unclosed: D.validGeo({ type: 'Polygon', coordinates: [[[0, 0], [0, 5], [5, 5], [5, 0]]] }, {}),
+      bowtie: D.validGeo({ type: 'Polygon', coordinates: [[[0, 0], [1, 1], [1, 0], [0, 1], [0, 0]]] }, {}),
+      world: D.validGeo({ type: 'Polygon', coordinates: [[[-179, -85], [-179, 85], [179, 85], [179, -85], [-179, -85]]] }, {}),
+      realWE: (() => { const g = window.countryGeo; if (!g) return { ok: true }; const cg = D.codesGeo(D.regionGroup('western europe').codes); return D.validGeo(cg.geo, { trusted: true }); })(),
+    };
+  });
+  expect(v.triangle.ok).toBe(false);
+  expect(v.triangle.reason).toBe('degenerate-triangle');
+  expect(v.unclosed.ok).toBe(false);
+  expect(v.bowtie.ok).toBe(false);
+  expect(v.world.ok).toBe(false);
+  expect(v.realWE.ok).toBe(true);   // real national borders always pass
+});
+
+// Consecutive commands: a new highlight fully replaces the previous one (no stale groups/colours left over).
+test('consecutive highlights replace cleanly (no leftover groups)', async () => {
+  await hl(['西欧', '東欧', '南欧', '北欧']);   // 4 groups
+  const r2 = await hl(['north america', 'south america']);   // 2 groups
+  expect(r2.ok).toBe(true);
+  expect(r2.poly.n).toBe(2);
+  expect(r2.poly.polys.map((p) => p.name)).toEqual(['north america', 'south america']);
+  // colours restart from the palette head → first group is the palette's first colour again
+  expect(r2.poly.polys[0].color).toBe(await page.evaluate(() => window.IntMapAtlasDebug.paletteColor(0)));
+});
+
+// A single region stays single-colour (no spurious multi-colour path for one target).
+test('single region → single-colour path (not multi-group)', async () => {
+  const r = await page.evaluate(async () => {
+    const res = await window.IntMapConsole.dispatch({ type: 'highlight', countries: 'former ussr' });
+    return { ok: res && res.ok, poly: window.IntMapAtlasDebug.polyState() };
+  });
+  expect(r.ok).toBe(true);
+  // former USSR is ONE group of 15 countries → painted via the single-colour feature-state path, not as 15 poly groups
+  expect(r.poly.n).toBe(0);
+});
+
+// Boot honesty: no uncaught exceptions across all the above interactions.
+test('no uncaught page errors during R143 interactions', async () => {
+  expect(diag.pageErrors, `pageerror(s):\n${diag.pageErrors.join('\n---\n')}`).toHaveLength(0);
+});


### PR DESCRIPTION
## 業務委託：Atlas改善（地理対象解決の汎用基盤）

**症状**（「東西南北欧をハイライトして」）: 西欧が未描画・4地域が同色・南欧が巨大な三角形・国境データでなく雑な近似図形・未完了なのに完了報告・曖昧性の長文説明が地図操作を妨害。

**真因**: ヨーロッパのサブ地域（西欧/東欧/南欧/北欧）は**国集合**なのに、コードは `REGION_BBOX` の粗い矩形／AIポリゴンでしか解決できず、`regionGroup`（国集合）段を素通り。加えて `paintPolys` が色未指定ポリを全て単色 `_hlColor` で塗り（4地域同色）、多地域のグループ管理・凡例・**描画前のジオメトリ検証が皆無**。`_rrResolve` の `ambiguous` 返却が長文で描画を止めていた。

Europe専用ハックでなく **Atlas全体の汎用基盤** として、パイプラインを `解釈→地理対象解決→実行計画→描画→実状態検証→返答` に統一。

### 変更（全て `index.html` 加算・単一HTML温存）
- **UN M49 国集合**を `REGION_GROUPS` に実 ISO3 で追加（欧州4サブ地域＝互いに素な4分割／米州・アフリカ5サブ地域・西アジア・オセアニア…）。`regionGroup` は 5言語 `REGION_ALIASES` も参照→ 西欧/Westeuropa/западная европа が自動で**実国境**へ。自然地域（Sahara/Alps）は null で従来経路温存。
- **多地域＝グループ別色＋凡例**: `_HL_PALETTE` の別色で `nlq-poly-src` に描画、`_codesGeo` が `countryGeo` の実国境から MultiPolygon 構築、`_hlLegendHtml` で色スウォッチ凡例。単一/単色指定は従来経路（回帰なし）。表示名は `M49_LABELS`（5言語）。
- **`_validGeo` 描画前検証**: 未閉リング・巨大三角形（少頂点×大スパン）・長辺・自己交差・全世界blob・極小を拒否（実国境は trusted で免除）。`_bboxSoftPoly` を厳密閉リング化。
- **`_verifyPolyPaint` 実状態検証** ＋ 実行結果からの正直返答（成功/失敗＝Not found・Rejected・Ambiguous を分離、部分失敗は `meta.partial` で say 抑止）。
- **`_hlGen` 世代トークン**（遅延上書き阻止）＋バウンド再試行＋`_expandRegionCompound`（「東西南北欧」→4、方向欧2語以上で M49 正準化）。

### テスト
- `IntMapRegionResolverTest` に純検証 ~30 件（M49解決・5言語別名・4分割の互いに素性・`_validGeo` バッテリ・パレット・凡例）。
- 新 `tests/r143.spec.js` 10件（実 Chromium）: 東西南北欧（複合）→ 4 M49 地域・実 MultiPolygon 国境・4色 distinct・凡例・全 valid・partial なし／AI分割・英/独/露／部分失敗／validGeo拒否／連続コマンド／単一=単色。
- `npm test` 緑（**Playwright 44/44**・pageerror 0）。返信スクショで凡例UI実視認（Western/Eastern/Southern/Northern Europe＋別色＋9/10/16/11か国＋national borders）。

### 未検証
- 地図ピクセル目視は headless 制約で未（プロジェクト従来通りデータ整合＋返信スクショで代替）。ログイン＋ライブ Nominatim/AI 併用の非M49地域混在は E2E hermetic 未網羅（M49国集合経路は完全網羅）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)