### PR TITLE
R144: Area Monitors audit hardening — prod run-state guard, atomic claim, long-lived baseline, grounded reports, DB-error safety

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -1179,12 +1179,14 @@ hash）はすべて敵性入力として扱う。詳細は **`docs/SECURITY-ARCH
 - CI＝**CodeQL**（`security.yml`）＋`check:static`に**第三者Action SHA固定**検査＋`tests/security-logic.mjs`
   （Edge Function認証不変条件）＋pgTAP `03_security_test.sql`。`npm test`で全実行。
 
-## 18. 地域監視基盤 (Area Monitors) — R141
+## 18. 地域監視基盤 (Area Monitors) — R141 / R144
 
 ログインユーザーが**監視地域**（円/描画/解決済み地域/現在の地図表示）を保存し、**サーバー側が定期実行**して**意味のある変化がある時だけ根拠付きレポート**を生成する機能。詳細は [`docs/AREA-MONITORS.md`](docs/AREA-MONITORS.md)。
 
+> **R144 監査ハードニング**（migration `20260721120000_area_monitors_hardening.sql`）：本番の Supabase default-privilege（全ロール全権限＝RLSが実防御）で R141 の column-grant が no-op だった真因を **BEFORE UPDATE トリガ `tg_monitors_guard_state`**（run-state列・`next_run_at` を非runnerに対し凍結/server再計算）で根治。長期 `monitor_seen_items` レジャで **「過去N日」比較を実データ化**＋**cap耐性のnovelty**。**原子 `monitor_claim_one`**（手動二重実行防止）。**根拠付きレポート**（headline/summary/gapsをauthoritative diffからコード生成・AIは接地済claimのみ）。**全DB write error検査**＋原子 `monitor_finalize`/`monitor_commit_report`。**決定的**news順序。**`monitor_limit_self()`**（他人plan探索不可）。本番適用・deploy・E2E検証済（bad_refs 0）。
+
 - **中核原則**＝**変化の有無はコードが判定、AIは説明のみ**。処理順＝取得→正規化/重複排除→スナップショット→機械的diff(new/gone/continuing・件数・クラスタ・媒体多様性)→change score→**変化があり閾値超の時だけAI**→**AIが引いたevidence IDを実行後にコードで検証**（偽ID主張は棄却）→run/evidence/report永続化。**取得失敗は「変化なし」ではなく専用status**。
-- **DB**（migration `20260721090000_area_monitors.sql`）＝4表 `area_monitors`/`monitor_runs`/`monitor_evidence`/`monitor_reports`。**RLS全表owner-only**、runs/evidence/reportsは**service_role書込・user読取専用**（実行結果偽造不可）、area_monitors UPDATEは**列単位grant**でrun-state列除外（ロック/メタ改竄不可）。UUID PK。`monitor_limit()`（plan別上限・**課金接続点**）を挿入トリガで強制。`monitor_claim_due()`＝`FOR UPDATE SKIP LOCKED`で二重実行防止。pgTAP `04_monitors_test.sql`。
+- **DB**（migration `20260721090000` + `20260721120000` hardening）＝5表 `area_monitors`/`monitor_runs`/`monitor_evidence`/`monitor_reports`/**`monitor_seen_items`**(#R144 長期レジャ)。**RLS全表owner-only**、runs/evidence/reports/seenは**service_role書込・user読取専用**（実行結果偽造不可）。area_monitors UPDATEは**列単位grant**（run-state列・`next_run_at`除外）＋**#R144 `tg_monitors_guard_state` トリガ**で本番の全開grant下でも run-state/`next_run_at` を凍結（grant非依存の実防御）。UUID PK。`monitor_limit()`（plan別上限・**課金接続点**）を挿入トリガで強制・**#R144 EXECUTE revoke＋`monitor_limit_self()`**（他人plan探索不可）。`monitor_claim_due()`＝cron用`FOR UPDATE SKIP LOCKED`／**#R144 `monitor_claim_one()`**＝手動用原子claim（二重成功不可）／**`monitor_finalize`/`monitor_commit_report`**＝run+report+meta単一txn。pgTAP `04_monitors_test.sql`。
 - **Edge Function** `monitor-run`（`--no-verify-jwt`・自前fail-closed）＝①cron（`x-monitor-secret`）で due monitors をclaim・逐次処理、②user「今すぐ実行」（JWT+monitorId・所有権照合）。純ロジックは `logic.mjs`（runtime非依存ESM）を Deno と Node テストで共有。status体系10種（success/success_no_change/partial/source_unavailable/ai_failed/timed_out/invalid_geometry/quota_exceeded/disabled/internal_error）。**AI失敗でもsnapshot/diff/evidenceは保持**。
 - **定期実行**＝pg_cron（refresh-news 同型・`net.http_post` でヘッダに秘密・`docs/AREA-MONITORS.md` にSQL）。
 - **UI/Atlas**（`index.html` 加算）＝**Monitorsタブ**（通常/モバイル/Workspace・5言語）、`window.IntMapMonitors`（一覧/作成ダイアログ/詳細/レポート＝結論・主な変化→evidence chip・数値比較・根拠一覧(出典リンク)・変化地点を地図表示・取得できなかったデータ・制約・日時/status）。Atlas `{"type":"monitor","op":…}`＝**返信は実DB結果のみ**（偽の成功報告なし）。全描画 `IntMapSafe`（XSS-inert 実証）。

--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -5,6 +5,36 @@
 
 ---
 
+## R144 — Area Monitors 監査ハードニング：本番default-privilege真因／run-stateガードトリガ／長期seenレジャ／原子claim／根拠付きレポート／DB-error安全／決定的取得 (tag `#R144`)
+
+**業務委託**：R141 Area Monitors の実装監査で判明した問題を、設計報告でなく **実コード・本番・DB・CI上で再現/確認し根本から修正、本番完成まで**。R142/R143維持。
+
+### 最重要・非自明な本番真因（Section 7）
+- 本番 `pg_class.relacl` は `{authenticated=arwdDxtm, anon=arwdDxtm, …}`＝**Supabaseのschema-wide default privilegeで全ロールに全権限**（RLSが唯一の実防御・grantは全開）。よって R141 の **column-level UPDATE grant は本番では無効(no-op)**：`area_monitors` は UPDATE ポリシーを持つため、本人行の **run-state列・`next_run_at` を書けてしまう**。pgTAP は vanilla CI Postgres で通り**検出不能**だった。子表(runs/evidence/reports)は write ポリシー無し→RLS default-denyで本番でも forge 不可。
+- **修正＝BEFORE UPDATE トリガ `tg_monitors_guard_state`**（JWT role≠service_role/空 なら run-state列を OLD に固定・`next_run_at` は enable/interval変更時のみ `greatest(now, last_run+interval)` で server再計算）＝grant非依存の実防御。加えて `revoke update … from authenticated` → column-grant再付与（`next_run_at`/run-state除外）を defense-in-depth。
+
+### 各指摘と修正
+- **§2 baseline_window が実質12run止まり** → 新表 `monitor_seen_items`（monitor×source×dedup_key 一意・first/last_seen_at・45日保持=`RETAIN_SEEN_DAYS`）。**novelty=レジャ未在のdedup_keyのみ「new」**（cap churn/flap耐性・mode非依存・決定的）。UIの「過去30日」=`MAX_SEEN_WINDOW_DAYS`≤保持。
+- **§3 手動claim非原子(TOCTOU)** → `monitor_claim_one(mon,user,cooldown,stale)`＝単一 `UPDATE…WHERE(owner∧enabled∧lock-free|stale∧cooldown)…RETURNING`。二重成功不可・cron claimと非競合・honest reason返却。runner-only。
+- **§4 headline/summary等が非接地** → `buildReport` が **authoritative diff数値＋検証済claimからheadline/summary/unchanged/data_gapsをコード生成**（AI自由文破棄）。AIは `changes[{claim,evidence_ids}]`＋bounded severityのみ、`validateClaims` が evidence_id実在をゲート。
+- **§5 DBエラー握り潰し** → 全 supabase write の `error` 検査。scaffold失敗→続行せずlock解放。evidence失敗→report成功にしない。成功経路は `monitor_commit_report`（report挿入+run更新+monitorメタを単一txn原子化・外部API呼出はtxn外）、no-report経路は `monitor_finalize`。report失敗時 `report_generated=false`。
+- **§6 news取得が非決定的** → `collectNews` に `.order('pub_date',desc).order('id',asc)` を cap前に付与。novelty=レジャ基準＝cap偽goneが変化化しない。
+- **§8 `monitor_limit(uuid)` 属性漏洩** → authenticated/anon から EXECUTE revoke＋`monitor_limit_self()`（`auth.uid()`のみ）。挿入トリガは DEFINER で従来通り。
+- **§9 CodeQL#37-39** = `tests/monitors.spec.js` の `.replace(/<[^>]+>/g,'')` → 不活性 `DOMParser().textContent`（static-checkの `truncate` 誤検知も `revoke … truncate` を除外する statement-only regex に修正）。
+- **§10 Workspace** = R142 の `defRects().monitors` 維持＋回帰テスト（ws-window生成でclampRect throw無し・pageerror 0）。
+
+### 本番反映・検証
+- migration は **`supabase db query --file … --linked`**（Management API・DBパス不要／begin-commit原子）で適用→`migration repair --status applied 20260721120000`（baselineは既知の未記録gap＝`db push`不可のため個別適用）。事前に `commit;→rollback;` 差替でprod schema検証。
+- `monitor-run` を本番deploy（v4）。cron(job 3, `*/10`)は継続succeeded 200。
+- **本番E2E**（合成monitor=Europe→cascade削除）：run#1=baseline確立(`success_no_change`・AIスキップ・60レジャ・report無)、novelty強制でrun#2=`success`+report(score0.8・**claim横断29 evidence参照が全て実在=bad_refs 0**)。owner rolled-back probe＝run-state/`next_run_at` UPDATE=DENIED・`monitor_limit(uuid)`=DENIED/`_self()`=5・`claim_one`=claimed→already_running。ユーザ削除で全cascade=0。
+
+### テスト
+- `monitor-logic.test.mjs`＝30件（validateClaims/buildReport/partitionByNovelty/classifyDisappeared 追加）。`security-logic` 併せ node 40件。
+- `04_monitors_test.sql`＝prod default grantを模擬しトリガ凍結を値検証・claim_one原子性・limit self-only・seen RLS。
+- `monitors.spec.js`＝Workspace回帰＋XSS-inert＋DOMParser化。Playwright 45件緑。
+
+---
+
 ## R143 — Atlas地理対象解決の汎用基盤：UN M49 国集合＝実国境／多地域＝グループ別色＋凡例／描画前ジオメトリ検証／実状態検証／正直返答 (tag `#R143`)
 
 **業務委託**：「東西南北欧をハイライトして」で **西欧未描画・4地域同色・南欧が巨大な三角形・国境でなく雑な近似図形・未完了なのに完了報告・曖昧性の長文説明が地図操作を妨害**。このケース専用でなく **Atlas全体の汎用基盤** として、`解釈→地理対象解決→実行計画→描画→実状態検証→返答` に統一すること。

--- a/docs/AREA-MONITORS.md
+++ b/docs/AREA-MONITORS.md
@@ -5,8 +5,18 @@ Saved, server-side **area watches** that re-check a user-selected region on a sc
 real change is detected**. News is the first data source; the collector layer is generic so
 earthquakes/weather/fires/etc. can be added without schema churn.
 
-This page is the **architecture + operations** reference. See `DEV-NOTES.md` → R141 for the
-change log, and the inline `(#R141)` comments in the code.
+This page is the **architecture + operations** reference. See `DEV-NOTES.md` → R141 (initial)
+and **R144** (audit hardening) for the change logs, and the inline `(#R141)`/`(#R144)` comments.
+
+> **R144 hardening (audit fixes).** In production, Supabase's schema-wide default privileges
+> grant every role full table access (RLS is the real protection), so R141's *column-level*
+> UPDATE grant was a no-op in prod. R144 closes that and five other findings:
+> a **BEFORE UPDATE trigger** (`tg_monitors_guard_state`) that freezes the run-state columns and
+> server-owns `next_run_at` regardless of grants; a **long-lived `monitor_seen_items` ledger** so
+> "past 30 days" really means 30 days; an **atomic `monitor_claim_one`** so two "Run now" clicks
+> can't both run; **grounded reports** (headline/summary/gaps built from the authoritative diff,
+> not AI free text); **every DB write error-checked** with atomic finalize RPCs; **deterministic**
+> news ordering; and **`monitor_limit_self()`** so a user can't probe another user's plan.
 
 ## Design principle — code decides "changed?", the AI only explains
 
@@ -28,21 +38,54 @@ collect (per source) → normalize + dedup → snapshot → load baseline
 - Every factual claim in a report must cite evidence ids (`ev_1`…) that exist in that run's
   `monitor_evidence`. Claims citing a nonexistent id are dropped; a report with no grounded
   claim is rejected and recorded as `ai_failed` (snapshot + diff + evidence are still kept).
+- **(#R144) The whole report is grounded, not just the claims.** The AI writes *only* the
+  per-claim text (each cited to real evidence) and a bounded severity. `headline`, `summary`,
+  and `unchanged` are **built in code** (`buildReport`) from the authoritative machine-computed
+  diff numbers; `data_gaps` come only from sources that actually failed; `limitations` are fixed
+  general caveats. There is no path for a fabricated headline, summary, or count to reach the UI.
+- **(#R144) "new" is decided by the long-lived ledger, not a single snapshot.** An item counts
+  as new only if its `dedup_key` is not already in `monitor_seen_items` within the lookback
+  window (the comparison window for `baseline_window`, the news window for `previous_run`). This
+  is cap-proof and deterministic: a re-appearing item, or one pushed past the fetch cap by newer
+  arrivals, is never mistaken for a change. `gone` never scores and never calls the AI, so a
+  cap-displaced item cannot manufacture a report.
 
-## Data model (`supabase/migrations/20260721090000_area_monitors.sql`)
+## Data model
+
+Migrations: `20260721090000_area_monitors.sql` (R141) + `20260721120000_area_monitors_hardening.sql` (R144).
 
 | table | who writes | RLS |
 |---|---|---|
-| `area_monitors` | the owner (create/edit/delete) + the runner | owner-only; UPDATE is a **column grant** that excludes the run-state columns (`running_since`, `last_*`, `run_count`) so a user cannot forge run metadata or touch the lock |
+| `area_monitors` | the owner (create/edit/delete) + the runner | owner-only; UPDATE is a **column grant** that excludes the run-state columns **and `next_run_at`**, backed by the `tg_monitors_guard_state` trigger (below) so the restriction holds even under Supabase's default full grants |
 | `monitor_runs` | **service_role only** | owner **read-only** — run results cannot be forged |
 | `monitor_evidence` | **service_role only** | owner **read-only** |
 | `monitor_reports` | **service_role only** | owner **read-only**; `read` flips via the `monitor_mark_read` RPC (body stays client-immutable) |
+| `monitor_seen_items` *(#R144)* | **service_role only** | owner **read-only**; the long-lived per-item ledger (one row per `dedup_key`) powering the "past N days" baseline + cap-proof novelty. Cascades on monitor/user delete |
 
 - PKs are random UUIDs (never guessable sequential ids).
 - `monitor_limit(user)` is the **per-plan cap** (free = 5, pro/plus = 25, admin/unlimited =
-  200) enforced by a BEFORE INSERT trigger — this is the billing connection point.
+  200) enforced by a BEFORE INSERT trigger — the billing connection point. **(#R144)** its
+  EXECUTE is now revoked from users (so a user cannot pass an arbitrary UUID to infer someone
+  else's plan/admin state); the UI reads its own cap via **`monitor_limit_self()`**.
 - `monitor_claim_due(limit, stale_minutes)` claims due monitors with `FOR UPDATE SKIP LOCKED`
   so two concurrent cron ticks never process the same monitor (service_role only).
+
+### (#R144) Run-state guard, atomic claim & finalize (all service_role / trigger-owned)
+
+- **`tg_monitors_guard_state`** — BEFORE UPDATE on `area_monitors`. For any caller that is not
+  the service_role runner (or a trusted direct DB session), it pins `running_since`, `last_run_at`,
+  `run_count`, `last_status`, `last_change_severity`, `last_report_id` to their OLD values and
+  **server-recomputes `next_run_at`** (only on an enable or interval change, and never earlier than
+  `last_run + interval`). This is grant-independent protection: a user can never hand-pick their
+  execution time or forge run metadata, even though prod grants them full table UPDATE.
+- **`monitor_claim_one(monitor, user, cooldown_s, stale_min)`** — the atomic manual claim: a single
+  `UPDATE … WHERE (owner ∧ enabled ∧ lock-free-or-stale ∧ cooldown-elapsed) RETURNING`. Two
+  concurrent "Run now" requests can never both succeed, and it can't race the cron claim (same row
+  lock). Returns `{claimed, reason, monitor}` with an honest reason (`already_running`/`cooldown`/
+  `disabled`/`not_found`).
+- **`monitor_finalize` / `monitor_commit_report`** — finalize a run + (optionally) insert its report
+  + update the monitor meta in **one transaction**. A partial DB failure rolls the whole thing back,
+  so there is never a `report_generated=true` without a report, and the lock is always released.
 
 ## Edge Function (`supabase/functions/monitor-run/`)
 
@@ -57,10 +100,21 @@ The pure comparison logic lives in `logic.mjs` (runtime-agnostic ESM) and is imp
 the Deno function and the Node test (`tests/monitor-logic.test.mjs`) — the code under test is
 the code that runs.
 
+**(#R144) The manual path now claims via `monitor_claim_one`** (atomic; ownership + enabled +
+lock + cooldown in one statement) instead of a check-then-act sequence. News collection is
+**deterministically ordered** (`order by pub_date desc, id asc` before the cap). Every DB write
+is **error-checked**: a scaffold-insert failure aborts (lock released, no processing); an
+evidence-write failure records a retryable failure and never reports success; the report path
+commits atomically via `monitor_commit_report`, so a report-write failure leaves
+`report_generated=false` with snapshot+diff kept.
+
 ### Run status taxonomy
 
 `success` · `success_no_change` · `partial` · `source_unavailable` · `ai_failed` ·
 `timed_out` · `invalid_geometry` · `quota_exceeded` · `disabled` · `internal_error`.
+Internal run-outcome codes for partial-persistence failures (surfaced honestly, retried next
+run): `scaffold_failed` · `evidence_failed` · `report_failed` (each stored as `internal_error`
+with an `error_category`).
 
 ## Deploy / operate
 
@@ -74,9 +128,20 @@ supabase secrets set MONITOR_SECRET="$(openssl rand -hex 24)" --project-ref vpek
 #    Optional kill-switch → mechanical-only, no AI reports:
 #    supabase secrets set MONITOR_AI=off --project-ref vpekfwdpurzejrrmacac
 
-# 3. Apply the migration to production (gated — needs the DB password; see docs/MIGRATIONS.md)
-supabase db push
+# 3. Apply the migrations to production via the Management API (no DB password needed).
+#    NOTE: the baseline (20260718090000) is an unrecorded gap in the remote history
+#    (it was applied via `migration repair` originally), so `db push` refuses. Apply
+#    a NEW migration file directly, then record it — the R144 flow:
+supabase db query --file supabase/migrations/20260721120000_area_monitors_hardening.sql --linked
+supabase migration repair --status applied 20260721120000 --linked
+#    (Validate first without committing by swapping the file's final `commit;` for `rollback;`
+#     and running the same `db query --file` — a clean run proves it applies against live prod.)
 ```
+
+Rollback: the migration is additive/idempotent; to remove it, drop the new objects
+(`monitor_seen_items`, `trg_monitors_guard`, `tg_monitors_guard_state`, `monitor_claim_one`,
+`monitor_finalize`, `monitor_commit_report`, `monitor_limit_self`) and restore the prior grant
+(`grant update (…, next_run_at) on public.area_monitors to authenticated`). Prefer a forward fix.
 
 ### 4. Schedule the runner with pg_cron (same pattern as refresh-news)
 
@@ -109,7 +174,11 @@ per-monitor frequency is set by `interval_minutes` (minimum 30).
 - Per-run caps: ≤ 60 evidence rows stored, ≤ 40 new items sent to the AI, 110 s wall-clock
   budget per tick (unprocessed claims are released for the next tick), 55 s AI timeout.
 - Per-user monitor cap (`monitor_limit`), 30-minute minimum interval, 30 s manual cooldown.
-- Retention: newest 100 runs per monitor; evidence kept only for the newest 12 runs.
+- Retention: newest 100 runs per monitor; evidence kept only for the newest 12 runs; **(#R144)**
+  the `monitor_seen_items` ledger is kept for **45 days** (`RETAIN_SEEN_DAYS`) — this is the
+  hard bound on the comparison window. The UI offers **"past 30 days"** (`MAX_SEEN_WINDOW_DAYS`),
+  which is ≤ retention, so a 30-day comparison always has 30 days of history to reference. Do not
+  offer a UI window longer than `RETAIN_SEEN_DAYS`.
 
 ## Data sources / privacy
 
@@ -125,10 +194,29 @@ per-monitor frequency is set by `interval_minutes` (minimum 30).
 ## Tests
 
 - **DB / RLS** — `supabase/tests/04_monitors_test.sql` (pgTAP): cross-user isolation, no
-  forging of runs/evidence/reports, no tampering with the run lock, plan-limit enforcement,
-  service-role claim. Runs in CI (`db.yml`).
+  forging of runs/evidence/reports, plan-limit enforcement, service-role claim. **(#R144)** it
+  now **simulates the prod default grant** (`grant update … to authenticated`) and proves the
+  guard **trigger** freezes run-state/`next_run_at` (value-unchanged, not merely DENIED);
+  `monitor_claim_one` atomicity (single success, cooldown, disabled, stale-reclaim, owner-only,
+  no cron/manual conflict); `monitor_limit_self` vs. the revoked `monitor_limit(uuid)`;
+  `monitor_seen_items` RLS. Runs in CI (`db.yml`).
 - **Logic** — `tests/monitor-logic.test.mjs` (Node): point-in-circle/polygon, dedup, diff,
-  clustering, change score, first-run vs no-change vs real-change decisions, evidence-id
-  validation. Runs in CI (`ci.yml`).
+  clustering, change score, decideAI, **(#R144)** `validateClaims` (fabricated-id rejection),
+  `buildReport` (headline/summary/gaps from authoritative numbers only), `partitionByNovelty`
+  (cap-proof + order-independent), `classifyDisappeared`. Runs in CI (`ci.yml`).
 - **Browser** — `tests/monitors.spec.js` (Playwright, hermetic): tab present, login gating,
-  honest Atlas routing, geometry accessor, and a report rendering **XSS-inert**. Runs in CI.
+  honest Atlas routing, geometry accessor, a report rendering **XSS-inert**, and **(#R144)** a
+  **Workspace regression** test (the Monitors ws-window has a default rect → no clampRect throw).
+  The tag-stripping regexes were replaced with an inert `DOMParser` (clears CodeQL
+  `js/incomplete-multi-character-sanitization`). Runs in CI.
+
+## Production verification (#R144)
+
+Verified end-to-end on prod with a synthetic monitor (Europe), then cascade-deleted:
+run #1 established the baseline (`success_no_change`, AI skipped `insufficient_baseline`, 60
+ledger rows, **no report**); forcing novelty produced run #2 (`success`, AI used, report
+generated, score 0.8) whose headline/summary were code-built from the authoritative numbers and
+whose **29 evidence references across 9 claims were all real** (`bad_refs = 0`). A rolled-back
+probe as the owner confirmed run-state/`next_run_at` UPDATE = **DENIED**, `monitor_limit(uuid)` =
+**DENIED** / `monitor_limit_self()` = 5, and `monitor_claim_one` = `true:claimed` then
+`false:already_running`. Deleting the synthetic user cascaded all rows back to zero.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -54,6 +54,15 @@ is the human explanation.
 | `dashboard_cards` | Curated strategic-location cards. | Everyone. | Admin (+ service_role). |
 | `current_news` | Server-refreshed, pre-geolocated news. | Everyone. | **service_role only** (`refresh-news`). |
 
+### Area monitors (#R141 / #R144)
+| Table | Purpose | Read | Write |
+|---|---|---|---|
+| `area_monitors` | A saved area watch (geometry + sources + comparison/sensitivity + schedule + denormalized run-state). | Owner. | Owner insert/delete; UPDATE is a **column grant** (config columns only — **not** `next_run_at` or the run-state columns) reinforced by the `tg_monitors_guard_state` trigger. |
+| `monitor_runs` | One execution attempt (status, snapshot, mechanical diff, AI meta). | Owner. | **service_role only** — results cannot be forged. |
+| `monitor_evidence` | Structured evidence gathered by a run (`ev_key`, source, url, coords, `dedup_key`). | Owner. | **service_role only.** |
+| `monitor_reports` | The report a run generated (severity, headline, summary, grounded `changes`, metrics, change_points). | Owner. | **service_role only**; `read` flips via `monitor_mark_read`. |
+| `monitor_seen_items` *(#R144)* | Long-lived per-item ledger (one row per `dedup_key`) → "past N days" baseline + cap-proof novelty. | Owner. | **service_role only.** |
+
 ## Relationships
 
 - `profiles.id`, `ai_usage.user_id`, `user_prefs.user_id`, `favorites.user_id`,
@@ -72,6 +81,10 @@ is the human explanation.
 | `public.handle_new_user()` + `on_auth_user_created` trigger on `auth.users` | SECURITY DEFINER | Creates the `profiles` row on signup (copies id/email/display_name). |
 | `public.increment_ai_usage(uuid, integer)` | SECURITY DEFINER, `search_path=''` | Atomically consumes one AI use if under the limit. Returns `(used, allowed)`. EXECUTE = service_role only. |
 | `public.refund_ai_usage(uuid)` | SECURITY DEFINER, `search_path=''` | Refunds one use after a failed provider call. EXECUTE = service_role only. |
+| `public.monitor_limit(uuid)` / `monitor_limit_self()` *(#R144)* | SECURITY DEFINER, `search_path=''` | Per-plan monitor cap. `(uuid)` is **service_role-only** (users can't probe another user's plan); the UI reads its own via `monitor_limit_self()`. Enforced by a BEFORE INSERT trigger. |
+| `public.monitor_claim_due(int,int)` / `monitor_claim_one(uuid,uuid,int,int)` *(#R144)* | SECURITY DEFINER, `search_path=''` | Atomic claims (cron `FOR UPDATE SKIP LOCKED`; manual `UPDATE…WHERE…RETURNING`). service_role only. |
+| `public.monitor_finalize(...)` / `monitor_commit_report(...)` *(#R144)* | SECURITY DEFINER, `search_path=''` | Finalize a run + (optionally) insert its report + update the monitor meta in one transaction. service_role only. |
+| `public.tg_monitors_guard_state()` + `trg_monitors_guard` *(#R144)* | SECURITY DEFINER, `search_path=''` | BEFORE UPDATE on `area_monitors`: freezes run-state columns and server-owns `next_run_at` for any non-runner caller (grant-independent). |
 
 Every SECURITY DEFINER function pins an empty `search_path` and schema-qualifies its objects,
 so a caller cannot hijack it via their own search path.
@@ -87,8 +100,16 @@ so a caller cannot hijack it via their own search path.
    SQL (below) or `service_role`.
 3. **AI quota is tamper-proof.** `ai_usage` is written only by the SECURITY DEFINER RPCs, and
    those RPCs are executable only by `service_role`.
+4. **(#R144) Server-owned run-state.** Monitor run results (`monitor_runs`/`_evidence`/`_reports`/
+   `_seen_items`) have no write policy → only `service_role` writes them, so they cannot be forged.
+   On `area_monitors`, the run-state columns and `next_run_at` are protected by **both** a column
+   grant **and** the `tg_monitors_guard_state` trigger — the trigger matters because in production
+   Supabase's default privileges grant users full table UPDATE (RLS is the real protection), which
+   would otherwise let a user forge run metadata or hand-pick their execution time. `monitor_limit`
+   is service-role-only so plans can't be enumerated.
 
-All three are proven by the pgTAP tests — see [`RLS-TESTING.md`](RLS-TESTING.md).
+Guarantees 1–3 (and the R144 monitor matrix) are proven by the pgTAP tests
+(`04_monitors_test.sql` simulates the prod default grant) — see [`RLS-TESTING.md`](RLS-TESTING.md).
 
 ## Admin privileges
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -8,10 +8,14 @@ work branch → Pull Request → CI (green) → staging check → merge to main 
                                                                                      rollback
 ```
 
-Today production publishes automatically from the `main` branch (GitHub Pages “Deploy from
-a branch”). The workflows in `.github/workflows/` add a **CI-gated** path on top of that,
-which becomes active only after you opt in (see [Enabling the gated deploy](#enabling-the-gated-deploy)).
-Until then, nothing about publishing changes.
+**Current state (as of R144): production publishes via the CI-gated GitHub Actions workflow**
+(`.github/workflows/deploy.yml`). Pages **Source = “GitHub Actions”** and the repo variable
+**`ENABLE_PAGES_DEPLOY = true`** are both set, so every push to `main` runs build → static
+checks → hermetic browser tests → publish the exact committed tree (`git archive HEAD`) →
+post-deploy smoke against the live URL. Confirm a deploy landed with
+`curl -s https://rwmqx7dwb5-arch.github.io/IntMap/build-info.json` — its `sha` must equal
+`git rev-parse origin/main`. (The older “Deploy from a branch” default is no longer in use; if
+`ENABLE_PAGES_DEPLOY` is ever unset the jobs skip green and Pages would fall back to it.)
 
 ## Normal change flow
 
@@ -58,12 +62,13 @@ never be mistaken for production. Production never shows it.
 
 ## Production deploy
 
-- **Default (today):** merging to `main` publishes via GitHub Pages “Deploy from a branch”.
-- **Gated (after opt-in):** `deploy.yml` runs on push to `main`, re-runs static + browser
-  tests, publishes the **exact committed tree** plus a `build-info.json` stamp, then runs
-  the post-deploy smoke against the live URL.
+- **Active (current):** `deploy.yml` runs on push to `main` (Source = GitHub Actions,
+  `ENABLE_PAGES_DEPLOY = true`), re-runs static + browser tests, publishes the **exact committed
+  tree** plus a `build-info.json` stamp, then runs the post-deploy smoke against the live URL.
+- **Fallback:** if `ENABLE_PAGES_DEPLOY` is unset, `deploy.yml` skips green and Pages reverts to
+  “Deploy from a branch”. The steps below are how the gated path was turned on (kept for reference).
 
-### Enabling the gated deploy
+### Enabling the gated deploy (already done — kept for reference)
 
 This is the one settings change that upgrades you from “auto-publish on push” to
 “publish only after tests pass”. Do it once:

--- a/docs/SECURITY-ARCHITECTURE.md
+++ b/docs/SECURITY-ARCHITECTURE.md
@@ -77,11 +77,19 @@ flowchart LR
 - **AuthN:** Supabase Auth (email + Google/Apple OAuth). The session JWT is stored by the
   Supabase JS client in `localStorage` (its default; Supabase JS cannot use an httpOnly
   cookie). Consequence: **an XSS = token theft**, which is exactly why §4 is the priority.
-- **AuthZ — data:** Postgres **Row Level Security** on all 15 tables + column-level UPDATE
+- **AuthZ — data:** Postgres **Row Level Security** on every table + column-level UPDATE
   grants so a user can only touch their own rows and **cannot** set `is_admin`/`is_pro`/
   `plan`/`email` on their profile (no privilege escalation). See
   [`DATABASE.md`](DATABASE.md) / [`RLS-TESTING.md`](RLS-TESTING.md); enforced baseline in
   `supabase/migrations/20260718090000_baseline.sql`; attack cases in `supabase/tests/*_test.sql`.
+  - **(#R144) RLS is the real protection — grants are wide open in prod.** Supabase's
+    schema-wide default privileges grant `anon`/`authenticated` **full** table privileges on
+    every `public` table (`relacl = {authenticated=arwdDxtm,…}`), so a *column-level* grant does
+    **not** actually restrict a table that has a permissive RLS policy. Where a column must stay
+    server-owned even though its row is user-editable (the Area-Monitors run-state + `next_run_at`),
+    protection is a **BEFORE UPDATE trigger** (`tg_monitors_guard_state`), not the grant. Tables
+    whose writes are meant to be service-role-only rely on RLS **default-deny** (no write policy) —
+    that holds in prod regardless of grants. pgTAP now simulates the prod grant so tests catch this.
 - **AuthZ — AI quota:** `ai_usage` is writable **only** by the SECURITY DEFINER RPCs
   `increment_ai_usage` / `refund_ai_usage`, whose EXECUTE is granted to `service_role` only.
   A user cannot inflate/deflate their own quota.

--- a/index.html
+++ b/index.html
@@ -32791,6 +32791,10 @@ window.addEventListener('DOMContentLoaded', () => {
       quota_exceeded:()=>ML('Quota exceeded','上限超過','Kontingent überschritten','Превышена квота','Cuota excedida'),
       disabled:()=>ML('Paused','停止中','Pausiert','Пауза','Pausado'),
       internal_error:()=>ML('Error','エラー','Fehler','Ошибка','Error'),
+      /* rare partial-persistence outcomes (#R144): shown honestly, retried next run */
+      evidence_failed:()=>ML('Error (data not saved)','エラー（データ未保存）','Fehler (nicht gespeichert)','Ошибка (не сохранено)','Error (no guardado)'),
+      report_failed:()=>ML('Error (report not saved)','エラー（レポート未保存）','Fehler (Bericht nicht gespeichert)','Ошибка (отчёт не сохранён)','Error (informe no guardado)'),
+      scaffold_failed:()=>ML('Error','エラー','Fehler','Ошибка','Error'),
       running:()=>ML('Running…','実行中…','Läuft…','Выполняется…','Ejecutando…')
     };
     const statusLabel=(s)=>{ const f=STATUS_L[s]; return f?f():(s||'—'); };
@@ -32888,21 +32892,32 @@ window.addEventListener('DOMContentLoaded', () => {
         bbox:area.bbox||_bboxOf(area.geometry)||null, area_label:area.label||null,
         sources:(opts.sources&&opts.sources.length?opts.sources:['news']),
         comparison:opts.comparison||{mode:'previous_run',window_days:30}, sensitivity:opts.sensitivity||{},
-        interval_minutes:Math.max(30,parseInt(opts.intervalMin||360,10)||360), enabled:true, next_run_at:new Date().toISOString() };
+        interval_minutes:Math.max(30,parseInt(opts.intervalMin||360,10)||360), enabled:true };  /* next_run_at is server-owned (DB default now()); the client never sets an execution time (#R144) */
       try{ const {data,error}=await DB.from('area_monitors').insert(row).select('*').single(); if(error) return {ok:false,error:_errMsg(error),raw:error}; return {ok:true,monitor:data}; }
       catch(e){ return {ok:false,error:_errMsg(e),raw:e}; } }
     async function setEnabled(id,on){ try{ const {error}=await DB.from('area_monitors').update({enabled:!!on}).eq('id',id); return !error; }catch(_){ return false; } }
     async function remove(id){ try{ const {error}=await DB.from('area_monitors').delete().eq('id',id); return !error; }catch(_){ return false; } }
     async function pause(id){ const ok=await setEnabled(id,false); if(ok) render(); return ok; }
     async function resume(id){ const ok=await setEnabled(id,true); if(ok) render(); return ok; }
-    async function runNow(id){ if(!_loggedIn()){ _promptLogin(); return {ok:false,error:'login'}; }
+    /* Honest, localized reasons for why a manual run couldn't start. The server
+       decides atomically (monitor_claim_one) and returns a distinct code — the UI
+       never claims success and never invents a reason. */
+    function _runReasonMsg(code){ switch(String(code||'')){
+      case 'already_running': return ML('Already running — it’s in progress.','すでに実行中です。','Läuft bereits.','Уже выполняется.','Ya se está ejecutando.');
+      case 'cooldown':        return ML('Please wait a moment before running again.','少し待ってから再実行してください。','Bitte kurz warten, bevor Sie erneut ausführen.','Подождите немного перед повторным запуском.','Espera un momento antes de volver a ejecutar.');
+      case 'disabled':        return ML('This monitor is paused — resume it to run.','この監視は停止中です。再開してください。','Dieser Monitor ist pausiert — fortsetzen zum Ausführen.','Монитор на паузе — возобновите для запуска.','El monitor está en pausa; reanúdalo para ejecutar.');
+      case 'not_found':       return ML('Monitor not found.','監視が見つかりません。','Monitor nicht gefunden.','Монитор не найден.','Monitor no encontrado.');
+      case 'login':           return ML('Log in to run monitors.','ログインすると実行できます。','Zum Ausführen anmelden.','Войдите, чтобы запускать.','Inicia sesión para ejecutar.');
+      default:                return ML('This monitor can’t run right now.','今は実行できません。','Kann derzeit nicht ausgeführt werden.','Сейчас запустить нельзя.','No se puede ejecutar ahora.');
+    } }
+    async function runNow(id){ if(!_loggedIn()){ _promptLogin(); return {ok:false,error:'login',message:_runReasonMsg('login')}; }
       let token=''; try{ const r=await DB.auth.getSession(); token=(r&&r.data&&r.data.session&&r.data.session.access_token)||''; }catch(_){}
-      if(!token) return {ok:false,error:'login'};
+      if(!token) return {ok:false,error:'login',message:_runReasonMsg('login')};
       try{ const resp=await fetch(FN_URL,{method:'POST',headers:{'Content-Type':'application/json','apikey':window.SUPABASE_ANON_KEY||'','Authorization':'Bearer '+token},body:JSON.stringify({monitorId:id})});
         const j=await resp.json().catch(()=>null);
-        if(!resp.ok){ const err=(j&&(j.message||j.error))||('HTTP '+resp.status); return {ok:false,error:err,status:resp.status}; }
+        if(!resp.ok){ const code=(j&&j.error)||('http_'+resp.status); return {ok:false,error:code,message:_runReasonMsg(code),status:resp.status}; }
         return {ok:true,status:(j&&j.status)||'ok'}; }
-      catch(e){ return {ok:false,error:String(e&&e.message||e)}; } }
+      catch(e){ return {ok:false,error:'network',message:ML('Network error — please try again.','ネットワークエラー。再試行してください。','Netzwerkfehler.','Ошибка сети.','Error de red.')}; } }
 
     /* ---- rendering: the list ---- */
     function _statusChip(m){ const run=(m.running_since&&(Date.now()-new Date(m.running_since).getTime())<15*60000); const key=run?'running':(m.enabled===false?'disabled':(m.last_status||'')); const sev=m.last_change_severity;
@@ -32950,7 +32965,7 @@ window.addEventListener('DOMContentLoaded', () => {
           else if(act==='run'){ b.disabled=true; b.textContent='…'; const r=await runNow(id); b.disabled=false; b.textContent='▶';
             if(r.ok){ _toast(ML('Monitor ran: ','実行しました: ','Ausgeführt: ','Запущено: ','Ejecutado: ')+statusLabel(r.status)); render(); }
             else if(r.error==='login'){ _promptLogin(); }
-            else { _toast(ML('Run failed: ','実行失敗: ','Fehlgeschlagen: ','Ошибка: ','Fallo: ')+String(r.error||'')); } }
+            else { _toast(r.message||_runReasonMsg(r.error)); } }
         }; });
       }); }
 
@@ -33023,7 +33038,7 @@ window.addEventListener('DOMContentLoaded', () => {
         +'<h4 class="mon-h4">'+S(ML('Run history','実行履歴','Verlauf','История','Historial'))+'</h4>'+runsHtml;
       const ov=_overlay(inner,'mon-ov-detail');
       ov.querySelectorAll('.mon-detail-acts .mon-btn').forEach(b=>{ b.onclick=async()=>{ const d=b.getAttribute('data-d');
-        if(d==='run'){ b.disabled=true; b.textContent='…'; const r=await runNow(id); if(r.ok){ _toast(ML('Ran: ','実行: ','Lauf: ','Запуск: ','Ejec.: ')+statusLabel(r.status)); ov.remove(); render(); setTimeout(()=>openDetail(id),400); } else if(r.error==='login'){ _promptLogin(); } else { b.disabled=false; _toast(String(r.error||'')); } }
+        if(d==='run'){ b.disabled=true; b.textContent='…'; const r=await runNow(id); if(r.ok){ _toast(ML('Ran: ','実行: ','Lauf: ','Запуск: ','Ejec.: ')+statusLabel(r.status)); ov.remove(); render(); setTimeout(()=>openDetail(id),400); } else if(r.error==='login'){ _promptLogin(); } else { b.disabled=false; _toast(r.message||_runReasonMsg(r.error)); } }
         else if(d==='map'){ let pts=[]; try{ if(m.last_report_id){ const rep=await _report(m.last_report_id); if(rep&&rep.change_points) pts=rep.change_points; } }catch(_){} showOnMap({geometry:m.geometry,bbox:m.bbox},pts); ov.remove(); _closeSheetIfMobile(); }
         else if(d==='pause'){ await pause(id); ov.remove(); }
         else if(d==='resume'){ await resume(id); ov.remove(); }

--- a/scripts/static-checks.mjs
+++ b/scripts/static-checks.mjs
@@ -127,7 +127,10 @@ const DESTRUCTIVE = [
   { name: 'DROP COLUMN', re: /\bdrop\s+column\b/i },
   { name: 'ALTER … TYPE', re: /\balter\s+column\b[\s\S]{0,60}?\btype\b/i },
   { name: 'DISABLE ROW LEVEL SECURITY', re: /\bdisable\s+row\s+level\s+security\b/i },
-  { name: 'TRUNCATE', re: /\btruncate\b/i },
+  // Match TRUNCATE only as a STATEMENT (start of a statement), so that REVOKEing
+  // the TRUNCATE *privilege* — which is hardening, the opposite of destructive —
+  // is not flagged. A real `truncate [table] x` always begins a statement.
+  { name: 'TRUNCATE', re: /(?:^|;)\s*truncate\b/im },
   { name: 'DELETE FROM', re: /\bdelete\s+from\b/i },
 ];
 const stripSqlComments = (s) => s.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');

--- a/supabase/functions/monitor-run/index.ts
+++ b/supabase/functions/monitor-run/index.ts
@@ -35,8 +35,8 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.4";
 import {
   normalizeNewsRow, dedupeEvidence, pointInMonitorArea, bboxOfGeometry, validGeometry,
-  buildNewsSnapshot, diffKeys, clusterPoints, computeChangeScore, severityFromScore,
-  decideAI, validateAndCleanReport,
+  buildNewsSnapshot, clusterPoints, computeChangeScore, severityFromScore,
+  decideAI, validateClaims, buildReport, partitionByNovelty,
 } from "./logic.mjs";
 
 const cors = {
@@ -59,6 +59,12 @@ const NEWS_WINDOW_MS = 72 * 3600 * 1000; // current_news only holds ~72 h
 const RETAIN_RUNS = 100;          // keep the newest N runs per monitor
 const RETAIN_EVIDENCE_RUNS = 12;  // keep evidence only for the newest N runs (bulk data)
 const KEEP_RUNS_PER_MONITOR = RETAIN_RUNS;
+// The long-lived per-item ledger (monitor_seen_items) is what makes a "past N
+// days" baseline real. Retention MUST be ≥ the largest comparison window the UI
+// offers (30 days) so novelty over that window is always answerable; margin lets
+// an item age out gracefully. Keep the UI's window options ≤ this.
+const RETAIN_SEEN_DAYS = 45;
+const MAX_SEEN_WINDOW_DAYS = 30;  // the largest window the UI/DB actually supports
 
 // (#R138-style) constant-time compare so MONITOR_SECRET can't be recovered byte-by-byte.
 function timingSafeEqual(a: string, b: string): boolean {
@@ -179,10 +185,17 @@ type DB = any;
 async function collectNews(db: DB, monitor: Record<string, unknown>, sinceISO: string) {
   try {
     const bbox = (Array.isArray(monitor.bbox) ? monitor.bbox : bboxOfGeometry(monitor.geometry)) as number[] | null;
+    // DETERMINISTIC ORDER (#R144): newest-first with a stable id tie-breaker, applied
+    // BEFORE the cap, so the same DB state always yields the same set of rows (no
+    // phantom churn from Postgres' unspecified default order). Novelty itself is
+    // decided by the long-lived ledger, not this cap — so an item pushed past the
+    // cap by newer arrivals is never mistaken for a real change.
     let q = db.from("current_news")
       .select("id,lang,topic,title,publisher,link,pub_date,description,subject_lng,subject_lat,subject_name_en,subject_name_jp,pub_label")
       .not("subject_lng", "is", null).not("subject_lat", "is", null)
-      .gte("pub_date", sinceISO).limit(1500);
+      .gte("pub_date", sinceISO)
+      .order("pub_date", { ascending: false }).order("id", { ascending: true })
+      .limit(1500);
     if (bbox) q = q.gte("subject_lng", bbox[0]).lte("subject_lng", bbox[2]).gte("subject_lat", bbox[1]).lte("subject_lat", bbox[3]);
     const { data, error } = await q;
     if (error) return { ok: false, items: [] as Record<string, unknown>[] };
@@ -200,8 +213,26 @@ const COLLECTORS: Record<string, (db: DB, m: Record<string, unknown>, sinceISO: 
   news: collectNews,
 };
 
+// Release a monitor's lock + reschedule directly (fallback when the finalize RPC
+// itself is unavailable). NEVER leaves running_since set.
+async function releaseLock(db: DB, monId: string, monitor: Record<string, unknown>, intervalMin: number, nowISO: string, status: string | null) {
+  const next = new Date(Date.now() + intervalMin * 60_000).toISOString();
+  try {
+    await db.from("area_monitors").update({
+      running_since: null, last_run_at: nowISO, next_run_at: next,
+      run_count: (Number(monitor.run_count) || 0) + 1, last_status: status,
+    }).eq("id", monId);
+  } catch (_) {
+    try { await db.from("area_monitors").update({ running_since: null }).eq("id", monId); } catch (__) { /* */ }
+  }
+}
+
 // ---------------------------------------------------------------------------
 //  Process ONE monitor end-to-end. Always leaves a run row + releases the lock.
+//  Every DB write is error-checked: a partial persistence failure is recorded as
+//  a failure (retryable) and NEVER reported as success. The run finalize + report
+//  + monitor-meta writes go through atomic RPCs (monitor_finalize /
+//  monitor_commit_report) so they either all land or all roll back.
 // ---------------------------------------------------------------------------
 async function processMonitor(db: DB, monitor: Record<string, unknown>, aiCfg: { provider: string; key: string; model: string } | null, trigger: string, nowMs: number) {
   const start = nowMs;
@@ -212,37 +243,43 @@ async function processMonitor(db: DB, monitor: Record<string, unknown>, aiCfg: {
   const sensitivity = (monitor.sensitivity && typeof monitor.sensitivity === "object") ? monitor.sensitivity as Record<string, unknown> : {};
   const comparison = (monitor.comparison && typeof monitor.comparison === "object") ? monitor.comparison as Record<string, unknown> : {};
   const intervalMin = Number(monitor.interval_minutes) || 360;
+  const nextRunISO = () => new Date(Date.now() + intervalMin * 60_000).toISOString();
+  const monMeta = () => ({ last_run_at: nowISO, next_run_at: nextRunISO(), run_count: (Number(monitor.run_count) || 0) + 1 });
 
-  // Scaffold the run row FIRST so snapshot/diff/evidence survive even a late crash.
-  let runId = "";
-  const { data: runIns } = await db.from("monitor_runs").insert({
+  // Scaffold the run row FIRST. If THIS fails there is nowhere to record results —
+  // so we must NOT proceed: release the lock and report the scaffold failure.
+  const { data: runIns, error: scaffoldErr } = await db.from("monitor_runs").insert({
     monitor_id: monId, user_id: userId, status: "internal_error", trigger,
     started_at: nowISO, sources_attempted: sources,
   }).select("id").single();
-  runId = runIns?.id;
+  const runId = runIns?.id as string | undefined;
+  if (scaffoldErr || !runId) {
+    try { console.error("monitor-run scaffold insert failed", String(scaffoldErr?.message || "").slice(0, 120)); } catch (_) { /* */ }
+    await releaseLock(db, monId, monitor, intervalMin, nowISO, "internal_error");
+    return "scaffold_failed";
+  }
 
-  const finalizeRun = async (patch: Record<string, unknown>) => {
-    patch.finished_at = new Date().toISOString();
-    patch.duration_ms = Date.now() - start;
-    if (runId) await db.from("monitor_runs").update(patch).eq("id", runId);
-  };
-  const scheduleNext = async (extra: Record<string, unknown> = {}) => {
-    const next = new Date(Date.now() + intervalMin * 60_000).toISOString();
-    await db.from("area_monitors").update({
-      running_since: null, last_run_at: nowISO, next_run_at: next,
-      run_count: (Number(monitor.run_count) || 0) + 1, ...extra,
-    }).eq("id", monId);
+  // Atomic finalize (run + monitor meta). Returns false if the RPC errored (then
+  // we fall back to releasing the lock so a monitor never wedges).
+  const finalize = async (runPatch: Record<string, unknown>, monPatch: Record<string, unknown>) => {
+    (runPatch as Record<string, unknown>).duration_ms = Date.now() - start;
+    const { error } = await db.rpc("monitor_finalize", { p_run: runId, p_mon: monId, run_patch: runPatch, mon_patch: monPatch });
+    if (error) {
+      try { console.error("monitor_finalize failed", String(error.message || "").slice(0, 120)); } catch (_) { /* */ }
+      await releaseLock(db, monId, monitor, intervalMin, nowISO, String(runPatch.status || "internal_error"));
+      return false;
+    }
+    return true;
   };
 
   try {
     if (monitor.enabled === false) {
-      await finalizeRun({ status: "disabled" });
-      await db.from("area_monitors").update({ running_since: null }).eq("id", monId);
+      await finalize({ status: "disabled", retryable: false }, { ...monMeta(), last_status: "disabled" });
       return "disabled";
     }
     if (!validGeometry(monitor.geometry) && monitor.geometry_kind !== "circle") {
-      await finalizeRun({ status: "invalid_geometry", error_category: "invalid_geometry", error_detail: "geometry is not a valid Polygon/MultiPolygon", retryable: false });
-      await scheduleNext({ last_status: "invalid_geometry" });
+      await finalize({ status: "invalid_geometry", error_category: "invalid_geometry", error_detail: "geometry is not a valid Polygon/MultiPolygon", retryable: false },
+                     { ...monMeta(), last_status: "invalid_geometry" });
       return "invalid_geometry";
     }
 
@@ -258,81 +295,125 @@ async function processMonitor(db: DB, monitor: Record<string, unknown>, aiCfg: {
       else failSources.push(src);
     }
     items = dedupeEvidence(items).slice(0, MAX_EVIDENCE);
+    const partial = failSources.length > 0;
 
     // All sources down → source_unavailable (NEVER "no change"). Keep the run row.
     if (okSources.length === 0) {
-      await finalizeRun({ status: "source_unavailable", sources_ok: okSources, sources_failed: failSources, error_category: "source_unavailable", retryable: true });
-      await scheduleNext({ last_status: "source_unavailable" });
+      await finalize({ status: "source_unavailable", sources_ok: okSources, sources_failed: failSources, error_category: "source_unavailable", retryable: true },
+                     { ...monMeta(), last_status: "source_unavailable" });
       return "source_unavailable";
     }
 
     // 2) SNAPSHOT (per-source + overall).
     const snapshot = { news: buildNewsSnapshot(items.filter((i) => i.source_type === "news")), sources_ok: okSources, sources_failed: failSources } as Record<string, unknown>;
     const curKeys = items.map((i) => i.dedup_key as string);
+    const curKeySet = new Set(curKeys);
+    const newsSnap = snapshot.news as { count: number; publishers: number; keys: string[] };
 
-    // 3) BASELINE — previous run's snapshot, or the accumulated window of evidence.
+    // 3) NOVELTY via the long-lived ledger (cap-proof, deterministic). "new" = a
+    //    dedup_key NOT seen within the applicable lookback window (the comparison
+    //    window for baseline_window mode; the news window for previous_run mode).
+    //    This is what a "past 30 days" comparison actually references — independent
+    //    of per-run evidence pruning — and it never mistakes a cap-displaced or
+    //    re-appearing item for a real change.
+    const mode = String(comparison.mode || "previous_run");
+    const windowDays = Math.max(1, Math.min(MAX_SEEN_WINDOW_DAYS, Number(comparison.window_days) || 30));
+    const lookbackMs = mode === "baseline_window" ? windowDays * 86400000 : NEWS_WINDOW_MS;
+    const winStartISO = new Date(nowMs - lookbackMs).toISOString();
+    const { data: seenPrior, error: seenErr } = await db.from("monitor_seen_items")
+      .select("dedup_key").eq("monitor_id", monId).gte("last_seen_at", winStartISO);
+    const ledgerOk = !seenErr;
+    const priorKeys = new Set((seenPrior || []).map((r: { dedup_key: string }) => r.dedup_key));
+
+    // Total ledger size (ever) → distinguishes a genuinely-establishing run (empty
+    // ledger, e.g. the first run after this feature shipped) from a quiet window.
+    const { count: seenTotal } = await db.from("monitor_seen_items").select("id", { count: "exact", head: true }).eq("monitor_id", monId);
+
+    // Previous-run snapshot for the DISPLAY baseline (previous_run mode metrics).
     const { data: prevRun } = await db.from("monitor_runs")
       .select("id,snapshot").eq("monitor_id", monId).not("snapshot", "is", null).neq("id", runId)
       .order("started_at", { ascending: false }).limit(1).maybeSingle();
-    const isFirstRun = !prevRun;
     const baselineSnap = (prevRun?.snapshot?.news) || null;
-    let baselineKeys: string[] = baselineSnap?.keys || [];
-    if (String(comparison.mode || "previous_run") === "baseline_window") {
-      const windowDays = Number(comparison.window_days) || 30;
-      const winStart = new Date(nowMs - windowDays * 86400000).toISOString();
-      const { data: evrows } = await db.from("monitor_evidence").select("dedup_key").eq("monitor_id", monId).neq("run_id", runId).gte("fetched_at", winStart);
-      baselineKeys = Array.from(new Set((evrows || []).map((r: { dedup_key: string }) => r.dedup_key)));
-    }
+    // Establishing when there is no prior run, the ledger read failed (never flood
+    // on a transient error), or the ledger is empty (first run under this system).
+    const establishing = !prevRun || !ledgerOk || (Number(seenTotal) || 0) === 0;
 
-    // 4) MECHANICAL DIFF + change score (CODE decides "changed?", not the AI).
-    const diff = diffKeys(curKeys, baselineKeys);
-    const newItems = items.filter((i) => diff.new.includes(i.dedup_key as string));
+    const { newItems, newKeys } = partitionByNovelty(items, priorKeys) as { newItems: Record<string, unknown>[]; newKeys: string[] };
+    const newSet = new Set(newKeys);
+    const continuing = curKeys.filter((k) => !newSet.has(k));
+    // "gone" is informational only (never scores, never triggers the AI) so a
+    // cap-displaced item can't manufacture a report.
+    const baselineKeys = mode === "baseline_window" ? Array.from(priorKeys) : (baselineSnap?.keys || []);
+    const goneKeys = baselineKeys.filter((k: string) => !curKeySet.has(k));
+    const prevCount = mode === "baseline_window" ? priorKeys.size : (baselineSnap?.count || 0);
+
+    // 4) CLUSTER + change score (CODE decides "changed?", not the AI). Score uses
+    //    the ledger-based NEW set.
     const clusters = clusterPoints(newItems.map((i) => ({ lng: i.lng as number, lat: i.lat as number })), 60);
     const newClusters = clusters.length;
     const corroboratedClusters = clusters.filter((members) => {
       const pubs = new Set(members.map((idx) => String((newItems[idx].source_name as string) || "").toLowerCase()).filter(Boolean));
       return pubs.size >= 2;
     }).length;
-    const changeScore = computeChangeScore({ diff, current: snapshot.news as never, baseline: baselineSnap, newClusters, corroboratedClusters });
-    const diffOut = { new: diff.new.length, gone: diff.gone.length, continuing: diff.continuing.length, new_clusters: newClusters, corroborated_clusters: corroboratedClusters, prev_count: baselineSnap?.count || 0, cur_count: (snapshot.news as { count: number }).count };
+    const changeScore = computeChangeScore({ diff: { new: newKeys, gone: goneKeys, continuing }, current: newsSnap as never, baseline: baselineSnap, newClusters, corroboratedClusters });
+    const diffOut = { new: newKeys.length, gone: goneKeys.length, continuing: continuing.length, new_clusters: newClusters, corroborated_clusters: corroboratedClusters, prev_count: prevCount, cur_count: newsSnap.count };
 
-    // 5) Persist evidence with per-run ev_key ids (ev_1…). Tag change_kind.
+    // 5) Persist evidence with per-run ev_key ids (ev_1…). Tag change_kind. If the
+    //    evidence write fails we CANNOT ground a report → record a retryable
+    //    failure (keep snapshot+diff) and never claim success.
     const evRows = items.slice(0, MAX_EVIDENCE).map((it, i) => ({
       run_id: runId, monitor_id: monId, user_id: userId, ev_key: "ev_" + (i + 1),
       source_type: it.source_type, source_name: it.source_name, source_url: it.source_url, external_id: it.external_id,
       title: it.title, observed_at: it.observed_at, fetched_at: nowISO, lng: it.lng, lat: it.lat,
       payload: it.payload, dedup_key: it.dedup_key,
-      change_kind: diff.new.includes(it.dedup_key as string) ? "new" : (diff.continuing.includes(it.dedup_key as string) ? "continuing" : null),
+      change_kind: newSet.has(it.dedup_key as string) ? "new" : "continuing",
     }));
-    if (evRows.length) await db.from("monitor_evidence").insert(evRows);
+    if (evRows.length) {
+      const { error: evErr } = await db.from("monitor_evidence").insert(evRows);
+      if (evErr) {
+        try { console.error("monitor evidence insert failed", String(evErr.message || "").slice(0, 120)); } catch (_) { /* */ }
+        await finalize({ status: "internal_error", sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
+                         report_generated: false, ai_used: false, error_category: "evidence_write_failed", error_detail: "could not persist evidence rows", retryable: true, evidence_count: 0 },
+                       { ...monMeta(), last_status: "internal_error" });
+        await prune(db, monId);
+        return "evidence_failed";
+      }
+    }
+
+    // Record the current items in the long-lived ledger for future novelty (AFTER
+    // computing novelty). first_seen_at is set once (default); last_seen_at bumps.
+    if (ledgerOk && items.length) {
+      const seenRows = items.map((it) => ({
+        monitor_id: monId, user_id: userId, source_type: it.source_type, dedup_key: it.dedup_key,
+        title: it.title, source_name: it.source_name, source_url: it.source_url,
+        observed_at: it.observed_at, lng: it.lng, lat: it.lat, last_seen_at: nowISO, metadata: it.payload || null,
+      }));
+      const { error: upErr } = await db.from("monitor_seen_items").upsert(seenRows, { onConflict: "monitor_id,source_type,dedup_key" });
+      if (upErr) { try { console.error("monitor seen upsert failed", String(upErr.message || "").slice(0, 120)); } catch (_) { /* */ } }
+    }
+
     // Map dedup_key → ev_key and → coords/label (for evidence-id validation + change points).
     const keyToEv = new Map(evRows.map((e) => [e.dedup_key, e.ev_key]));
     const validKeys = new Set(evRows.map((e) => e.ev_key));
     const evByKey = new Map(evRows.map((e) => [e.ev_key, { lng: e.lng as number, lat: e.lat as number, label: (e.title as string) || "" }]));
-
-    const partial = failSources.length > 0;
-    const mechGaps = failSources.map((s) => `The ${s} source was unavailable this run.`);
     const baseStatus = partial ? "partial" : "success";
 
-    // 6) DECIDE whether to call the AI. Only a real, code-detected change qualifies.
-    const decision = decideAI({ isFirstRun, hasData: items.length > 0, newCount: diff.new.length, changeScore, sensitivity: sensitivity as never });
-
-    if (!aiCfg && decision.call) decision.call = false, decision.skip = "not_configured";
+    // 6) DECIDE whether to call the AI. Only a real, code-detected change qualifies;
+    //    an establishing run only populates the ledger (no AI, no report).
+    const decision = decideAI({ isFirstRun: establishing, hasData: items.length > 0, newCount: newKeys.length, changeScore, sensitivity: sensitivity as never });
+    if (!aiCfg && decision.call) { decision.call = false; decision.skip = "not_configured"; }
 
     if (!decision.call) {
-      // No report. Record a run-only outcome honestly. success_no_change unless the
-      // run also had a partial source failure (then keep the partial signal).
       const status = partial ? "partial" : "success_no_change";
-      await finalizeRun({
-        status, sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
-        report_generated: false, ai_used: false, ai_skip_reason: decision.skip, evidence_count: evRows.length,
-      });
-      await scheduleNext({ last_status: status, last_change_severity: "none" });
+      await finalize({ status, sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
+                       report_generated: false, ai_used: false, ai_skip_reason: decision.skip, evidence_count: evRows.length },
+                     { ...monMeta(), last_status: status, last_change_severity: "none" });
       await prune(db, monId);
       return status;
     }
 
-    // 7) CALL AI — build the evidence + change summary message (NEW items only).
+    // 7) CALL AI — it only writes the per-claim TEXT (each grounded in real
+    //    evidence). The headline/summary/counts are built mechanically below.
     const aiEvidence = newItems.slice(0, MAX_AI_EVIDENCE).map((it) => ({
       id: keyToEv.get(it.dedup_key as string), source: it.source_name, title: it.title,
       url: it.source_url, date: it.observed_at, place: (it.payload as { subject?: string })?.subject || null,
@@ -343,55 +424,58 @@ async function processMonitor(db: DB, monitor: Record<string, unknown>, aiCfg: {
       "CHANGE SUMMARY (authoritative): " + JSON.stringify(diffOut) + "\n" +
       "EVIDENCE (new items in the area; cite ids exactly):\n" + JSON.stringify(aiEvidence) + "\n\n" +
       // OpenAI's json_object mode requires the literal word "json" in the input message.
-      "Respond with ONLY a single JSON object: {severity, headline, summary, changes:[{claim, evidence_ids}], unchanged, data_gaps, limitations}.";
+      "Respond with ONLY a single JSON object: {severity, changes:[{claim, evidence_ids}]}. Each claim MUST cite ids from the evidence.";
 
     let aiText = "", aiOk = false, aiErr = "";
     try { aiText = await callAI(aiCfg!, userMsg); aiOk = !!aiText; }
     catch (e) { aiErr = String((e as Error)?.message || e).slice(0, 160); }
 
     const parsed = aiOk ? parseJson(aiText) : null;
-    const valid = parsed ? validateAndCleanReport(parsed, validKeys, evByKey) : { ok: false, cleaned: null, invalidRefs: [] };
+    const valid = parsed ? validateClaims(parsed, validKeys, evByKey) : { ok: false, claims: [], severity: null, changePoints: [], invalidRefs: [] };
 
-    if (!valid.ok || !valid.cleaned) {
-      // AI attempted but failed/hallucinated → ai_failed, but KEEP snapshot+diff+evidence.
-      await finalizeRun({
-        status: "ai_failed", sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
-        report_generated: false, ai_used: true, ai_provider: aiCfg!.provider, ai_model: aiCfg!.model,
-        error_category: "ai_failed", error_detail: (aiErr || "AI output had no evidence-grounded claim").slice(0, 200), retryable: true, evidence_count: evRows.length,
-      });
-      await scheduleNext({ last_status: "ai_failed" });
+    if (!valid.ok) {
+      // AI attempted but produced no evidence-grounded claim → ai_failed, KEEP data.
+      await finalize({ status: "ai_failed", sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
+                       report_generated: false, ai_used: true, ai_provider: aiCfg!.provider, ai_model: aiCfg!.model,
+                       error_category: "ai_failed", error_detail: (aiErr || "AI output had no evidence-grounded claim").slice(0, 200), retryable: true, evidence_count: evRows.length },
+                     { ...monMeta(), last_status: "ai_failed" });
       await prune(db, monId);
       return "ai_failed";
     }
 
-    // 8) Build + persist the validated report. Merge mechanical gaps/limitations.
-    const cleaned = valid.cleaned;
-    const severity = cleaned.severity || severityFromScore(changeScore);
-    const dataGaps = Array.from(new Set([...(cleaned.data_gaps || []), ...mechGaps]));
-    const limitations = Array.from(new Set([...(cleaned.limitations || []), "Locations represent the reported subject of each article, not a confirmed on-the-ground position."]));
-    const metrics = { articles: { prev: baselineSnap?.count || 0, cur: (snapshot.news as { count: number }).count, delta: (snapshot.news as { count: number }).count - (baselineSnap?.count || 0) }, new_items: diff.new.length, new_clusters: newClusters, publishers: { prev: baselineSnap?.publishers || 0, cur: (snapshot.news as { publishers: number }).publishers } };
+    // 8) Build the GROUNDED report (headline/summary/unchanged/data_gaps from the
+    //    authoritative diff numbers + validated claims; limitations are fixed
+    //    general caveats) and commit it + finalize the run + monitor meta ATOMICALLY.
+    const metrics = { articles: { prev: prevCount, cur: newsSnap.count, delta: newsSnap.count - prevCount }, new_items: newKeys.length, new_clusters: newClusters, corroborated_clusters: corroboratedClusters, publishers: { prev: baselineSnap?.publishers || 0, cur: newsSnap.publishers } };
+    const report = buildReport({ areaLabel: String(monitor.area_label || monitor.name || ""), diffOut, metrics, claims: valid.claims, severity: valid.severity, changePoints: valid.changePoints, failSources });
+    const severity = report.severity || severityFromScore(changeScore);
 
-    const { data: repIns } = await db.from("monitor_reports").insert({
-      monitor_id: monId, run_id: runId, user_id: userId, severity,
-      headline: cleaned.headline, summary: cleaned.summary,
-      changes: cleaned.changes, unchanged: cleaned.unchanged, data_gaps: dataGaps, limitations,
-      metrics, change_points: cleaned.change_points,
-      ai_provider: aiCfg!.provider, ai_model: aiCfg!.model, prompt_version: PROMPT_VERSION,
-    }).select("id").single();
-    const reportId = repIns?.id;
-
-    await finalizeRun({
-      status: baseStatus, sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
-      report_generated: true, report_id: reportId, ai_used: true, ai_provider: aiCfg!.provider, ai_model: aiCfg!.model,
-      ai_skip_reason: null, evidence_count: evRows.length,
+    const { data: repId, error: commitErr } = await db.rpc("monitor_commit_report", {
+      p_run: runId, p_mon: monId, p_user: userId,
+      report: { ...report, severity, ai_provider: aiCfg!.provider, ai_model: aiCfg!.model, prompt_version: PROMPT_VERSION },
+      run_patch: { status: baseStatus, sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
+                   ai_used: true, ai_provider: aiCfg!.provider, ai_model: aiCfg!.model, ai_skip_reason: null, evidence_count: evRows.length, duration_ms: Date.now() - start },
+      mon_patch: { ...monMeta(), last_status: baseStatus, last_change_severity: severity },
     });
-    await scheduleNext({ last_status: baseStatus, last_change_severity: severity, last_report_id: reportId });
+
+    if (commitErr || !repId) {
+      // The atomic commit rolled back → NOTHING was written. Record a retryable
+      // failure (keep snapshot+diff), never report_generated=true, release the lock.
+      try { console.error("monitor_commit_report failed", String(commitErr?.message || "").slice(0, 120)); } catch (_) { /* */ }
+      await finalize({ status: "internal_error", sources_ok: okSources, sources_failed: failSources, snapshot, diff: diffOut, change_score: changeScore,
+                       report_generated: false, ai_used: true, ai_provider: aiCfg!.provider, ai_model: aiCfg!.model,
+                       error_category: "report_write_failed", error_detail: String(commitErr?.message || "report commit failed").slice(0, 200), retryable: true, evidence_count: evRows.length },
+                     { ...monMeta(), last_status: "internal_error" });
+      await prune(db, monId);
+      return "report_failed";
+    }
+
     await prune(db, monId);
     return baseStatus + "+report";
   } catch (e) {
-    await finalizeRun({ status: "internal_error", error_category: "internal_error", error_detail: String((e as Error)?.message || e).slice(0, 200), retryable: true });
-    // Always release the lock + reschedule so a crash never wedges a monitor.
-    try { await scheduleNext({ last_status: "internal_error" }); } catch (_) { await db.from("area_monitors").update({ running_since: null }).eq("id", monId); }
+    const ok = await finalize({ status: "internal_error", error_category: "internal_error", error_detail: String((e as Error)?.message || e).slice(0, 200), retryable: true },
+                              { ...monMeta(), last_status: "internal_error" });
+    if (!ok) await releaseLock(db, monId, monitor, intervalMin, nowISO, "internal_error");
     return "internal_error";
   }
 }
@@ -411,6 +495,11 @@ async function prune(db: DB, monId: string) {
       // delete evidence whose run is not among the newest RETAIN_EVIDENCE_RUNS
       await db.from("monitor_evidence").delete().eq("monitor_id", monId).not("run_id", "in", "(" + keepEv.map((x) => `"${x}"`).join(",") + ")");
     }
+    // Ledger retention: keep the long-lived seen-items only within RETAIN_SEEN_DAYS
+    // of their last sighting. This bounds growth while guaranteeing the ledger
+    // always covers the largest supported comparison window (MAX_SEEN_WINDOW_DAYS).
+    const seenCutoff = new Date(Date.now() - RETAIN_SEEN_DAYS * 86400000).toISOString();
+    await db.from("monitor_seen_items").delete().eq("monitor_id", monId).lt("last_seen_at", seenCutoff);
   } catch (_) { /* best-effort */ }
 }
 
@@ -457,7 +546,11 @@ Deno.serve(async (req) => {
     return json({ ok: true, mode: "cron", claimed: monitors.length, results });
   }
 
-  // ── MODE 2: USER "run now" (JWT + {monitorId}). Verify ownership + cooldown.
+  // ── MODE 2: USER "run now" (JWT + {monitorId}). Verify the JWT, then claim the
+  //    monitor ATOMICALLY (ownership + enabled + lock-free-or-stale + cooldown are
+  //    ALL inside one UPDATE…WHERE…RETURNING via monitor_claim_one). Two concurrent
+  //    "Run now" requests can never both succeed — no check-then-act TOCTOU. It
+  //    also cannot race the cron claim (both take the same row lock on the monitor).
   if (!authHeader) return json({ error: "unauthorized", message: "Send x-monitor-secret (cron) or a user JWT + monitorId." }, 401);
   const userClient = createClient(url, anon, { global: { headers: { Authorization: authHeader } }, auth: { persistSession: false } });
   const { data: userData } = await userClient.auth.getUser();
@@ -466,17 +559,27 @@ Deno.serve(async (req) => {
   const monitorId = String(payload.monitorId || "");
   if (!monitorId) return json({ error: "bad_request", message: "monitorId required." }, 400);
 
-  const { data: monitor } = await db.from("area_monitors").select("*").eq("id", monitorId).maybeSingle();
-  if (!monitor || monitor.user_id !== user.id) return json({ error: "not_found" }, 404);   // don't leak existence
-  if (monitor.running_since && (nowMs - new Date(monitor.running_since).getTime()) < 15 * 60_000) return json({ error: "already_running" }, 409);
+  const { data: claimRows, error: claimErr } = await db.rpc("monitor_claim_one", {
+    p_monitor_id: monitorId, p_user_id: user.id,
+    p_cooldown_seconds: Math.round(MANUAL_COOLDOWN_MS / 1000), p_stale_minutes: 15,
+  });
+  if (claimErr) return json({ error: "claim_failed", message: claimErr.message }, 500);
+  const claim = (Array.isArray(claimRows) ? claimRows[0] : claimRows) as { claimed?: boolean; reason?: string; monitor?: Record<string, unknown> } | undefined;
+  if (!claim || !claim.claimed || !claim.monitor) {
+    const reason = claim?.reason || "unavailable";
+    // Honest, distinct outcomes for the UI (never a lie about success).
+    const statusFor: Record<string, number> = { not_found: 404, disabled: 409, already_running: 409, cooldown: 429, unavailable: 409 };
+    const msgFor: Record<string, string> = {
+      not_found: "Monitor not found.",
+      disabled: "This monitor is paused — resume it to run.",
+      already_running: "This monitor is already running.",
+      cooldown: "Please wait a moment before running again.",
+      unavailable: "This monitor can't run right now.",
+    };
+    return json({ error: reason, message: msgFor[reason] || msgFor.unavailable }, statusFor[reason] || 409);
+  }
 
-  // Manual cooldown — the newest run must be older than MANUAL_COOLDOWN_MS.
-  const { data: lastRun } = await db.from("monitor_runs").select("started_at").eq("monitor_id", monitorId).order("started_at", { ascending: false }).limit(1).maybeSingle();
-  if (lastRun && (nowMs - new Date(lastRun.started_at).getTime()) < MANUAL_COOLDOWN_MS) return json({ error: "cooldown", message: "Please wait a moment before running again." }, 429);
-
-  // Claim (lock) then process just this one.
-  await db.from("area_monitors").update({ running_since: new Date(nowMs).toISOString() }).eq("id", monitorId);
-  const status = await processMonitor(db, monitor, aiCfg, "manual", Date.now());
+  const status = await processMonitor(db, claim.monitor, aiCfg, "manual", Date.now());
   return json({ ok: true, mode: "manual", monitorId, status });
  } catch (topErr) {
   try { console.error("monitor-run UNCAUGHT", String((topErr as Error)?.message || topErr).slice(0, 200)); } catch (_) { /* */ }

--- a/supabase/functions/monitor-run/logic.mjs
+++ b/supabase/functions/monitor-run/logic.mjs
@@ -188,6 +188,42 @@ export function diffKeys(currentKeys, baselineKeys) {
   return { new: isNew, gone, continuing: cont };
 }
 
+// Ledger-based novelty (the cap-proof, determinism-preserving definition of
+// "new"). Given the run's items (already deterministically ordered + capped) and
+// the set of dedup_keys this monitor has EVER recorded before this run (from
+// monitor_seen_items), split into genuinely-new vs already-known. Because novelty
+// is decided by the long-lived ledger — not by comparison to one capped snapshot —
+// a re-appearing item or one displaced past the fetch cap is NOT falsely "new",
+// and the same DB state always yields the same partition.
+export function partitionByNovelty(items, priorSeenKeys) {
+  const prior = priorSeenKeys instanceof Set ? priorSeenKeys : new Set(priorSeenKeys || []);
+  const newItems = [], knownItems = [];
+  for (const it of items || []) {
+    if (it && it.dedup_key != null && !prior.has(it.dedup_key)) newItems.push(it);
+    else knownItems.push(it);
+  }
+  return { newItems, knownItems, newKeys: newItems.map((i) => i.dedup_key) };
+}
+
+// Split baseline keys absent from the current snapshot into "expired" (their
+// observed_at fell out of the news window — a natural, non-meaningful ageing-out)
+// vs "absent" (still in-window but not fetched this run — almost always just
+// pushed past the fetch cap). NEITHER is treated as a meaningful disappearance;
+// this exists so a run can RECORD the distinction honestly instead of counting a
+// cap-displaced item as a real "gone".
+export function classifyDisappeared(baselineKeys, currentKeySet, observedAtByKey, windowStartMs) {
+  const cur = currentKeySet instanceof Set ? currentKeySet : new Set(currentKeySet || []);
+  const expired = [], absent = [];
+  for (const k of baselineKeys || []) {
+    if (cur.has(k)) continue;
+    const t = observedAtByKey && observedAtByKey.get ? observedAtByKey.get(k) : null;
+    const ms = t ? Date.parse(t) : NaN;
+    if (isFinite(ms) && isFinite(windowStartMs) && ms < windowStartMs) expired.push(k);
+    else absent.push(k);
+  }
+  return { expired, absent };
+}
+
 // Greedy spatial clustering of points (km radius). Returns clusters of indices.
 export function clusterPoints(points, radiusKm = 60) {
   const clusters = [];
@@ -282,17 +318,18 @@ export function decideAI({ isFirstRun, hasData, newCount, changeScore, sensitivi
 }
 
 // ---------------------------------------------------------------------------
-//  Evidence-id validation — the anti-fabrication gate. EVERY evidence_id an AI
-//  report cites MUST be a real ev_key from THIS run's evidence. Claims that cite
-//  a nonexistent id are dropped; a report with no surviving grounded claim is
-//  rejected entirely (caller then records ai_failed and keeps snapshot+diff).
+//  Evidence-id validation — the anti-fabrication gate. EVERY factual claim the AI
+//  makes MUST cite a real ev_key from THIS run's evidence, or it is dropped. The
+//  AI's free-form headline/summary/unchanged/data_gaps/limitations are IGNORED
+//  entirely (see buildReport): only the per-claim text (each grounded in real
+//  evidence) and a bounded severity survive. A run with no surviving grounded
+//  claim is rejected (caller records ai_failed and keeps snapshot+diff+evidence).
 // ---------------------------------------------------------------------------
-export function validateAndCleanReport(report, validKeySet, changePointsByKey) {
+export function validateClaims(report, validKeySet, changePointsByKey) {
   const invalid = new Set();
   const arr = (v) => (Array.isArray(v) ? v : []);
-  const strArr = (v) => arr(v).map((x) => String(x)).filter(Boolean).slice(0, 40);
 
-  const changes = arr(report && report.changes)
+  const claims = arr(report && report.changes)
     .map((c) => {
       const ids = arr(c && c.evidence_ids).map((x) => String(x));
       const good = ids.filter((id) => {
@@ -300,44 +337,102 @@ export function validateAndCleanReport(report, validKeySet, changePointsByKey) {
         if (!ok) invalid.add(id);
         return ok;
       });
-      return { claim: String((c && c.claim) || "").slice(0, 500), evidence_ids: good, metric: c && c.metric ? String(c.metric).slice(0, 120) : undefined };
+      return { claim: String((c && c.claim) || "").slice(0, 500), evidence_ids: good };
     })
     // A factual claim with NO surviving evidence id is not allowed to stand.
     .filter((c) => c.claim && c.evidence_ids.length > 0);
 
-  // change_points: keep only points whose evidence_id is real.
+  // change_points: keep only points whose evidence_id is a real ev_key.
   const points = arr(report && report.change_points)
     .map((p) => ({ lng: Number(p && p.lng), lat: Number(p && p.lat), label: String((p && p.label) || "").slice(0, 120), evidence_id: p && p.evidence_id ? String(p.evidence_id) : null }))
     .filter((p) => isFinite(p.lng) && isFinite(p.lat) && (!p.evidence_id || validKeySet.has(p.evidence_id)));
 
   // If the AI gave no change_points but cited evidence, synthesize points from the cited keys' coords.
-  let finalPoints = points;
-  if (!finalPoints.length && changePointsByKey) {
+  let changePoints = points;
+  if (!changePoints.length && changePointsByKey) {
     const seen = new Set();
-    finalPoints = [];
-    for (const c of changes) {
+    changePoints = [];
+    for (const c of claims) {
       for (const id of c.evidence_ids) {
         if (seen.has(id)) continue;
         seen.add(id);
         const pt = changePointsByKey.get(id);
-        if (pt && isFinite(pt.lng) && isFinite(pt.lat)) finalPoints.push({ lng: pt.lng, lat: pt.lat, label: pt.label || "", evidence_id: id });
+        if (pt && isFinite(pt.lng) && isFinite(pt.lat)) changePoints.push({ lng: pt.lng, lat: pt.lat, label: pt.label || "", evidence_id: id });
       }
     }
   }
 
   const severity = ["none", "low", "medium", "high", "critical"].includes(report && report.severity) ? report.severity : null;
+  const ok = claims.length > 0;
+  return { ok, claims, severity, changePoints: changePoints.slice(0, 60), invalidRefs: Array.from(invalid) };
+}
 
-  const cleaned = {
-    severity,
-    headline: String((report && report.headline) || "").slice(0, 200),
-    summary: String((report && report.summary) || "").slice(0, 2000),
-    changes,
-    unchanged: strArr(report && report.unchanged).map((s) => s.slice(0, 300)),
-    data_gaps: strArr(report && report.data_gaps).map((s) => s.slice(0, 300)),
-    limitations: strArr(report && report.limitations).map((s) => s.slice(0, 300)),
-    change_points: finalPoints.slice(0, 60),
+const _plural = (n, one, many) => `${n} ${n === 1 ? one : many}`;
+
+// ---------------------------------------------------------------------------
+//  Mechanical report assembly — the anti-fabrication rule for the WHOLE report,
+//  not just the claims. headline / summary / unchanged / data_gaps are built HERE
+//  from the AUTHORITATIVE machine-computed diff numbers and the already-validated
+//  (evidence-grounded) claims — never from AI free text. limitations are fixed,
+//  clearly-general caveats (not factual assertions). This closes the "the headline
+//  or summary was fabricated" path: every number traces to `diffOut`, every claim
+//  to real evidence, every gap to a source that actually failed.
+//
+//    diffOut : { new, gone, continuing, new_clusters, corroborated_clusters,
+//                prev_count, cur_count }  (all authoritative, from CODE)
+//    claims  : validated [{claim, evidence_ids}]
+//    metrics : the numeric block stored on the report
+// ---------------------------------------------------------------------------
+export function buildReport({ areaLabel, diffOut, metrics, claims, severity, changePoints, failSources }) {
+  const d = diffOut || {};
+  const area = String(areaLabel || "the monitored area").slice(0, 120);
+  const newCount = Math.max(0, Number(d.new) || 0);
+  const clusters = Math.max(0, Number(d.new_clusters) || 0);
+  const corrob = Math.max(0, Number(d.corroborated_clusters) || 0);
+  const cont = Math.max(0, Number(d.continuing) || 0);
+  const prev = Math.max(0, Number(d.prev_count) || 0);
+  const cur = Math.max(0, Number(d.cur_count) || 0);
+  const delta = cur - prev;
+
+  const headline = `${_plural(newCount, "new report", "new reports")} in ${area}`;
+
+  const summaryBits = [
+    `A mechanical comparison found ${_plural(newCount, "new item", "new items")} across ${_plural(clusters, "location cluster", "location clusters")}` +
+      (corrob > 0 ? `, ${_plural(corrob, "cluster", "clusters")} corroborated by two or more publishers.` : "."),
+    `Reports in the area: ${prev} → ${cur} (${delta >= 0 ? "+" : ""}${delta}).`,
+  ];
+  const summary = summaryBits.join(" ").slice(0, 2000);
+
+  const unchanged = cont > 0
+    ? [`${_plural(cont, "previously-seen report is", "previously-seen reports are")} still present in the area.`]
+    : [];
+
+  const data_gaps = (Array.isArray(failSources) ? failSources : [])
+    .map((s) => `The ${String(s)} source was unavailable this run, so any changes there are not reflected.`);
+
+  const limitations = [
+    "Locations represent the reported subject of each article, not a confirmed on-the-ground position.",
+    "Only the sources you selected, within the monitored area and the most recent news window, are considered.",
+  ];
+
+  return {
+    severity: severity || severityFromScore(computeScoreFromDiff(d)),
+    headline,
+    summary,
+    changes: claims || [],
+    unchanged,
+    data_gaps,
+    limitations,
+    change_points: changePoints || [],
+    metrics: metrics || null,
   };
+}
 
-  const ok = !!cleaned.headline && changes.length > 0;
-  return { ok, cleaned, invalidRefs: Array.from(invalid) };
+// A tiny score fallback from a diff (only used if the AI omitted a valid severity
+// AND the caller didn't pass one) — keeps severity honest without the AI.
+function computeScoreFromDiff(d) {
+  const cNew = clamp01((Number(d.new) || 0) / 8);
+  const cClusters = clamp01((Number(d.new_clusters) || 0) / 3);
+  const cCorro = clamp01((Number(d.corroborated_clusters) || 0) / 2);
+  return clamp01(0.5 * cNew + 0.3 * cClusters + 0.2 * cCorro);
 }

--- a/supabase/migrations/20260721120000_area_monitors_hardening.sql
+++ b/supabase/migrations/20260721120000_area_monitors_hardening.sql
@@ -1,0 +1,335 @@
+-- ============================================================================
+--  IntMap — AREA MONITORS hardening migration (#R144)
+-- ----------------------------------------------------------------------------
+--  Fixes the R141 audit findings. Additive & idempotent on top of
+--  20260721090000_area_monitors.sql. No DROP TABLE / DROP COLUMN / data DELETE.
+--
+--  WHY (the non-obvious prod truth):
+--    In production, Supabase's schema-wide DEFAULT PRIVILEGES grant EVERY role
+--    (anon/authenticated/service_role) ALL privileges on every public table
+--    (pg_class.relacl = {authenticated=arwdDxtm,…}). RLS — not table grants — is
+--    the real protection. That means R141's *column-level* UPDATE grant on
+--    area_monitors was a NO-OP in prod: because area_monitors has an UPDATE RLS
+--    policy (own rows), a logged-in user could UPDATE ANY column on their own
+--    monitor, including the run-state lock/counters and next_run_at. (pgTAP ran
+--    on vanilla CI Postgres that lacks those default grants, so it never caught
+--    it.) The durable fix is a BEFORE UPDATE TRIGGER that freezes the run-state
+--    columns for anyone who isn't the service_role runner — robust regardless of
+--    what the grants happen to be. We ALSO tighten the grants (defense in depth).
+--
+--  THIS MIGRATION ADDS
+--    1. monitor_seen_items — a lightweight, long-lived per-item history so a
+--       "past 30 days" comparison actually references 30 days of observations,
+--       independent of per-run evidence pruning (Section 2).
+--    2. tg_monitors_guard_state — BEFORE UPDATE guard that (a) freezes run-state
+--       columns for non-runner callers and (b) recomputes next_run_at safely on
+--       enable/interval changes, so a user can never hand-pick their run time
+--       (Section 7). Plus grant tightening as belt-and-suspenders.
+--    3. monitor_claim_one — atomic single-monitor claim (UPDATE…WHERE…RETURNING)
+--       so two concurrent "Run now" requests can never both succeed (Section 3).
+--    4. monitor_finalize / monitor_commit_report — finalize a run + (optionally)
+--       persist its report + update the monitor meta in ONE transaction, so a
+--       partial DB failure can never leave "report_generated=true" without a
+--       report, or success without a run (Section 5).
+--    5. monitor_limit_self + revoke monitor_limit(uuid) from users — so a user
+--       can read their OWN cap but cannot probe anyone else's plan/admin state by
+--       passing an arbitrary UUID (Section 8).
+-- ============================================================================
+
+begin;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  1. monitor_seen_items — the long-lived per-item observation ledger.
+--     ONE row per (monitor, source_type, dedup_key). first_seen_at is when the
+--     monitor first ever saw the item; last_seen_at is the most recent sighting.
+--     This is what makes "past 30 days" real: novelty is "not in this ledger yet"
+--     — cap-churn and per-run evidence pruning cannot fabricate a change.
+-- ─────────────────────────────────────────────────────────────────────────────
+create table if not exists public.monitor_seen_items (
+  id            uuid primary key default gen_random_uuid(),
+  monitor_id    uuid not null references public.area_monitors(id) on delete cascade,
+  user_id       uuid not null references auth.users(id) on delete cascade,  -- denormalized for RLS
+  source_type   text not null,
+  dedup_key     text not null,
+  title         text,
+  source_name   text,
+  source_url    text,
+  observed_at   timestamptz,                      -- event/publication time
+  lng           double precision,
+  lat           double precision,
+  first_seen_at timestamptz not null default now(),
+  last_seen_at  timestamptz not null default now(),
+  seen_count    integer     not null default 1,
+  metadata      jsonb,
+  unique (monitor_id, source_type, dedup_key)
+);
+comment on table public.monitor_seen_items is
+  '(#R144) Long-lived per-item observation ledger per monitor (one row per unique dedup_key). Powers the "past N days" baseline and cap-proof novelty. Written only by the service_role runner; owner-only SELECT via RLS. Cascades on monitor/user delete.';
+
+create index if not exists idx_monseen_monitor      on public.monitor_seen_items (monitor_id, source_type);
+create index if not exists idx_monseen_firstseen    on public.monitor_seen_items (monitor_id, first_seen_at desc);
+create index if not exists idx_monseen_lastseen     on public.monitor_seen_items (monitor_id, last_seen_at);
+create index if not exists idx_monseen_user         on public.monitor_seen_items (user_id);
+
+alter table public.monitor_seen_items enable row level security;
+-- READ own only; no write policy AND (below) no write grant → users cannot write
+-- it at all. Only the service_role runner (which bypasses RLS) populates it.
+drop policy if exists monseen_select_own on public.monitor_seen_items;
+create policy monseen_select_own on public.monitor_seen_items
+  for select to authenticated using (user_id = (select auth.uid()));
+
+grant select on public.monitor_seen_items to authenticated;
+grant all    on public.monitor_seen_items to service_role;
+-- Belt-and-suspenders against the schema-wide default ALL grant: strip writes.
+revoke insert, update, delete, truncate on public.monitor_seen_items from anon, authenticated;
+
+-- Add it to realtime (idempotent) so the UI can reflect history if it wants.
+do $$
+begin
+  if exists (select 1 from pg_publication where pubname = 'supabase_realtime')
+     and not exists (select 1 from pg_publication_tables
+        where pubname='supabase_realtime' and schemaname='public' and tablename='monitor_seen_items') then
+    execute 'alter publication supabase_realtime add table public.monitor_seen_items';
+  end if;
+end;
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  2. RUN-STATE GUARD — the real (grant-independent) protection for the run-state
+--     columns and next_run_at. Fires BEFORE UPDATE on area_monitors. The runner
+--     (service_role) is exempt; every other caller has the run-state columns
+--     pinned to their OLD values, and next_run_at recomputed under strict rules.
+--     next_run_at on enable/interval change = greatest(now, last_run+interval),
+--     so pause→resume or shrinking the interval can never jump the schedule below
+--     the configured cadence (and never below the 30-min floor).
+-- ─────────────────────────────────────────────────────────────────────────────
+create or replace function public.tg_monitors_guard_state()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_role text := coalesce(nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role', '');
+  v_int  integer := greatest(coalesce(new.interval_minutes, 360), 30);
+begin
+  -- service_role (the runner) or a direct trusted DB session (no JWT → '', e.g.
+  -- migrations / pg_cron running as postgres) may set anything.
+  if v_role = 'service_role' or v_role = '' then
+    return new;
+  end if;
+
+  -- Everyone else: run-state columns are read-only (pin to OLD).
+  new.running_since        := old.running_since;
+  new.last_run_at          := old.last_run_at;
+  new.run_count            := old.run_count;
+  new.last_status          := old.last_status;
+  new.last_change_severity := old.last_change_severity;
+  new.last_report_id       := old.last_report_id;
+
+  -- next_run_at is server-owned: recompute only on an enable or interval change,
+  -- and never earlier than one interval after the last run (schedule can't be
+  -- hand-picked or reset by pause/resume churn). Otherwise it stays put.
+  if new.enabled is not true then
+    new.next_run_at := old.next_run_at;                       -- paused: irrelevant, frozen
+  elsif (old.enabled is not true) or (new.interval_minutes is distinct from old.interval_minutes) then
+    new.next_run_at := greatest(now(),
+                                coalesce(old.last_run_at, old.created_at, now()) + make_interval(mins => v_int));
+  else
+    new.next_run_at := old.next_run_at;                       -- config-only edit: frozen
+  end if;
+  return new;
+end;
+$$;
+comment on function public.tg_monitors_guard_state() is
+  '(#R144) BEFORE UPDATE guard: freezes run-state columns and server-owns next_run_at for any caller that is not the service_role runner (grant-independent protection). Recomputes next_run_at on enable/interval change as greatest(now, last_run+interval).';
+
+drop trigger if exists trg_monitors_guard on public.area_monitors;
+create trigger trg_monitors_guard
+  before update on public.area_monitors
+  for each row execute function public.tg_monitors_guard_state();
+
+-- Grant tightening (defense in depth on top of the trigger). Remove the blanket
+-- table-level UPDATE the Supabase default privileges hand to users, and re-grant
+-- ONLY the user-editable config columns — NOT next_run_at, NOT the run-state.
+revoke update on public.area_monitors from anon, authenticated;
+revoke insert, delete, truncate, references, trigger on public.area_monitors from anon;
+grant update (name, geometry, geometry_kind, center_lng, center_lat, radius_km,
+              bbox, area_label, sources, comparison, sensitivity, interval_minutes,
+              enabled) on public.area_monitors to authenticated;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  3. ATOMIC MANUAL CLAIM — the single-statement UPDATE…WHERE…RETURNING that
+--     makes "Run now" concurrency-safe. Ownership + enabled + lock-free-or-stale
+--     + cooldown are ALL in the WHERE, so two concurrent requests can never both
+--     claim. service_role-only (the runner calls it with the verified user id).
+--     Returns a claim flag + an honest reason (for the UI) + the monitor row.
+-- ─────────────────────────────────────────────────────────────────────────────
+create or replace function public.monitor_claim_one(
+  p_monitor_id uuid,
+  p_user_id    uuid,
+  p_cooldown_seconds integer default 30,
+  p_stale_minutes    integer default 15
+)
+returns table(claimed boolean, reason text, monitor jsonb)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare m public.area_monitors;
+begin
+  update public.area_monitors a
+     set running_since = now()
+   where a.id = p_monitor_id
+     and a.user_id = p_user_id
+     and a.enabled = true
+     and (a.running_since is null or a.running_since < now() - make_interval(mins => greatest(p_stale_minutes, 1)))
+     and (a.last_run_at   is null or a.last_run_at   < now() - make_interval(secs => greatest(p_cooldown_seconds, 0)))
+   returning a.* into m;
+  if found then
+    claimed := true; reason := 'claimed'; monitor := to_jsonb(m); return next; return;
+  end if;
+
+  -- Not claimed — diagnose WHY (own-row only; never leak another user's row).
+  select a.* into m from public.area_monitors a where a.id = p_monitor_id and a.user_id = p_user_id;
+  if not found then
+    claimed := false; reason := 'not_found'; monitor := null; return next; return;
+  end if;
+  if m.enabled is not true then
+    reason := 'disabled';
+  elsif m.running_since is not null and m.running_since >= now() - make_interval(mins => greatest(p_stale_minutes, 1)) then
+    reason := 'already_running';
+  elsif m.last_run_at is not null and m.last_run_at >= now() - make_interval(secs => greatest(p_cooldown_seconds, 0)) then
+    reason := 'cooldown';
+  else
+    reason := 'unavailable';
+  end if;
+  claimed := false; monitor := to_jsonb(m); return next; return;
+end;
+$$;
+comment on function public.monitor_claim_one(uuid, uuid, integer, integer) is
+  '(#R144) Atomically claim ONE due, owned, unlocked, cooled-down monitor (UPDATE…WHERE…RETURNING). Concurrency-safe "Run now". service_role only; returns {claimed, reason, monitor}.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  4. TRANSACTIONAL FINALIZE — write the run result + (optionally) the report +
+--     the monitor meta together, so a partial failure rolls the whole thing back.
+--     No external API calls happen inside (the runner does the AI call BEFORE and
+--     passes the already-built report in). service_role only.
+-- ─────────────────────────────────────────────────────────────────────────────
+create or replace function public.monitor_finalize(
+  p_run uuid, p_mon uuid, run_patch jsonb, mon_patch jsonb
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  update public.monitor_runs r set
+    status           = coalesce(run_patch->>'status', r.status),
+    finished_at      = now(),
+    duration_ms      = coalesce((run_patch->>'duration_ms')::int, r.duration_ms),
+    sources_ok       = coalesce((select array(select jsonb_array_elements_text(run_patch->'sources_ok'))), r.sources_ok),
+    sources_failed   = coalesce((select array(select jsonb_array_elements_text(run_patch->'sources_failed'))), r.sources_failed),
+    snapshot         = coalesce(run_patch->'snapshot', r.snapshot),
+    diff             = coalesce(run_patch->'diff', r.diff),
+    change_score     = coalesce((run_patch->>'change_score')::numeric, r.change_score),
+    report_generated = coalesce((run_patch->>'report_generated')::boolean, r.report_generated),
+    report_id        = coalesce((run_patch->>'report_id')::uuid, r.report_id),
+    ai_used          = coalesce((run_patch->>'ai_used')::boolean, r.ai_used),
+    ai_skip_reason   = coalesce(run_patch->>'ai_skip_reason', r.ai_skip_reason),
+    ai_provider      = coalesce(run_patch->>'ai_provider', r.ai_provider),
+    ai_model         = coalesce(run_patch->>'ai_model', r.ai_model),
+    error_category   = run_patch->>'error_category',
+    error_detail     = run_patch->>'error_detail',
+    retryable        = coalesce((run_patch->>'retryable')::boolean, r.retryable),
+    evidence_count   = coalesce((run_patch->>'evidence_count')::int, r.evidence_count)
+  where r.id = p_run;
+
+  update public.area_monitors m set
+    running_since        = null,
+    last_run_at          = coalesce((mon_patch->>'last_run_at')::timestamptz, m.last_run_at),
+    next_run_at          = coalesce((mon_patch->>'next_run_at')::timestamptz, m.next_run_at),
+    run_count            = coalesce((mon_patch->>'run_count')::int, m.run_count),
+    last_status          = coalesce(mon_patch->>'last_status', m.last_status),
+    last_change_severity = coalesce(mon_patch->>'last_change_severity', m.last_change_severity),
+    last_report_id       = coalesce((mon_patch->>'last_report_id')::uuid, m.last_report_id)
+  where m.id = p_mon;
+end;
+$$;
+comment on function public.monitor_finalize(uuid, uuid, jsonb, jsonb) is
+  '(#R144) Atomically finalize a run + update its monitor meta (one transaction, no external calls). Always clears running_since (releases the lock). service_role only.';
+
+create or replace function public.monitor_commit_report(
+  p_run uuid, p_mon uuid, p_user uuid, report jsonb, run_patch jsonb, mon_patch jsonb
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare v_id uuid;
+begin
+  insert into public.monitor_reports
+    (monitor_id, run_id, user_id, severity, headline, summary, changes, unchanged,
+     data_gaps, limitations, metrics, change_points, ai_provider, ai_model, prompt_version)
+  values
+    (p_mon, p_run, p_user,
+     coalesce(report->>'severity', 'low'),
+     coalesce(report->>'headline', ''),
+     report->>'summary',
+     coalesce(report->'changes', '[]'::jsonb),
+     coalesce(report->'unchanged', '[]'::jsonb),
+     coalesce(report->'data_gaps', '[]'::jsonb),
+     coalesce(report->'limitations', '[]'::jsonb),
+     report->'metrics',
+     report->'change_points',
+     report->>'ai_provider', report->>'ai_model', report->>'prompt_version')
+  returning id into v_id;
+
+  -- Fold the fresh report id into the patches and finalize in the SAME txn.
+  perform public.monitor_finalize(
+    p_run, p_mon,
+    run_patch || jsonb_build_object('report_generated', true, 'report_id', v_id::text),
+    mon_patch || jsonb_build_object('last_report_id', v_id::text)
+  );
+  return v_id;
+end;
+$$;
+comment on function public.monitor_commit_report(uuid, uuid, uuid, jsonb, jsonb, jsonb) is
+  '(#R144) Insert a report AND finalize its run AND update the monitor meta in ONE transaction. If any part fails the whole thing rolls back — no "report_generated=true" without a report. service_role only.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+--  5. PLAN-LIMIT ATTRIBUTE-LEAK FIX. monitor_limit(uuid) stays (the insert
+--     trigger + service_role need it) but users can no longer call it with an
+--     arbitrary UUID to infer someone else's plan/admin state. They call
+--     monitor_limit_self(), which only ever reads their OWN cap.
+-- ─────────────────────────────────────────────────────────────────────────────
+create or replace function public.monitor_limit_self()
+returns integer
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select public.monitor_limit((select auth.uid()));
+$$;
+comment on function public.monitor_limit_self() is
+  '(#R144) The caller''s OWN monitor cap. Safe self-only replacement for user-facing use of monitor_limit(uuid), which can no longer be called with an arbitrary UUID to probe another user''s plan/admin state.';
+
+-- The trigger (SECURITY DEFINER, owned by postgres) can still call monitor_limit;
+-- users cannot (they use monitor_limit_self). This closes the enumeration.
+revoke execute on function public.monitor_limit(uuid) from public, anon, authenticated;
+grant  execute on function public.monitor_limit(uuid) to service_role;
+grant  execute on function public.monitor_limit_self() to authenticated, service_role;
+
+-- New RPCs are runner-only (users must never claim/finalize/forge).
+revoke execute on function public.monitor_claim_one(uuid, uuid, integer, integer)          from public, anon, authenticated;
+grant  execute on function public.monitor_claim_one(uuid, uuid, integer, integer)          to service_role;
+revoke execute on function public.monitor_finalize(uuid, uuid, jsonb, jsonb)               from public, anon, authenticated;
+grant  execute on function public.monitor_finalize(uuid, uuid, jsonb, jsonb)               to service_role;
+revoke execute on function public.monitor_commit_report(uuid, uuid, uuid, jsonb, jsonb, jsonb) from public, anon, authenticated;
+grant  execute on function public.monitor_commit_report(uuid, uuid, uuid, jsonb, jsonb, jsonb) to service_role;
+revoke execute on function public.tg_monitors_guard_state() from public, anon, authenticated;
+
+commit;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -170,3 +170,13 @@ update public.area_monitors
 update public.monitor_runs
    set report_id = '10000000-0000-0000-0000-0000000000a3'
  where id = '10000000-0000-0000-0000-0000000000a2';
+
+-- (#R144) Long-lived per-item ledger row for A's monitor (the "past N days"
+-- baseline + cap-proof novelty source). Owner-only RLS; used by 04_monitors_test.
+insert into public.monitor_seen_items
+  (monitor_id, user_id, source_type, dedup_key, title, source_name, source_url, observed_at, lng, lat, first_seen_at, last_seen_at)
+values
+  ('10000000-0000-0000-0000-0000000000a1', '11111111-1111-1111-1111-111111111111',
+   'news', 'news:example.test/news-en-1', 'Synthetic headline EN', 'Test Wire',
+   'https://example.test/news-en-1', now() - interval '1 hour', 139.69, 35.68, now() - interval '1 hour', now())
+on conflict (monitor_id, source_type, dedup_key) do nothing;

--- a/supabase/tests/04_monitors_test.sql
+++ b/supabase/tests/04_monitors_test.sql
@@ -38,6 +38,15 @@ exception
 end;
 $$;
 
+-- (#R144) SIMULATE PRODUCTION. In real Supabase the schema-wide default privileges
+-- grant `authenticated` full table-level UPDATE on every public table (RLS is the
+-- real protection), which makes column-level UPDATE grants a NO-OP. We reproduce
+-- that here so the run-state protection is tested against the PROD reality — i.e.
+-- it must hold via the tg_monitors_guard_state TRIGGER, not merely via a column
+-- grant that prod ignores. Without this line the migration's column grant would
+-- mask the very hole R144 fixes.
+grant update on public.area_monitors to authenticated;
+
 -- ─────────────────────────── ANON (logged out) ─────────────────────────────
 select set_config('request.jwt.claims', '{"role":"anon"}', true);
 set local role anon;
@@ -45,6 +54,7 @@ select _sel('anon_monitors', 'select count(*) from public.area_monitors');    --
 select _sel('anon_runs',     'select count(*) from public.monitor_runs');      -- DENIED
 select _sel('anon_evidence', 'select count(*) from public.monitor_evidence');  -- DENIED
 select _sel('anon_reports',  'select count(*) from public.monitor_reports');   -- DENIED
+select _sel('anon_seen',     'select count(*) from public.monitor_seen_items');-- DENIED (#R144)
 reset role;
 
 -- ─────────────────────────── USER A (authenticated) ────────────────────────
@@ -61,22 +71,43 @@ select _sel('a_own_rep',   'select count(*) from public.monitor_reports');      
 select _dml('a_forge_run', 'insert into public.monitor_runs(monitor_id,user_id,status) values (''10000000-0000-0000-0000-0000000000a1'',''11111111-1111-1111-1111-111111111111'',''success'')');
 select _dml('a_forge_ev',  'insert into public.monitor_evidence(run_id,monitor_id,user_id,ev_key,source_type,dedup_key) values (''10000000-0000-0000-0000-0000000000a2'',''10000000-0000-0000-0000-0000000000a1'',''11111111-1111-1111-1111-111111111111'',''evX'',''news'',''k'')');
 select _dml('a_forge_rep', 'insert into public.monitor_reports(monitor_id,run_id,user_id,headline) values (''10000000-0000-0000-0000-0000000000a1'',''10000000-0000-0000-0000-0000000000a2'',''11111111-1111-1111-1111-111111111111'',''fake'')');
--- tamper with own monitor's RUN-STATE columns → DENIED (column-level grant excludes them)
-select _dml('a_set_lock',   'update public.area_monitors set running_since=now() where id=''10000000-0000-0000-0000-0000000000a1''');
-select _dml('a_set_count',  'update public.area_monitors set run_count=999 where id=''10000000-0000-0000-0000-0000000000a1''');
-select _dml('a_set_status', 'update public.area_monitors set last_status=''success'' where id=''10000000-0000-0000-0000-0000000000a1''');
--- edit own monitor's CONFIG columns → allowed
-select _dml('a_edit_name',  'update public.area_monitors set name=''A2'' where id=''10000000-0000-0000-0000-0000000000a1''');   -- ROWS:1
-select _dml('a_toggle',     'update public.area_monitors set enabled=false where id=''10000000-0000-0000-0000-0000000000a1''');-- ROWS:1
+-- (#R144) tamper with own monitor's RUN-STATE columns. With the prod-like table
+-- grant above the UPDATE reaches SQL (ROWS:1), but the guard TRIGGER pins the
+-- run-state columns to their OLD values — so the stored value never changes.
+select _dml('a_set_lock',    'update public.area_monitors set running_since=now() where id=''10000000-0000-0000-0000-0000000000a1''');
+select _sel('a_lock_val',    'select coalesce(running_since::text,''<null>'') from public.area_monitors where id=''10000000-0000-0000-0000-0000000000a1''');  -- still <null>
+select _dml('a_set_count',   'update public.area_monitors set run_count=999 where id=''10000000-0000-0000-0000-0000000000a1''');
+select _sel('a_count_val',   'select run_count::text from public.area_monitors where id=''10000000-0000-0000-0000-0000000000a1''');   -- still 0
+select _dml('a_set_status',  'update public.area_monitors set last_status=''hacked'' where id=''10000000-0000-0000-0000-0000000000a1''');
+select _sel('a_status_val',  'select coalesce(last_status,''<null>'') from public.area_monitors where id=''10000000-0000-0000-0000-0000000000a1''');   -- still <null>
+-- (#R144) user CANNOT hand-pick the execution time: injecting a past next_run_at is
+-- ignored (a config-only edit leaves it frozen → still in the future).
+select _dml('a_set_next',    'update public.area_monitors set next_run_at=''2000-01-01T00:00:00Z'' where id=''10000000-0000-0000-0000-0000000000a1''');
+select _sel('a_next_future', 'select (next_run_at > now() - interval ''2 minutes'')::text from public.area_monitors where id=''10000000-0000-0000-0000-0000000000a1''');  -- true (NOT the year-2000 injection)
+-- edit own monitor's CONFIG columns → allowed (name/enabled). interval is editable,
+-- but next_run_at is SERVER-recomputed (not the injected past value).
+select _dml('a_edit_name',   'update public.area_monitors set name=''A2'' where id=''10000000-0000-0000-0000-0000000000a1''');   -- ROWS:1
+select _dml('a_set_interval','update public.area_monitors set interval_minutes=30, next_run_at=''2000-01-01T00:00:00Z'' where id=''10000000-0000-0000-0000-0000000000a1''');
+select _sel('a_interval_val','select interval_minutes::text from public.area_monitors where id=''10000000-0000-0000-0000-0000000000a1''');   -- 30 (config changed)
+select _sel('a_next_recomp', 'select (next_run_at > now() - interval ''2 minutes'')::text from public.area_monitors where id=''10000000-0000-0000-0000-0000000000a1''');  -- true (recomputed, NOT year-2000)
+select _dml('a_toggle',      'update public.area_monitors set enabled=false where id=''10000000-0000-0000-0000-0000000000a1''');-- ROWS:1
 -- cannot touch B's monitor
 select _dml('a_edit_b_mon', 'update public.area_monitors set name=''HACK'' where id=''20000000-0000-0000-0000-0000000000b1''');-- ROWS:0
 select _dml('a_del_b_mon',  'delete from public.area_monitors where id=''20000000-0000-0000-0000-0000000000b1''');             -- ROWS:0
 -- cannot create a monitor owned by B (WITH CHECK)
 select _dml('a_ins_as_b',   'insert into public.area_monitors(user_id,name,geometry) values (''22222222-2222-2222-2222-222222222222'',''spoof'',''{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}''::jsonb)');
--- cannot call the service-role claim RPC (quota/lock bypass blocked)
+-- cannot call the service-role claim RPCs (quota/lock bypass blocked)
 select _sel('a_claim',      'select count(*) from public.monitor_claim_due(5,15)');   -- DENIED
--- plan limit function about self is readable (free → 5) — the billing hook
-select _sel('a_limit',      'select public.monitor_limit(''11111111-1111-1111-1111-111111111111'')::text'); -- 5
+select _sel('a_claim_one',  'select claimed from public.monitor_claim_one(''10000000-0000-0000-0000-0000000000a1'',''11111111-1111-1111-1111-111111111111'')'); -- DENIED (runner-only)
+-- (#R144) plan-limit attribute-leak fix: OWN cap via the self RPC is fine, but a
+-- user CANNOT call monitor_limit(uuid) with an arbitrary UUID to probe another
+-- user's plan/admin state (execute revoked → DENIED).
+select _sel('a_limit_self', 'select public.monitor_limit_self()::text');                                        -- 5 (own, free)
+select _sel('a_limit_uuid', 'select public.monitor_limit(''11111111-1111-1111-1111-111111111111'')::text');     -- DENIED (even about self, the raw fn is revoked)
+select _sel('a_limit_probe','select public.monitor_limit(''33333333-3333-3333-3333-333333333333'')::text');     -- DENIED (cannot probe admin''s plan)
+-- (#R144) seen-items ledger: A reads only its own rows.
+select _sel('a_seen_own',   'select count(*) from public.monitor_seen_items where monitor_id=''10000000-0000-0000-0000-0000000000a1''');  -- 1 (seeded)
+select _sel('a_seen_all',   'select count(*) from public.monitor_seen_items');                                  -- 1 (only own)
 reset role;
 
 -- ─────────────────────────── USER B (authenticated) ────────────────────────
@@ -87,6 +118,7 @@ select _sel('b_a_mon',     'select count(*) from public.area_monitors where id='
 select _sel('b_runs',      'select count(*) from public.monitor_runs');      -- 0 (A''s run invisible)
 select _sel('b_ev',        'select count(*) from public.monitor_evidence');  -- 0
 select _sel('b_reports',   'select count(*) from public.monitor_reports');   -- 0
+select _sel('b_seen',      'select count(*) from public.monitor_seen_items');-- 0 (A''s ledger invisible, #R144)
 reset role;
 
 -- ─────────────────────────── ADMIN — no backdoor into private monitors ─────
@@ -96,7 +128,7 @@ select set_config('request.jwt.claims', '{"sub":"33333333-3333-3333-3333-3333333
 set local role authenticated;
 select _sel('admin_mon',   'select count(*) from public.area_monitors');     -- 0 (admin owns none; no backdoor)
 select _sel('admin_rep',   'select count(*) from public.monitor_reports');   -- 0
-select _sel('admin_limit', 'select public.monitor_limit(''33333333-3333-3333-3333-333333333333'')::text'); -- 200 (unlimited plan)
+select _sel('admin_limit', 'select public.monitor_limit_self()::text');      -- 200 (own, unlimited plan; #R144 self-only)
 reset role;
 
 -- ─────────────────────────── SERVICE ROLE (the runner) ─────────────────────
@@ -107,6 +139,21 @@ select _sel('svc_all_mon', 'select count(*) from public.area_monitors');        
 select _sel('svc_all_rep', 'select count(*) from public.monitor_reports');               -- 1
 select _dml('svc_ins_run', 'insert into public.monitor_runs(monitor_id,user_id,status,trigger) values (''20000000-0000-0000-0000-0000000000b1'',''22222222-2222-2222-2222-222222222222'',''success_no_change'',''schedule'')'); -- ROWS:1
 select _sel('svc_claim',   'select count(*) from public.monitor_claim_due(5,15)');       -- 0 (seed monitors due in +1h → none claimed)
+-- (#R144) ATOMIC MANUAL CLAIM (monitor_claim_one). Make B due + unlocked, then:
+select _dml('svc_b_due',      'update public.area_monitors set next_run_at=now()-interval ''1 minute'', running_since=null, enabled=true, last_run_at=null where id=''20000000-0000-0000-0000-0000000000b1''');
+select _sel('svc_claim1',     'select claimed||'':''||reason from public.monitor_claim_one(''20000000-0000-0000-0000-0000000000b1'',''22222222-2222-2222-2222-222222222222'')');  -- true:claimed (locks it)
+select _sel('svc_claim2',     'select claimed||'':''||reason from public.monitor_claim_one(''20000000-0000-0000-0000-0000000000b1'',''22222222-2222-2222-2222-222222222222'')');  -- false:already_running (no double success)
+select _sel('svc_claim_owner','select claimed||'':''||reason from public.monitor_claim_one(''20000000-0000-0000-0000-0000000000b1'',''11111111-1111-1111-1111-111111111111'')');  -- false:not_found (wrong owner)
+select _sel('svc_claim_cron', 'select count(*) from public.monitor_claim_due(5,15) where id=''20000000-0000-0000-0000-0000000000b1''');  -- 0 (cron won''t grab a manually-locked, due monitor)
+-- cooldown: reset the lock but stamp a very recent last_run_at → claim refused.
+select _dml('svc_b_cooldown', 'update public.area_monitors set running_since=null, last_run_at=now() where id=''20000000-0000-0000-0000-0000000000b1''');
+select _sel('svc_claim_cool', 'select claimed||'':''||reason from public.monitor_claim_one(''20000000-0000-0000-0000-0000000000b1'',''22222222-2222-2222-2222-222222222222'',30,15)');  -- false:cooldown
+-- stale lock IS reclaimable (running_since older than p_stale_minutes).
+select _dml('svc_b_stale',    'update public.area_monitors set running_since=now()-interval ''30 minutes'', last_run_at=null where id=''20000000-0000-0000-0000-0000000000b1''');
+select _sel('svc_claim_stale','select claimed||'':''||reason from public.monitor_claim_one(''20000000-0000-0000-0000-0000000000b1'',''22222222-2222-2222-2222-222222222222'',30,15)');  -- true:claimed (stale reclaimed)
+-- disabled monitor cannot be claimed.
+select _dml('svc_b_disable',  'update public.area_monitors set enabled=false, running_since=null, last_run_at=null where id=''20000000-0000-0000-0000-0000000000b1''');
+select _sel('svc_claim_dis',  'select claimed||'':''||reason from public.monitor_claim_one(''20000000-0000-0000-0000-0000000000b1'',''22222222-2222-2222-2222-222222222222'')');  -- false:disabled
 reset role;
 
 -- ─────────────────────────── LIMIT ENFORCEMENT (LAST — mutates A''s count) ──
@@ -127,6 +174,7 @@ select is((select v from _cap where k='anon_monitors'), 'DENIED', 'anon cannot r
 select is((select v from _cap where k='anon_runs'),     'DENIED', 'anon cannot read monitor_runs');
 select is((select v from _cap where k='anon_evidence'), 'DENIED', 'anon cannot read monitor_evidence');
 select is((select v from _cap where k='anon_reports'),  'DENIED', 'anon cannot read monitor_reports');
+select is((select v from _cap where k='anon_seen'),     'DENIED', 'anon cannot read monitor_seen_items (#R144)');
 -- user A isolation + capability
 select is((select v from _cap where k='a_own_mon'), '1',      'A reads own monitor');
 select is((select v from _cap where k='a_all_mon'), '1',      'A sees only own monitors');
@@ -137,31 +185,50 @@ select is((select v from _cap where k='a_own_rep'), '1',      'A reads own repor
 select is((select v from _cap where k='a_forge_run'),'DENIED','A CANNOT forge a run result');
 select is((select v from _cap where k='a_forge_ev'), 'DENIED','A CANNOT forge evidence');
 select is((select v from _cap where k='a_forge_rep'),'DENIED','A CANNOT forge a report');
-select is((select v from _cap where k='a_set_lock'), 'DENIED','A CANNOT touch the run lock (running_since)');
-select is((select v from _cap where k='a_set_count'),'DENIED','A CANNOT forge run_count on its own monitor');
-select is((select v from _cap where k='a_set_status'),'DENIED','A CANNOT forge last_status on its own monitor');
+-- (#R144) run-state guard TRIGGER — the UPDATE lands (ROWS:1, prod-like table
+-- grant) but the value is pinned to OLD (the true prod-grade protection).
+select is((select v from _cap where k='a_lock_val'),  '<null>', 'A CANNOT change running_since (trigger freezes it → seed <null>)');
+select is((select v from _cap where k='a_count_val'), '1',      'A CANNOT change run_count (trigger freezes it → seed 1)');
+select is((select v from _cap where k='a_status_val'),'success','A CANNOT change last_status (trigger freezes it → seed success)');
+select is((select v from _cap where k='a_next_future'),'true', 'A CANNOT inject a past next_run_at (config edit keeps it in the future)');
+select is((select v from _cap where k='a_interval_val'),'30',  'A CAN change interval_minutes (a config column)');
+select is((select v from _cap where k='a_next_recomp'),'true', 'next_run_at is SERVER-recomputed on interval change, not user-picked');
 select is((select v from _cap where k='a_edit_name'),'ROWS:1', 'A can rename its own monitor');
 select is((select v from _cap where k='a_toggle'),   'ROWS:1', 'A can enable/disable its own monitor');
 select is((select v from _cap where k='a_edit_b_mon'),'ROWS:0','A cannot edit B''s monitor');
 select is((select v from _cap where k='a_del_b_mon'),'ROWS:0', 'A cannot delete B''s monitor');
 select is((select v from _cap where k='a_ins_as_b'), 'DENIED', 'A cannot create a monitor owned by B (WITH CHECK)');
 select is((select v from _cap where k='a_claim'),    'DENIED', 'A cannot call monitor_claim_due (runner-only)');
-select is((select v from _cap where k='a_limit'),    '5',      'A (free) monitor limit is 5');
+select is((select v from _cap where k='a_claim_one'),'DENIED', 'A cannot call monitor_claim_one (runner-only, #R144)');
+select is((select v from _cap where k='a_limit_self'),'5',     'A can read OWN cap via monitor_limit_self (free → 5)');
+select is((select v from _cap where k='a_limit_uuid'),'DENIED','A cannot call raw monitor_limit(uuid) (#R144)');
+select is((select v from _cap where k='a_limit_probe'),'DENIED','A cannot probe another user''s plan via monitor_limit(uuid) (#R144)');
+select is((select v from _cap where k='a_seen_own'), '1',      'A reads its own seen-items ledger row');
+select is((select v from _cap where k='a_seen_all'), '1',      'A sees only its own seen-items (#R144)');
 -- user B isolation
 select is((select v from _cap where k='b_own_mon'), '1', 'B reads own monitor');
 select is((select v from _cap where k='b_a_mon'),   '0', 'B cannot read A''s monitor');
 select is((select v from _cap where k='b_runs'),    '0', 'B cannot read A''s runs');
 select is((select v from _cap where k='b_ev'),      '0', 'B cannot read A''s evidence');
 select is((select v from _cap where k='b_reports'), '0', 'B cannot read A''s reports');
+select is((select v from _cap where k='b_seen'),    '0', 'B cannot read A''s seen-items ledger (#R144)');
 -- admin: no private-monitor backdoor
 select is((select v from _cap where k='admin_mon'),   '0',   'admin has NO backdoor into private monitors');
 select is((select v from _cap where k='admin_rep'),   '0',   'admin cannot read others'' reports');
-select is((select v from _cap where k='admin_limit'), '200', 'admin/unlimited monitor limit is 200');
+select is((select v from _cap where k='admin_limit'), '200', 'admin/unlimited own monitor limit is 200 (self-only, #R144)');
 -- service role
 select is((select v from _cap where k='svc_all_mon'), '2',      'service_role sees all monitors (bypass RLS)');
 select is((select v from _cap where k='svc_all_rep'), '1',      'service_role sees all reports');
 select is((select v from _cap where k='svc_ins_run'), 'ROWS:1', 'service_role (runner) can write a run');
 select is((select v from _cap where k='svc_claim'),   '0',      'monitor_claim_due returns nothing when no monitor is due');
+-- (#R144) atomic manual claim
+select is((select v from _cap where k='svc_claim1'),     'true:claimed',          'monitor_claim_one claims a due, unlocked, owned monitor');
+select is((select v from _cap where k='svc_claim2'),     'false:already_running', 'a second concurrent claim is refused — never two successes');
+select is((select v from _cap where k='svc_claim_owner'),'false:not_found',       'a non-owner cannot claim the monitor');
+select is((select v from _cap where k='svc_claim_cron'), '0',                     'cron claim skips a monitor a manual claim already locked (no conflict)');
+select is((select v from _cap where k='svc_claim_cool'), 'false:cooldown',        'claim refused during the manual cooldown');
+select is((select v from _cap where k='svc_claim_stale'),'true:claimed',          'a stale lock is reclaimable');
+select is((select v from _cap where k='svc_claim_dis'),  'false:disabled',        'a disabled monitor cannot be claimed');
 -- limit enforcement
 select is((select v from _cap where k='a_ins2'), 'ROWS:1',    'A insert #2 ok (under limit)');
 select is((select v from _cap where k='a_ins5'), 'ROWS:1',    'A insert #5 ok (reaches limit 5)');

--- a/tests/monitor-logic.test.mjs
+++ b/tests/monitor-logic.test.mjs
@@ -12,7 +12,8 @@ import {
   haversineKm, pointInRing, pointInGeometry, bboxOfGeometry, pointInMonitorArea,
   validGeometry, isSafeHttpUrl, normalizeNewsRow, dedupeEvidence, diffKeys,
   clusterPoints, distinctPublishers, buildNewsSnapshot, computeChangeScore,
-  severityFromScore, decideAI, validateAndCleanReport,
+  severityFromScore, decideAI, validateClaims, buildReport, partitionByNovelty,
+  classifyDisappeared,
 } from "../supabase/functions/monitor-run/logic.mjs";
 
 // Square polygon covering [0,0]..[2,2].
@@ -149,41 +150,120 @@ test("decideAI — real change calls AI", () => {
   assert.equal(r.call, true);
 });
 
-test("validateAndCleanReport — drops claims citing a nonexistent evidence id", () => {
+test("validateClaims — drops claims citing a nonexistent evidence id", () => {
   const valid = new Set(["ev_1", "ev_2"]);
   const byKey = new Map([["ev_1", { lng: 1, lat: 1, label: "A" }], ["ev_2", { lng: 2, lat: 2, label: "B" }]]);
   const report = {
-    severity: "medium", headline: "Two developments", summary: "…",
+    severity: "medium",
     changes: [
       { claim: "Real claim.", evidence_ids: ["ev_1", "ev_99"] },   // ev_99 dropped, claim survives on ev_1
       { claim: "Fabricated claim.", evidence_ids: ["ev_77"] },     // no valid id → dropped entirely
     ],
-    unchanged: ["nothing else"], data_gaps: [], limitations: [],
   };
-  const { ok, cleaned, invalidRefs } = validateAndCleanReport(report, valid, byKey);
+  const { ok, claims, invalidRefs, changePoints } = validateClaims(report, valid, byKey);
   assert.equal(ok, true);
-  assert.equal(cleaned.changes.length, 1);
-  assert.deepEqual(cleaned.changes[0].evidence_ids, ["ev_1"]);
+  assert.equal(claims.length, 1);
+  assert.deepEqual(claims[0].evidence_ids, ["ev_1"]);
   assert.ok(invalidRefs.includes("ev_99") && invalidRefs.includes("ev_77"));
   // change_points synthesized from the surviving cited evidence's coords
-  assert.equal(cleaned.change_points.length, 1);
-  assert.deepEqual(cleaned.change_points[0], { lng: 1, lat: 1, label: "A", evidence_id: "ev_1" });
+  assert.equal(changePoints.length, 1);
+  assert.deepEqual(changePoints[0], { lng: 1, lat: 1, label: "A", evidence_id: "ev_1" });
 });
 
-test("validateAndCleanReport — a report with NO grounded claim is rejected", () => {
+test("validateClaims — a report with NO grounded claim is rejected", () => {
   const valid = new Set(["ev_1"]);
   const report = { headline: "All made up", changes: [{ claim: "x", evidence_ids: ["ev_nope"] }] };
-  const { ok } = validateAndCleanReport(report, valid, new Map());
+  const { ok, claims } = validateClaims(report, valid, new Map());
   assert.equal(ok, false);
+  assert.equal(claims.length, 0);
 });
 
-test("validateAndCleanReport — invalid severity is nulled (caller falls back to score)", () => {
+test("validateClaims — invalid severity is nulled (caller falls back to score)", () => {
   const valid = new Set(["ev_1"]);
   const byKey = new Map([["ev_1", { lng: 0, lat: 0, label: "" }]]);
-  const report = { severity: "apocalyptic", headline: "H", changes: [{ claim: "c", evidence_ids: ["ev_1"] }] };
-  const { ok, cleaned } = validateAndCleanReport(report, valid, byKey);
+  const report = { severity: "apocalyptic", changes: [{ claim: "c", evidence_ids: ["ev_1"] }] };
+  const { ok, severity } = validateClaims(report, valid, byKey);
   assert.equal(ok, true);
-  assert.equal(cleaned.severity, null);
+  assert.equal(severity, null);
+});
+
+// ── (#R144) Grounded report: headline/summary/unchanged/data_gaps are built from
+//    the AUTHORITATIVE diff numbers + validated claims — never from AI free text.
+test("buildReport — headline & summary are built ONLY from authoritative numbers", () => {
+  const diffOut = { new: 3, gone: 1, continuing: 2, new_clusters: 2, corroborated_clusters: 1, prev_count: 5, cur_count: 8 };
+  const claims = [{ claim: "Flooding reported near the port.", evidence_ids: ["ev_1"] }];
+  const r = buildReport({ areaLabel: "Rotterdam", diffOut, metrics: { articles: { prev: 5, cur: 8, delta: 3 } }, claims, severity: "high", changePoints: [], failSources: [] });
+  // headline uses the authoritative NEW count and the area
+  assert.match(r.headline, /^3 new reports in Rotterdam$/);
+  // summary uses the authoritative numbers verbatim (5 → 8 (+3))
+  assert.match(r.summary, /3 new items/);
+  assert.match(r.summary, /5 → 8 \(\+3\)/);
+  // continuing count → an "unchanged" line
+  assert.equal(r.unchanged.length, 1);
+  assert.match(r.unchanged[0], /2 previously-seen reports/);
+  // the AI's claims are carried through verbatim as `changes`
+  assert.deepEqual(r.changes, claims);
+  assert.equal(r.severity, "high");
+});
+
+test("buildReport — no fabricated numbers can leak: it ignores any AI-supplied text fields", () => {
+  const diffOut = { new: 1, gone: 0, continuing: 0, new_clusters: 1, corroborated_clusters: 0, prev_count: 0, cur_count: 1 };
+  // Even if a caller tried to smuggle AI headline/summary in, buildReport doesn't read them.
+  const r = buildReport({ areaLabel: "Area", diffOut, metrics: null, claims: [{ claim: "c", evidence_ids: ["ev_1"] }], severity: null, changePoints: [], failSources: [] });
+  assert.match(r.headline, /^1 new report in Area$/);         // singular, from the number
+  assert.equal(r.unchanged.length, 0);                          // continuing=0 → no unchanged line
+  assert.ok(r.severity && r.severity !== "none");              // derived from the diff, not AI
+});
+
+test("buildReport — data_gaps come ONLY from sources that actually failed", () => {
+  const diffOut = { new: 2, gone: 0, continuing: 0, new_clusters: 1, corroborated_clusters: 0, prev_count: 0, cur_count: 2 };
+  const r = buildReport({ areaLabel: "X", diffOut, metrics: null, claims: [{ claim: "c", evidence_ids: ["ev_1"] }], severity: "low", changePoints: [], failSources: ["weather", "earthquake"] });
+  assert.equal(r.data_gaps.length, 2);
+  assert.match(r.data_gaps[0], /weather source was unavailable/);
+  assert.match(r.data_gaps[1], /earthquake source was unavailable/);
+  // limitations are fixed general caveats (not factual assertions), always present
+  assert.ok(r.limitations.length >= 1);
+  assert.match(r.limitations[0], /reported subject/);
+});
+
+// ── (#R144) Ledger-based novelty: cap-proof + deterministic "new".
+test("partitionByNovelty — a re-appearing/cap-displaced item is NOT falsely new", () => {
+  const items = [{ dedup_key: "a" }, { dedup_key: "b" }, { dedup_key: "c" }];
+  const prior = new Set(["b"]);                                  // b was seen before
+  const { newItems, newKeys } = partitionByNovelty(items, prior);
+  assert.deepEqual(newKeys.sort(), ["a", "c"]);                  // only genuinely-new keys
+  assert.equal(newItems.length, 2);
+  // adding a previously-seen key to the ledger makes it non-new next time (flap-proof)
+  const { newKeys: k2 } = partitionByNovelty(items, new Set(["a", "b", "c"]));
+  assert.deepEqual(k2, []);
+});
+
+test("partitionByNovelty — result is independent of item order (deterministic set)", () => {
+  const prior = new Set(["x"]);
+  const a = partitionByNovelty([{ dedup_key: "x" }, { dedup_key: "y" }, { dedup_key: "z" }], prior).newKeys.slice().sort();
+  const b = partitionByNovelty([{ dedup_key: "z" }, { dedup_key: "x" }, { dedup_key: "y" }], prior).newKeys.slice().sort();
+  assert.deepEqual(a, b);
+  assert.deepEqual(a, ["y", "z"]);
+});
+
+test("classifyDisappeared — cap-displaced (in-window) is 'absent', not a real 'gone'; aged-out is 'expired'", () => {
+  const now = Date.parse("2026-07-20T00:00:00Z");
+  const windowStart = now - 72 * 3600 * 1000;                    // 72h news window
+  const observed = new Map([
+    ["old", "2026-07-15T00:00:00Z"],   // 5 days old → outside window → expired
+    ["fresh", "2026-07-19T12:00:00Z"], // 12h old → inside window → absent (cap), NOT meaningful
+  ]);
+  const { expired, absent } = classifyDisappeared(["old", "fresh"], new Set(), observed, windowStart);
+  assert.deepEqual(expired, ["old"]);
+  assert.deepEqual(absent, ["fresh"]);
+});
+
+test("(#R144) cap-induced churn does not create a change: novelty is stable across a shifting cap", () => {
+  // Run N ledger already knows a1..a5. A new item a6 arrives; the cap drops a5.
+  const prior = new Set(["a1", "a2", "a3", "a4", "a5"]);
+  const capped = [{ dedup_key: "a6" }, { dedup_key: "a1" }, { dedup_key: "a2" }, { dedup_key: "a3" }, { dedup_key: "a4" }]; // a5 pushed out
+  const { newKeys } = partitionByNovelty(capped, prior);
+  assert.deepEqual(newKeys, ["a6"]);                             // ONLY the genuinely-new item, not a re-shuffle
 });
 
 test("buildNewsSnapshot / distinctPublishers", () => {

--- a/tests/monitors.spec.js
+++ b/tests/monitors.spec.js
@@ -65,16 +65,20 @@ test('opening the Monitors tab (logged out) shows the login prompt, not a fake l
 test('Atlas monitor action is HONEST: never claims success when it cannot', async () => {
   const res = await page.evaluate(async () => {
     const out = {};
+    // Extract plain text via an INERT DOMParser document (never executes scripts /
+    // fires onerror, and — unlike a tag-stripping regex — can't be defeated by
+    // malformed markup; also silences CodeQL js/incomplete-multi-character-sanitization).
+    const asText = (h) => (new DOMParser().parseFromString(String(h || ''), 'text/html').body.textContent || '');
     // no area selected → must ask for one, not create
     const create0 = await window.IntMapConsole.dispatch({ type: 'monitor', op: 'create' });
-    out.createNoArea = { ok: create0.ok, txt: (create0.html || '').replace(/<[^>]+>/g, '') };
+    out.createNoArea = { ok: create0.ok, txt: asText(create0.html) };
     // list (logged out) → must say login required, not open an empty list as success
     const list0 = await window.IntMapConsole.dispatch({ type: 'monitor', op: 'list' });
-    out.listLoggedOut = { ok: list0.ok, txt: (list0.html || '').replace(/<[^>]+>/g, '') };
+    out.listLoggedOut = { ok: list0.ok, txt: asText(list0.html) };
     // with an area but logged out → login required
     if (window._radiusFromPoint) window._radiusFromPoint(139.7, 35.68);
     const create1 = await window.IntMapConsole.dispatch({ type: 'monitor', op: 'create' });
-    out.createLoggedOut = { ok: create1.ok, txt: (create1.html || '').replace(/<[^>]+>/g, '') };
+    out.createLoggedOut = { ok: create1.ok, txt: asText(create1.html) };
     return out;
   });
   expect(res.createNoArea.ok).toBe(false);
@@ -145,6 +149,44 @@ test('the create dialog is login-gated (logged out → auth modal, no create dia
   });
   expect(r.createDialog).toBe(false);   // never opens the create form when logged out
   expect(r.authModalShown).toBe(true);  // it routes to login instead
+});
+
+test('(#R144) Workspace desktop: the Monitors window has a default rect — opening ws-mode does not throw', async () => {
+  // Regression guard for R142: the R141 Monitors window had NO defRects() entry, so
+  // mkWin() got an undefined rect and clampRect(undefined) threw at every desktop
+  // ws-mode boot (silently swallowed). Prove the window is now created cleanly and
+  // that entering/leaving ws-mode raises no page errors.
+  const before = diags.pageErrors.length;
+  await page.setViewportSize({ width: 1440, height: 900 });   // ws-mode is desktop-only
+  const r = await page.evaluate(async () => {
+    const out = { hasWs: !!window.IntMapWorkspace };
+    try {
+      window.IntMapWorkspace.open();                            // enter ws-mode → builds all windows (incl. hidden Monitors)
+      await new Promise((res) => setTimeout(res, 400));
+      out.wsActive = window.IntMapWorkspace.active();
+      out.monitorsWin = !!document.querySelector('.ws-monitors');  // the window wrapper exists = mkWin succeeded (no clampRect throw)
+      out.feedStillPresent = !!document.getElementById('monitors-feed');
+      // unhide + render it in ws-mode (mobile tab code path must not run here)
+      try { window.IntMapOS.exec('tab.monitors', { source: 'test' }); } catch (e) { out.execErr = String(e && e.message || e); }
+      await new Promise((res) => setTimeout(res, 250));
+      out.monitorsRendered = !!document.querySelector('.ws-monitors .mon-wrap, .ws-monitors .mon-empty');
+    } catch (e) {
+      out.threw = String(e && e.message || e);
+    } finally {
+      try { window.IntMapWorkspace.close(); } catch (_) { /* */ }
+    }
+    return out;
+  });
+  await page.setViewportSize({ width: 675, height: 900 });     // restore the mobile-ish default for later assertions
+  const after = diags.pageErrors.length;
+  expect(r.hasWs).toBe(true);
+  expect(r.wsActive).toBe(true);
+  expect(r.monitorsWin, 'the Monitors ws-window must be created (defRects entry present)').toBe(true);
+  expect(r.feedStillPresent).toBe(true);
+  expect(r.threw, `ws-mode threw: ${r.threw}`).toBeUndefined();
+  expect(r.execErr, `tab.monitors exec threw: ${r.execErr}`).toBeUndefined();
+  expect(r.monitorsRendered, 'Monitors content renders inside its ws-window').toBe(true);
+  expect(after - before, 'no new page errors during ws-mode open/close').toBe(0);
 });
 
 test('no uncaught page errors and no non-benign console errors', async () => {


### PR DESCRIPTION
Fixes the R141 Area Monitors implementation-audit findings, verified on the live prod DB (not just designed). R142/R143 preserved. All migration/function changes are **already applied to prod** (see below); this PR lands the source + tests + docs.

## Root cause (non-obvious, prod-only)
Production's `pg_class.relacl` grants **every role full table privileges** (`authenticated=arwdDxtm`) — Supabase's schema-wide default-privilege model where **RLS is the real protection**. So R141's *column-level* UPDATE grant on `area_monitors` was a **no-op in prod**: a user could write their own monitor's run-state columns and `next_run_at`. pgTAP passed because vanilla CI Postgres lacks those default grants. The durable fix is a **trigger**, and the pgTAP test now **simulates the prod grant**.

## What changed
| # | Finding | Fix |
|---|---|---|
| §1 | Pages deploy | Confirmed prod already on GitHub Actions (`ENABLE_PAGES_DEPLOY=true`, `build_type=workflow`); prod SHA == `main`. RELEASE.md corrected. |
| §2 | `baseline_window` only saw ~12 runs | New `monitor_seen_items` ledger (45-day retention ≥ 30-day UI window); novelty = "not in ledger". |
| §3 | Manual claim TOCTOU | `monitor_claim_one` = atomic `UPDATE…WHERE…RETURNING`; two "Run now" can't both succeed; no cron race. |
| §4 | headline/summary ungrounded | `buildReport` builds headline/summary/unchanged/data_gaps from the **authoritative diff numbers**; AI writes only per-claim text (evidence-validated) + bounded severity. |
| §5 | DB errors ignored | Every write error-checked; `monitor_finalize`/`monitor_commit_report` make run+report+meta atomic — never `report_generated=true` without a report. |
| §6 | Non-deterministic news set | `order by pub_date desc, id asc` before the cap; ledger novelty so cap churn ≠ change. |
| §7 | run-state/`next_run_at` user-writable | `tg_monitors_guard_state` BEFORE UPDATE trigger (grant-independent) + revoke broad UPDATE + column grant. |
| §8 | `monitor_limit(uuid)` plan probe | EXECUTE revoked from users; `monitor_limit_self()` added. |
| §9 | CodeQL 37/38/39 | tag-strip regex → inert `DOMParser`; static-checks `TRUNCATE` rule now statement-only. |
| §10 | Workspace regression | R142 `defRects().monitors` preserved + regression test. |

## Tests
- **node 40** — `validateClaims` (fabricated-id rejection), `buildReport` (numbers-only), `partitionByNovelty` (cap-proof + order-independent), `classifyDisappeared`.
- **pgTAP** `04_monitors_test.sql` — simulates the prod default grant and proves the guard **trigger** freezes run-state/`next_run_at` (value-unchanged, not merely DENIED); `monitor_claim_one` atomicity/cooldown/disabled/stale/owner/no-cron-conflict; `monitor_limit_self` vs revoked `monitor_limit(uuid)`; seen RLS.
- **Playwright 45** — adds the Workspace regression test; XSS-inert report retained.

## Production (already applied + verified)
- Migration `20260721120000` applied via Management API + `migration repair`; `monitor-run` deployed (v4); pg_cron healthy (200s).
- **E2E** (synthetic Europe monitor → cascade-deleted): run #1 baseline (`success_no_change`, AI skipped, 60 ledger rows, no report); forced novelty → run #2 (`success`, AI used, report, score 0.8) with **29 evidence refs across 9 claims all real (`bad_refs=0`)**. Owner probe: run-state/`next_run_at` UPDATE = DENIED, `monitor_limit(uuid)` = DENIED / `_self()` = 5, `claim_one` = claimed→already_running. Delete cascaded all rows to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)