### PR TITLE
R147: UX/config batch (14 items) — Atlas Terra model + quota 10, over-refusal scope layer, keigo, white buttons, typography, SV/legend/satellite, Companies/Radius/Monitor

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -715,10 +715,11 @@ supabase/
 - **方針：APIキーは絶対にフロントに置かない。** BYOK（ユーザーが鍵を入力）方式は**廃止済み (R27)**。
 - **アカウント制AI** — `supabase/functions/ai-proxy/index.ts`:
   - フロントの `askAI()` → `aiCallServer()` が、ユーザーのSupabase JWT を付けて ai-proxy に POST。
-  - ai-proxy は (1)JWTでユーザー確認（要ログイン）→ (2)`profiles.plan` で上限決定（R40で free=10/日 `PLAN_LIMITS`）→
+  - ai-proxy は (1)JWTでユーザー確認（要ログイン）→ (2)`profiles.plan` で上限決定（free=**10/日** `PLAN_LIMITS`。#R40=10→#R101=30→**#R147=10へ戻す**）→
     (3)`increment_ai_usage` RPC で当日分を原子的に消費（超過は 429）→ (4)**サーバー保持の鍵**でプロバイダ呼び出し →
     (5)失敗時は `refund_ai_usage` で消費分を返金。
-  - プロバイダは `AI_PROVIDER`（`anthropic`|`openai`|`gemini`）。モデルは `AI_MODEL`（既定はプロバイダ毎、**現行=`openai` / `gpt-5.6-luna`（Responses API）**。Gemini/Anthropic経路は温存・切替可）。
+  - プロバイダは `AI_PROVIDER`（`anthropic`|`openai`|`gemini`）。モデルは `AI_MODEL`（既定はプロバイダ毎、**現行=`openai` / `gpt-5.6-terra`（Responses API・#R147でLunaから変更）**。Gemini/Anthropic経路は温存・切替可だが**Gemini 3.1 Flash‑Liteは不使用**）。
+  - **#R147 Atlas scope/safety 判定層**：`SYS()` プランナー（＋`_analysisSystemPrompt()`）に「SCOPE & SAFETY」節。機微語の単語一致で全面拒否せず、**目的/対象/精度/出力の4軸**で分解→既定で**安全版を実行**（精密点→広域公開ゾーン、公開情報限定、攻撃最適化→脅威評価/到達圏/防災、不確実性・出典明示、`drawPolygon`/`radius`/`missile`/`radiation`/`impact` 等で実描画）。**全面拒否は真に有害なスライスのみ**の最終手段で、それでも「できる安全な分析」を提示。軍事/災害/感染症/化学(CBRN)/犯罪統計/サイバー/重要インフラに汎用適用。`provider_blocked` 文言も建設的（言い換え提案）に5言語。**日本語は既定で敬語**（ユーザーがくだけた口調を明示した時のみ例外）。
   - 用途：ニュースタイトル翻訳、ビューの要約、画像解析など**ユーザー操作のAI機能**。
   - **#R113 Gemini 3.5 Flash / `thinkingLevel:"low"` 移行 — 責任分離。** クライアントは**タスク種別**
     （`atlas_plan|map_report|analysis|free_text|json_extract|brief`）と**`webMode`**（`off|auto|required`）を送り、

--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -5,6 +5,61 @@
 
 ---
 
+## R147 — UX/設定バッチ14件：Atlasモデル Luna→Terra／無料枠10回／Atlas過剰拒否防止(scope/safety判定層)／敬語／送信・停止ボタン白／返信タイポグラフィ／オンオフ=ボタン／SV蛍光水色／ケッペン凡例=内容で停止／衛星タイル即時/Companies点滅解消・比較parity／Radius整理／モニター作成 (tag `#R147`)
+
+ユーザー指摘**14件**を根本原因から修正。`index.html`＋Edge Function `ai-proxy`/`monitor-run` の**加算的/微修正**（単一HTML・ビルド無し温存）。`npm test` 緑（static＋node 47＝security/monitor/**新r147-checks 7**＋**Playwright 63**＝新 `r147.spec.js` 6・r142の`#rad-r`参照を`#rad-c`へ更新、pageerror 0）。ローカル(127.0.0.1:8781)でAtlas白ボタン・Companies点滅解消(190社・再描画後clearbit step0=**0**)・Radius整理・各`window`関数ロードを実測。
+
+### ① Atlas使用モデル GPT‑5.6 Luna→**Terra**（#12）
+モデルidは**コードにハードコードされておらず** `AI_MODEL` Supabase secret（＝真の切替点）。secretを `gpt-5.6-terra` に変更＋`ai-proxy` のopenaiフォールバック `gpt-4o-mini`→`gpt-5.6-terra`・Luna言及コメントを全てTerraへ（ai-proxy/monitor-run/index.html）。**Gemini 3.1 Flash‑Liteは今後不使用**（そもそも未参照＝ドキュメント明記のみ）。Gemini経路はdormant温存。deploy: `supabase functions deploy ai-proxy --project-ref vpekfwdpurzejrrmacac`。
+
+### ② 無料AI枠 30→**10回/日**（#13）
+`ai-proxy` `PLAN_LIMITS.free 30→10`＋`index.html` `AI_FREE_DAILY 30→10`＋表示文言5言語（`aiSecHint` EN/JP/DE/RU/ES「10 uses/1日10回/…」）＋stale コメント（5/day→10/day）。サーバが真の権威・クライアントは表示/事前チェック。
+
+### ③ Atlas過剰拒否の防止＝汎用 scope/safety 判定層（#10・業務委託）
+**真因**＝IntMapに独自拒否層は無く、拒否は上流モデルの安全フィルタ由来。`SYS()` プランナープロンプトは「never refuse」と言うのみで**機微な依頼の安全な変換方針が無かった**。**修正＝`SYS()` に「SCOPE & SAFETY」節を追加**：単語一致でなく **目的/対象/精度/出力の4軸で分解**→**既定で安全版を実行・全面拒否は最終手段**→機微だが正当な依頼は**変換して実行**（精密点→広域公開ゾーン、公開情報限定、攻撃最適化→脅威評価/到達圏/防災、不確実性・出典明示、`drawPolygon`/`radius`/`missile`/`radiation`/`impact` 等で実描画）。**軍事だけでなく災害/感染症/化学(CBRN)/犯罪統計/サイバー/重要インフラに汎用適用**。**全面拒否は真に有害なスライスのみ**（実時間標的、特定人物/無防備地点の精密打撃計画、兵器/危険物の作成手順）で、それでも「できる安全な分析」を提示。`_analysisSystemPrompt()` にも並行の SCOPE 節。`provider_blocked` の文言も**建設的**（広域・公開情報での言い換えを提案）に5言語で改訂。**完了条件**＝ミサイル例で広域発射想定ゾーン＋到達圏＋不確実性を描画し、単なる拒否で終わらない（本番検証で確認）。テスト＝`r147-checks` が4軸/変換方針/ドメイン網羅/keigoをソース保証。
+
+### ④ Atlas日本語=敬語（#2）
+`_langLine()`/`_aiLangLine()`/`_analysisSystemPrompt()` に「日本語では既定で丁寧語（です・ます／敬語）、ユーザーがくだけた/タメ口を明示した場合のみ例外」を追加（返信言語がJapaneseのときだけ付加）。
+
+### ⑤ Atlas送信・停止ボタン=白（#11）
+`.atl-go`（送信）/`.atl-go.busy`（停止）を **背景`#fff`＋アイコン`var(--primary-color)`**（`currentColor`）に。ライト/ダーク両テーマで視認できるよう薄border＋shadow。idle（空入力）も白＋muted。実測 `getComputedStyle(.atl-go).backgroundColor === rgb(255,255,255)`。
+
+### ⑥ Atlas返信タイポグラフィ（#8）
+**真因**＝主返信 `say` が `esc()` のみ（**markdown/改行すら描画されず単調な塊**）＋`mdMini` の見出しが固定px小＋サイドバーの`!important`が見出しを15pxへ潰す。**修正**＝`say` を `mdMini` 経由に（2箇所）・`mdMini` の見出し/箇条書きを**em単位**化（バブルfont-sizeに比例＝通常12.8/サイドバー15の両方で階層が効く・`[style*="font-size:12px"]`潰しを回避）・段落`\n\n`に実余白（spacer div）。見出し h1=1.38em/h2=1.2em/h3=1.06em。
+
+### ⑦ Atlasオンオフ=ボタン拡充（#6）
+`_featTogHtml` を iOSスイッチ→**ラベル＋ON/OFFバッジの明示ボタン**（`.atl-featbtn`）に。delegated `.atl-feat-tog` ハンドラは実コントロールをフリップ＋バッジ更新。`base`(衛星) ディスパッチにも `_featTogHtml('satellite')` を配線（既存 grid/3D/国情報/SVに加え）。クラス名 `atl-feat-tog` 温存で既存r145/r146テスト不変。
+
+### ⑧ SVカバレッジ=蛍光水色（#5）
+`sv-cov-lyr` raster paint を `saturation:0.28→0.95・hue-rotate:-34→-42・brightness-min:0.5追加・contrast:0.15・opacity:1`＝ネオン水色に発光（高彩度でR145型の退色を回避）。
+
+### ⑨ ケッペン凡例=内容末尾で停止（#7）
+**真因**＝`max-height:calc(100dvh-92px)` でグラバーが**内容より下＝空白まで**伸ばせた。**修正**＝新 `window._fitKoppenLegend()` が凡例の**自然な内容高さ（chrome＋`.kl-scroll` scrollHeight）をビューポート上限でクランプ**して `maxHeight` に設定。buildLegend末尾/表示時(rAF)/resize(debounce)で再計算。デスクトップのみ（モバイルCSSが `resize:none`）。「最後までいったらとまる」。
+
+### ⑩ 衛星画像タイル=即時（#9）
+**真因**＝`layer-sat` に paint 無し＝`raster-fade-duration` が既定300msでズーム/パン時にちらつく（他の全rasterは0）。**修正**＝`layer-sat`/`layer-sat-labels` に `raster-fade-duration:0`＋`satellite` source に `maxzoom:19`（過剰ズームの404防止）。高速ズーム/パン、特にモバイルが快適。
+
+### ⑪ Companiesロゴ点滅解消（#3）
+**真因**＝価格更新毎に `feed.innerHTML=html` で全ロゴ再生成→各再描画で **Clearbit→favicon→monogram ラダーを最初からやり直し**（空白→404→favicon→差替のちらつき）。resolved結果を**キャッシュしていなかった**。**修正**＝module級 `_coLogoCache`（dom→解決済url or 'mono'）＋`_coLogoInner`/`_coWireLogo`（onload/onerrorで登録）＝再描画は解決済srcを直接emit。価格更新の再描画も `_coRerenderSoon`（350msデバウンス）で凝縮。実測：解決後の再描画で **clearbit step0 = 0**（旧＝毎回やり直し）。
+
+### ⑫ Companies比較=Countries parity（#1）
+既に `#co-cmp-view` 同型（Bar/時系列/表・指標ピッカー・追加検索・CSV＝R145/R146）。今回**表に列ソート**（`data-cmpsort` ヘッダ・`_coCmpSort`・空欄末尾）＋**上限 8→10**（Countries一致）。
+
+### ⑬ Radiusポップアップ整理（#4）
+**真因**＝半径がスライダー＋数値入力＋statタイルの**3重表示**。**修正**＝冗長な `#rad-r`（半径）タイルを削除＝2タイル（円周・面積）に（`refresh()` の #rad-r 更新も除去・既存CSS再利用でモバイル不変）。Style/プリセットは折り畳み（既存）。
+
+### ⑭ モニター「監視を作成」が無反応（#14）
+**真因**＝範囲未選択時に作成ボタンが `disabled` レンダリング＝押しても無反応・無フィードバック。**修正**＝`openCreateDialog` で範囲未設定なら **`mapViewArea()`（現在の地図表示）を既定**に（作成が常に実行可能）＋「現在の地図表示を使用中・狭い範囲は半径/描画/地域で」ヒント（5言語）。クリックハンドラも `!area` 時は map-view フォールバック→無ければ明示トースト（**決して無音の no-op にしない**）。ログイン必須は不変。
+
+### 罠・教訓
+- **モデルidはsecret＝コードgrepでは出ない**（Luna参照は全てコメント）。真の切替は `AI_MODEL` secret＋openaiフォールバック。
+- **過剰拒否の真因は上流モデル**＝独自拒否層は無い→レバーは `SYS()` プロンプト。単語ブロックでなく4軸分解＋安全変換を明文化するのが正道（ユーザー要件）。
+- **タイポグラフィのflat化の真因は`say`が`esc()`のみ**（mdMini未経由）＋固定px見出しがサイドバー`!important`で潰れる→**em単位**で両モード比例＆潰し回避。
+- **ロゴ点滅=innerHTML全再生成×未キャッシュ・ラダー再実行**。resolved結果のmodule級キャッシュで根治（headless hermeticはfavicon不達→monoに落ちるので**同期dispatchで決定化してテスト**）。
+- **ヘッドレスBrowserペインは`isStyleLoaded`未完＝map層をqueryできない**→style/paintはソース＋Playwright実Chromium（`getStyle()`）で検証。
+
+---
+
 ## R146 — UX/正直化バッチ10件：SVスナップ根治(SingleImageSearch JSONP＋CSP)／東西独国境を実データ(Bundesländer)で作り直し／Companies比較ボタン＋網羅190社/live167・即時性(ADR15社live化)／Atlasサイドバー左右余白／Radius 3列グリッド／ケッペン凡例伸長／UVI日時／Atlasオンオフ・ボタン拡充／SV水色を鮮やかに (tag `#R146`)
 
 ユーザー指摘**10件**を根本原因から修正。全て `index.html`（＋データ `data/cshapes.js` を東西独ジオメトリで更新）の**加算的/微修正**。`npm test` 緑（静的+security+monitor+Playwright、pageerror 0）。ローカル(127.0.0.1:4173)でSVスナップ・Companies・東西独FC・Atlasトグルを実測。

--- a/index.html
+++ b/index.html
@@ -2516,7 +2516,7 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
     <div class="settings-sec">
     <div class="setting-group" id="ai-settings-group">
       <label data-i18n="aiSecTitle">AI features</label>
-      <div class="ai-hint" data-i18n="aiSecHint">Built-in AI — free for logged-in users (up to 30 uses per day). No API key needed.</div>
+      <div class="ai-hint" data-i18n="aiSecHint">Built-in AI — free for logged-in users (up to 10 uses per day). No API key needed.</div>
       <div id="ai-settings-body"></div>
     </div>
     </div>
@@ -2788,7 +2788,7 @@ window.addEventListener('DOMContentLoaded', () => {
       filtCiv:"Civilian", filtMil:"Military", filtAll:"All", trafficFilter:"Filter", lyrTime:"Layer date", thermWin24:"Last 24 h", thermWin48:"Last 48 h", thermWin72:"Last 72 h",
       tabCommunity:"Community", commAdd:"+ New post", commAddArmed:"Click on map to place pin", commTitle:"Title", commBody:"Share an observation, question, or theory...", commPost:"Post", commCancel:"Cancel", commEmpty:"No posts yet. Click \"+ New post\" to start the discussion.", commComment:"Comment", commLocate:"Show on map", commDelete:"Delete", commReply:"Reply", commWrite:"Write a comment...", commPostNew:"New post", commPlacedAt:"Placed at", commSortHot:"Hot", commSortNew:"New", commSortTop:"Top", commSearchPh:"Search posts…", commInView:"In view", commCat:"Category", commCatAll:"All", commEdit:"Edit", commEdited:"edited", commEditPost:"Edit post", commSaveEdit:"Save changes", commNoMatch:"No posts match your filters.", borders:"Country borders", compare:"Compare", compareEmpty:"Tap country rows to select and compare.", compareView:"Show comparison", compareClear:"Clear", back:"Back", deletePin:"Delete",
       satCtrlTitle:"Satellite imagery", satProvider:"Provider", satDate:"Capture date", satLatest:"Latest available", satMosaicSuffix:"cloudless mosaic", satLocked:"add API key", satPrevDay:"Previous day", satNextDay:"Next day", satKeysTitle:"Satellite imagery (BYOK)", satKeyHint:"Enter an API key to unlock these providers in the Satellite panel. Keys are stored only in this browser.", satKeyConnected:"Connected", satKeyNone:"No key", satErrAuth:"{provider}: authentication failed — check the API key", satErrTiles:"{provider}: imagery unavailable — switched to fallback",
-      aiSecTitle:"AI features", aiSecHint:"Built-in AI — free for logged-in users (up to 30 uses per day). No API key needed.",
+      aiSecTitle:"AI features", aiSecHint:"Built-in AI — free for logged-in users (up to 10 uses per day). No API key needed.",
       aiProvider:"AI provider", aiModel:"Model", aiApiKey:"API key", aiKeyConnected:"Connected", aiKeyNone:"No key", aiGetKey:"Get a key ↗", aiOnDevice:"Runs on-device in Chrome — no API key needed.",
       aiTest:"Test connection", aiTesting:"Testing…", aiTestOk:"Connection OK ✓",
       aiNoKey:"Add an AI API key in Settings → AI features first.", aiNoVision:"This model can't read images. Choose GPT-4o, Claude 3.5 Sonnet, or Gemini 1.5 Pro.",
@@ -2821,7 +2821,7 @@ window.addEventListener('DOMContentLoaded', () => {
       filtCiv:"民間", filtMil:"軍用", filtAll:"全て", trafficFilter:"絞り込み", lyrTime:"レイヤー日付", thermWin24:"過去24時間", thermWin48:"過去48時間", thermWin72:"過去72時間",
       tabCommunity:"コミュニティ", commAdd:"+ 新規投稿", commAddArmed:"地図をクリックしてピンを刺してください", commTitle:"タイトル", commBody:"考察・発見・疑問を投稿してください...", commPost:"投稿", commCancel:"キャンセル", commEmpty:"投稿はまだありません。「+ 新規投稿」をタップして議論を始めましょう。", commComment:"コメント", commLocate:"地図で見る", commDelete:"削除", commReply:"返信", commWrite:"コメントを書く...", commPostNew:"新規投稿", commPlacedAt:"投稿位置", commSortHot:"話題", commSortNew:"新着", commSortTop:"人気", commSearchPh:"投稿を検索…", commInView:"表示範囲", commCat:"カテゴリ", commCatAll:"すべて", commEdit:"編集", commEdited:"編集済み", commEditPost:"投稿を編集", commSaveEdit:"変更を保存", commNoMatch:"条件に一致する投稿がありません。", borders:"国境線", compare:"比較", compareEmpty:"行をタップして国を選び比較", compareView:"比較を表示", compareClear:"クリア", back:"戻る", deletePin:"削除",
       satCtrlTitle:"衛星画像", satProvider:"プロバイダ", satDate:"撮影日", satLatest:"最新（自動取得）", satMosaicSuffix:"雲なしモザイク", satLocked:"APIキーを登録", satPrevDay:"前日", satNextDay:"翌日", satKeysTitle:"衛星画像プロバイダ (BYOK)", satKeyHint:"APIキーを入力すると、Satelliteパネルで各プロバイダを選択できます。キーはこのブラウザにのみ保存されます。", satKeyConnected:"接続済み", satKeyNone:"未登録", satErrAuth:"{provider}: 認証に失敗しました — APIキーを確認してください", satErrTiles:"{provider}: 画像を取得できません — フォールバックに切替えました",
-      aiSecTitle:"AI機能", aiSecHint:"内蔵AI — ログインすると無料でご利用いただけます（1日30回まで）。APIキーは不要です。",
+      aiSecTitle:"AI機能", aiSecHint:"内蔵AI — ログインすると無料でご利用いただけます（1日10回まで）。APIキーは不要です。",
       aiProvider:"AIプロバイダ", aiModel:"モデル", aiApiKey:"APIキー", aiKeyConnected:"接続済み", aiKeyNone:"未登録", aiGetKey:"キーを取得 ↗", aiOnDevice:"Chrome内で端末内実行されます（APIキー不要）。",
       aiTest:"接続テスト", aiTesting:"テスト中…", aiTestOk:"接続に成功しました ✓",
       aiNoKey:"先に 設定 → AI機能 でAPIキーを登録してください。", aiNoVision:"このモデルは画像を解析できません。GPT-4o / Claude 3.5 Sonnet / Gemini 1.5 Pro を選択してください。",
@@ -2853,7 +2853,7 @@ window.addEventListener('DOMContentLoaded', () => {
       lblNavSens:"Navigationsempfindlichkeit", lblNavZoom:"Zoom", lblNavPan:"Schwenken",
       satKeysTitle:"Satellitenbilder (BYOK)", satKeyHint:"Geben Sie einen API-Schlüssel ein, um diese Anbieter im Satelliten-Panel freizuschalten. Schlüssel werden nur in diesem Browser gespeichert.",
       aisKeyLabel:"Live-Schiffsverkehr (AISstream-Schlüssel)", aisKeyHint:"Holen Sie sich einen kostenlosen Schlüssel bei aisstream.io und fügen Sie ihn hier ein. Wird nur in diesem Browser gespeichert.",
-      aiSecTitle:"KI-Funktionen", aiSecHint:"Integrierte KI — nach der Anmeldung kostenlos nutzbar (bis zu 30×/Tag). Kein API-Schlüssel erforderlich.",
+      aiSecTitle:"KI-Funktionen", aiSecHint:"Integrierte KI — nach der Anmeldung kostenlos nutzbar (bis zu 10×/Tag). Kein API-Schlüssel erforderlich.",
       blueberryBtn:"Unterstützen", borders:"Ländergrenzen", countries:"Länder (Info)", placeNames:"Ortsnamen", geoLabels:"Gewässer- & Geländenamen", adminBounds:"Bundesland-/Provinzgrenzen", roadsLayer:"Straßen", railLayer:"Eisenbahnen", favLayers:"★ Favoriten",
       measureMenuBtn:"Messen", measureDistBtn:"📏 Distanz / Fläche", drawBtn:"✏️ Zeichnen", radiusBtn:"⭕ Radius", objectsBtn:"🗂 Objekte", mScreenshot:"Screenshot", screenshotBtn:"📷 Screenshot", layersBtn:"Ebenen ▾", uploadGeoJSON:"GeoJSON hochladen",
       lblDataSources:"Datenquellen", viewDataSources:"Datenquellen ansehen ↗", lblNewsCountries:"Nachrichten-Länder", newsCountriesHint:"Lassen Sie das Feld leer für weltweite Nachrichten.",
@@ -2900,7 +2900,7 @@ window.addEventListener('DOMContentLoaded', () => {
       lblNavSens:"Чувствительность навигации", lblNavZoom:"Зум", lblNavPan:"Перемещение",
       satKeysTitle:"Спутниковые снимки (BYOK)", satKeyHint:"Введите ключ API, чтобы разблокировать этих провайдеров в панели спутника. Ключи хранятся только в этом браузере.",
       aisKeyLabel:"Морской трафик (ключ AISstream)", aisKeyHint:"Получите бесплатный ключ на aisstream.io и вставьте его сюда. Хранится только в этом браузере.",
-      aiSecTitle:"ИИ-функции", aiSecHint:"Встроенный ИИ — бесплатно после входа (до 30 раз в день). Ключ API не нужен.",
+      aiSecTitle:"ИИ-функции", aiSecHint:"Встроенный ИИ — бесплатно после входа (до 10 раз в день). Ключ API не нужен.",
       blueberryBtn:"Поддержать", borders:"Границы стран", countries:"Страны (инфо)", placeNames:"Названия мест", geoLabels:"Названия вод и рельефа", adminBounds:"Границы регионов", roadsLayer:"Дороги", railLayer:"Железные дороги", favLayers:"★ Избранное",
       measureMenuBtn:"Измерить", measureDistBtn:"📏 Расстояние / площадь", drawBtn:"✏️ Рисовать", radiusBtn:"⭕ Радиус", objectsBtn:"🗂 Объекты", mScreenshot:"Снимок", screenshotBtn:"📷 Снимок экрана", layersBtn:"Слои ▾", uploadGeoJSON:"Загрузить GeoJSON",
       lblDataSources:"Источники данных", viewDataSources:"Показать источники данных ↗", lblNewsCountries:"Страны новостей", newsCountriesHint:"Оставьте пустым для новостей со всего мира.",
@@ -2948,7 +2948,7 @@ window.addEventListener('DOMContentLoaded', () => {
       lblNavSens:"Sensibilidad de navegación", lblNavZoom:"Zoom", lblNavPan:"Desplazamiento",
       satKeysTitle:"Imágenes de satélite (BYOK)", satKeyHint:"Introduce una clave API para desbloquear estos proveedores en el panel de satélite. Las claves se guardan solo en este navegador.",
       aisKeyLabel:"Tráfico marítimo en vivo (clave AISstream)", aisKeyHint:"Obtén una clave gratuita en aisstream.io y pégala aquí. Se guarda solo en este navegador.",
-      aiSecTitle:"Funciones de IA", aiSecHint:"IA integrada — gratis al iniciar sesión (hasta 30 usos al día). No se necesita clave API.",
+      aiSecTitle:"Funciones de IA", aiSecHint:"IA integrada — gratis al iniciar sesión (hasta 10 usos al día). No se necesita clave API.",
       blueberryBtn:"Apoyar", borders:"Fronteras de países", countries:"Países (info)", placeNames:"Nombres de lugares", geoLabels:"Etiquetas de agua y relieve", adminBounds:"Fronteras de estados/provincias", roadsLayer:"Carreteras", railLayer:"Ferrocarriles", favLayers:"★ Favoritos",
       measureMenuBtn:"Medir", measureDistBtn:"📏 Distancia / área", drawBtn:"✏️ Dibujar", radiusBtn:"⭕ Radio", objectsBtn:"🗂 Objetos", mScreenshot:"Captura", screenshotBtn:"📷 Captura de pantalla", layersBtn:"Capas ▾", uploadGeoJSON:"Subir GeoJSON",
       lblDataSources:"Fuentes de datos", viewDataSources:"Ver fuentes de datos ↗", lblNewsCountries:"Países de noticias", newsCountriesHint:"Déjalo vacío para noticias de todo el mundo.",
@@ -3731,11 +3731,11 @@ window.addEventListener('DOMContentLoaded', () => {
   /* ---- (#R27) FIRST-PARTY, ACCOUNT-BASED AI -----------------------------------------------------
      BYOK is retired. Every AI call now routes through a Supabase Edge Function (ai-proxy) that holds
      the provider key SERVER-SIDE, identifies the user from their Supabase session JWT, and enforces a
-     per-day free-use quota (default 5/day, reset daily, stored in the `ai_usage` table). The model is
+     per-day free-use quota (default 10/day, reset daily, stored in the `ai_usage` table). The model is
      fixed on the server — users never see a key or a model picker. Login is REQUIRED: an un-logged-in
      click opens the auth modal; an over-quota click shows the "本日の無料AI使用回数に達しました" message.
      See supabase/functions/ai-proxy/index.ts + supabase_ai_usage.sql for the server half. */
-  const AI_FREE_DAILY = 30;                                  /* free plan daily quota (display + pre-check). #R40: 5→10; #R101: 10→30 per request */
+  const AI_FREE_DAILY = 10;                                  /* free plan daily quota (display + pre-check). #R40: 5→10; #R101: 10→30; #R147: 30→10 per request */
   window.INTMAP_AI_PROXY = window.INTMAP_AI_PROXY || {};
   if(!window.INTMAP_AI_PROXY.url){
     try{ window.INTMAP_AI_PROXY.url = (window.SUPABASE_URL||'').replace(/\/$/,'') + '/functions/v1/ai-proxy'; }catch(_){ window.INTMAP_AI_PROXY.url=''; }
@@ -3796,7 +3796,7 @@ window.addEventListener('DOMContentLoaded', () => {
       provider_quota:_pl('The AI provider quota was reached — this is separate from your IntMap free uses. Please try again later.','AIプロバイダ側の利用上限に達しました（あなたのIntMap無料利用枠とは別です）。後ほど再試行してください。','Das Kontingent des KI-Anbieters ist erschöpft — getrennt von Ihren IntMap-Freinutzungen. Später erneut versuchen.','Достигнут лимит провайдера ИИ — это отдельно от бесплатных использований IntMap. Повторите позже.','Se alcanzó la cuota del proveedor de IA — es independiente de tus usos gratuitos de IntMap. Inténtalo más tarde.'),
       provider_empty:_pl('The AI returned an empty response — please try again.','AIが空の応答を返しました。もう一度お試しください。','Die KI lieferte eine leere Antwort — bitte erneut versuchen.','ИИ вернул пустой ответ — повторите попытку.','La IA devolvió una respuesta vacía — inténtalo de nuevo.'),
       provider_malformed:_pl('The AI response was malformed — please try again.','AIの応答が不正な形式でした。もう一度お試しください。','Die KI-Antwort war fehlerhaft — bitte erneut versuchen.','Ответ ИИ был некорректным — повторите попытку.','La respuesta de la IA fue incorrecta — inténtalo de nuevo.'),
-      provider_blocked:_pl('The request was blocked by the AI safety filter.','リクエストがAIの安全フィルタによりブロックされました。','Die Anfrage wurde vom KI-Sicherheitsfilter blockiert.','Запрос заблокирован фильтром безопасности ИИ.','La solicitud fue bloqueada por el filtro de seguridad de la IA.'),
+      provider_blocked:_pl('The AI safety filter blocked that. Try rephrasing it as a public-information, broad-area analysis (e.g. an approximate zone or reach rings for defence/preparedness) rather than precise targeting.','AIの安全フィルタによりブロックされました。正確な標的指定ではなく、公開情報に基づく広域の分析（例：おおよそのゾーンや到達圏の表示など、防災・脅威評価目的）として言い換えてお試しください。','Der KI-Sicherheitsfilter hat das blockiert. Formulieren Sie es als öffentlich-informationsbasierte, großräumige Analyse (z. B. eine ungefähre Zone oder Reichweitenringe für Verteidigung/Vorsorge) statt als präzise Zielerfassung.','Фильтр безопасности ИИ заблокировал это. Переформулируйте как анализ по открытым данным для широкой области (например, приблизительная зона или кольца досягаемости для обороны/готовности), а не точное целеуказание.','El filtro de seguridad de la IA lo bloqueó. Reformúlalo como un análisis de información pública y de área amplia (p. ej., una zona aproximada o anillos de alcance para defensa/preparación) en lugar de una localización precisa de objetivos.'),
       provider_unavailable:_pl('The AI service is temporarily unavailable — please try again shortly.','AIサービスが一時的に利用できません。少し後に再試行してください。','Der KI-Dienst ist vorübergehend nicht verfügbar — bitte gleich erneut versuchen.','Сервис ИИ временно недоступен — повторите вскоре.','El servicio de IA no está disponible temporalmente — inténtalo pronto.'),
       invalid_structured_output:_pl('The AI structured output was invalid — please try again.','AIの構造化出力が不正でした。もう一度お試しください。','Die strukturierte KI-Ausgabe war ungültig — bitte erneut versuchen.','Структурированный вывод ИИ был неверным — повторите попытку.','La salida estructurada de la IA no era válida — inténtalo de nuevo.')
     };
@@ -3884,7 +3884,7 @@ window.addEventListener('DOMContentLoaded', () => {
      Appended to the SYSTEM prompt of the free-TEXT generators ONLY — never the JSON geocoders (place names
      must stay canonical) nor the connectivity test. Harmless/​reinforcing for EN/JP. */
   function _aiLangName(){ return ({en:'English',jp:'Japanese',de:'German',ru:'Russian',es:'Spanish'})[currentLang]||'English'; }
-  window._aiLangLine=function(){ const L=_aiLangName(); return ' IMPORTANT: Write your ENTIRE response in '+L+' only — every sentence, heading and bullet must be in '+L+', regardless of the language of the input or these instructions. Do not reply in English unless '+L+' is English.'; };
+  window._aiLangLine=function(){ const L=_aiLangName(); return ' IMPORTANT: Write your ENTIRE response in '+L+' only — every sentence, heading and bullet must be in '+L+', regardless of the language of the input or these instructions. Do not reply in English unless '+L+' is English.'+(L==='Japanese'?' When writing in Japanese, use polite form (です・ます／敬語) by default unless the user is clearly casual or explicitly asks for plain/casual speech.':''); };   /* (#R147) Japanese default = keigo */
   function aiParseJSON(raw){
     if(raw==null) return null;
     let s=String(raw).trim();
@@ -4224,9 +4224,9 @@ window.addEventListener('DOMContentLoaded', () => {
          at 18 — the extra tile set is pure GPU/RAM cost there ("ブラウザが落ちることがないように"). */
       center:[10,20], zoom:1.7, minZoom:0, maxZoom:(isMobile()?18:19),
       style:{ version:8, glyphs:'https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf',
-        sources:{ 'bl':{type:'raster',tiles:carto('light_all'),tileSize:256},'bln':{type:'raster',tiles:carto('light_nolabels'),tileSize:256},'bd':{type:'raster',tiles:carto('dark_all'),tileSize:256},'bdn':{type:'raster',tiles:carto('dark_nolabels'),tileSize:256},'sat-labels':{type:'raster',tiles:['https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}'],tileSize:256},'satellite':{type:'raster',tiles:['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}','https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],tileSize:256},'tool-source':{type:'geojson',data:{type:'FeatureCollection',features:[]}},'grid-source':{type:'geojson',data:{type:'FeatureCollection',features:[]}} },
-        layers:[ {id:'layer-sat',type:'raster',source:'satellite',layout:{visibility:'none'}},
-          {id:'layer-sat-labels',type:'raster',source:'sat-labels',layout:{visibility:'none'},paint:{'raster-opacity':0.95}},
+        sources:{ 'bl':{type:'raster',tiles:carto('light_all'),tileSize:256},'bln':{type:'raster',tiles:carto('light_nolabels'),tileSize:256},'bd':{type:'raster',tiles:carto('dark_all'),tileSize:256},'bdn':{type:'raster',tiles:carto('dark_nolabels'),tileSize:256},'sat-labels':{type:'raster',tiles:['https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}'],tileSize:256},'satellite':{type:'raster',tiles:['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}','https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],tileSize:256,maxzoom:19},'tool-source':{type:'geojson',data:{type:'FeatureCollection',features:[]}},'grid-source':{type:'geojson',data:{type:'FeatureCollection',features:[]}} },
+        layers:[ {id:'layer-sat',type:'raster',source:'satellite',layout:{visibility:'none'},paint:{'raster-fade-duration':0}},   /* (#R147) instant satellite tiles (no 300ms cross-fade) so fast zoom/pan is comfortable, esp. on mobile ("衛星画像の読み込みが…快適に") — matches every other raster overlay */
+          {id:'layer-sat-labels',type:'raster',source:'sat-labels',layout:{visibility:'none'},paint:{'raster-opacity':0.95,'raster-fade-duration':0}},
           /* (#R24) START on the NO-LABEL carto base (we ALWAYS use crisp vector labels now) so the old
              baked-in carto labels never flash at startup before applyTheme swaps them ("スタート時は旧来のまま"). */
           /* (#R34) DARK-MAP CONTRAST — done by genuinely INCREASING the base raster's contrast (the only
@@ -6348,7 +6348,7 @@ window.addEventListener('DOMContentLoaded', () => {
         list=`<div class="tp-sub">${radiusItems.length} ${t('radius')}</div><div class="radius-list">`+radiusItems.map((c,i)=>`<div class="radius-list-item"><span class="rl-sw" style="background:${c.color}"></span><span class="rl-main">${c.radiusKm} km · ${c.center[1].toFixed(2)}°,${c.center[0].toFixed(2)}°</span><button class="rl-del" onclick="removeRadiusItem('${c.id}')">✕</button></div>`).join('')+`</div><button class="tp-clear" onclick="clearAllRadius()" style="margin-top:6px;">${t('removeAll')}</button>`;
       }
       body=`<div class="tp-row radius-control"><input type="range" id="radius-range" min="1" max="20000" step="10" value="${Math.min(20000,radiusKm)}"><div class="radius-row"><button type="button" id="radius-dec" class="rad-step" title="${currentLang==='jp'?'小さく':currentLang==='de'?'Kleiner':currentLang==='ru'?'Мельче':currentLang==='es'?'Reducir':'Decrease'}">−</button><input type="number" id="radius-num" min="1" value="${radiusKm}"><button type="button" id="radius-inc" class="rad-step" title="${currentLang==='jp'?'大きく':currentLang==='de'?'Größer':currentLang==='ru'?'Крупнее':currentLang==='es'?'Aumentar':'Increase'}">＋</button><select id="radius-unit" style="background:var(--input-bg);color:var(--text-main);border:1px solid var(--glass-border,rgba(128,128,128,0.25));border-radius:6px;padding:2px 4px;font-size:11.5px;"><option value="km">km</option><option value="mi">mi</option></select></div></div>
-        <div class="rad-stats"><div class="rad-stat"><label>${t('radius')}</label><b id="rad-r">${distHTML(radiusKm)}</b></div><div class="rad-stat"><label>${t('circumference')}</label><b id="rad-c">${distHTML(2*Math.PI*radiusKm)}</b></div><div class="rad-stat"><label>${t('area')}</label><b id="rad-a">${areaHTML(Math.PI*radiusKm*radiusKm)}</b></div></div>
+        <div class="rad-stats"><div class="rad-stat"><label>${t('circumference')}</label><b id="rad-c">${distHTML(2*Math.PI*radiusKm)}</b></div><div class="rad-stat"><label>${t('area')}</label><b id="rad-a">${areaHTML(Math.PI*radiusKm*radiusKm)}</b></div></div><!-- (#R147) dropped the redundant Radius tile (already shown in the slider + number field) to declutter ("項目数が増え、煩雑…UIを整理") -->
         <details class="tp-more"><summary>${currentLang==='jp'?'スタイル・プリセット':currentLang==='de'?'Stil und Vorlagen':currentLang==='ru'?'Стиль и пресеты':currentLang==='es'?'Estilo y ajustes':'Style &amp; presets'}</summary>
         <div class="tp-sub" style="margin-top:4px;">${t('presetLbl')}</div><select class="tp-select" id="radius-preset">${opts}</select>
         <div class="radius-color-row"><span>${t('color')}</span><div class="rad-presets">${RADIUS_COLOR_PRESETS.map(c=>`<button type="button" class="rad-preset${radiusColor.toLowerCase()===c.col?' on':''}" data-col="${c.col}" title="${c.lbl}" style="background:${c.col}"></button>`).join('')}</div><input type="color" id="radius-color" value="${radiusColor}" title="${currentLang==='jp'?'カスタム色':currentLang==='de'?'Eigene Farbe':currentLang==='ru'?'Свой цвет':currentLang==='es'?'Color personalizado':'Custom color'}"><span class="tp-sub" style="margin:0;">${t('opacity')}</span><input type="range" id="radius-op" min="0" max="0.6" step="0.02" value="${radiusOpacity}" style="flex:1; accent-color:var(--primary-color);"></div></details>
@@ -6418,7 +6418,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const unitSel=p.querySelector('#radius-unit'); if(unitSel && (window.unitMode==='imperial')) unitSel.value='mi';
       const rImp=()=>!!(unitSel && unitSel.value==='mi');
       const dispVal=(km)=> rImp()? Math.round(km/1.60934*100)/100 : km;
-      const refresh=()=>{ p.querySelector('#rad-r').innerHTML=distHTML(radiusKm); p.querySelector('#rad-c').innerHTML=distHTML(2*Math.PI*radiusKm); p.querySelector('#rad-a').innerHTML=areaHTML(Math.PI*radiusKm*radiusKm); };
+      const refresh=()=>{ const rc=p.querySelector('#rad-c'), ra=p.querySelector('#rad-a'); if(rc) rc.innerHTML=distHTML(2*Math.PI*radiusKm); if(ra) ra.innerHTML=areaHTML(Math.PI*radiusKm*radiusKm); };   /* (#R147) radius tile removed */
       const setR=(v,fromInput)=>{ radiusKm=v; if(!fromInput)n.value=dispVal(v); r.value=Math.min(20000,v); refresh(); applyActive(); };
       r.oninput=()=>setR(Math.max(1,+r.value));
       n.oninput=()=>{ const raw=parseFloat(n.value); if(!isNaN(raw)&&raw>0){ const km=rImp()? raw*1.60934 : raw; setR(km,true); } };
@@ -10579,7 +10579,7 @@ window.addEventListener('DOMContentLoaded', () => {
      follow the time-machine year, so both the ranking and the comparison reflect past statistics. */
   let coCompareSet=new Set(), _coTimeWired=false, _coTimeDeb=null;
   /* (#R145) Companies compare view state — mirrors the Countries #scp-view (Bar / Time-series / Table, metric picker). */
-  let _coCmpMode='bar', _coCmpMetOpen=false, _coCmpMet=new Set(['mcap','rev','ni','emp']), _coCmpTsFrom=null, _coCmpTsTo=null, _coCmpCss=0;
+  let _coCmpMode='bar', _coCmpMetOpen=false, _coCmpMet=new Set(['mcap','rev','ni','emp']), _coCmpTsFrom=null, _coCmpTsTo=null, _coCmpCss=0, _coCmpSort={key:null,dir:-1};   /* (#R147) table column sort — Countries-parity */
   const _CO_CMP_METS=['mcap','rev','ni','emp','pe','price'];
   const _coCmpMetLbl=k=>{ const m={mcap:_coL('Market cap','時価総額','Marktkap.','Капитализация','Cap. bursátil'),rev:_coL('Revenue','売上高','Umsatz','Выручка','Ingresos'),ni:_coL('Net income','純利益','Nettogewinn','Чистая прибыль','Beneficio neto'),emp:_coL('Employees','従業員数','Mitarbeiter','Сотрудники','Empleados'),pe:_coL('P/E ratio','株価収益率 (P/E)','KGV','P/E','P/E'),price:_coL('Share price','株価','Aktienkurs','Цена акции','Precio acción')}; return m[k]||k; };
   const _CO_CMP_PAL=['#0a84ff','#ff9f0a','#30d158','#ff375f','#bf5af2','#64d2ff','#ffd60a','#ac8e68'];
@@ -10592,7 +10592,7 @@ window.addEventListener('DOMContentLoaded', () => {
        above would miss that past event — reflect the current clock now so the ranking opens on the historical year. */
     try{ const cur=new Date().getFullYear(); const y=window.IntMapTime.year(); if(!window.IntMapTime.isLive()&&y!=null&&y<cur) _apply(y); }catch(_){}
   }
-  window._coToggleCompare=function(tk){ if(coCompareSet.has(tk)) coCompareSet.delete(tk); else if(coCompareSet.size<8) coCompareSet.add(tk); else { const f=coCompareSet.values().next().value; coCompareSet.delete(f); coCompareSet.add(tk); }
+  window._coToggleCompare=function(tk){ if(coCompareSet.has(tk)) coCompareSet.delete(tk); else if(coCompareSet.size<10) coCompareSet.add(tk); else { const f=coCompareSet.values().next().value; coCompareSet.delete(f); coCompareSet.add(tk); }
     document.querySelectorAll('#info-dashboard .co-row').forEach(r=>r.classList.toggle('compare-on',coCompareSet.has(r.getAttribute('data-tk'))));
     try{ const c=IntMapCompanies.DATA.find(x=>x.tk===tk); if(c) imToast((coCompareSet.has(tk)?'✓ ':'− ')+_coName(c)); }catch(_){}
     renderCoCompareFixed(); };
@@ -10604,7 +10604,7 @@ window.addEventListener('DOMContentLoaded', () => {
     if(!tray){ tray=document.createElement('div'); tray.id='co-compare-fixed'; tray.className='co-compare-fixed'; feed.appendChild(tray); }
     const items=[...coCompareSet].map(tk=>IntMapCompanies.DATA.find(x=>x.tk===tk)).filter(Boolean);
     const chips=items.map(c=>`<span class="scb-chip">${IntMapSafe.html(_coName(c))}<button data-cx="${IntMapSafe.html(c.tk)}">×</button></span>`).join('');
-    tray.innerHTML=`<div class="scf-head"><span class="scf-title">${_coL('Compare','比較','Vergleich','Сравнение','Comparar')} (${coCompareSet.size}/8)</span><div style="display:flex;gap:6px;">`+(coCompareSet.size>=2?`<button class="scf-view" data-cv="1">${t('compareView')}</button>`:'')+`<button data-cc="1">${t('compareClear')}</button></div></div><div class="scf-chips">${chips}</div>`;
+    tray.innerHTML=`<div class="scf-head"><span class="scf-title">${_coL('Compare','比較','Vergleich','Сравнение','Comparar')} (${coCompareSet.size}/10)</span><div style="display:flex;gap:6px;">`+(coCompareSet.size>=2?`<button class="scf-view" data-cv="1">${t('compareView')}</button>`:'')+`<button data-cc="1">${t('compareClear')}</button></div></div><div class="scf-chips">${chips}</div>`;
     tray.querySelectorAll('[data-cx]').forEach(b=>b.onclick=()=>window._coToggleCompare(b.getAttribute('data-cx')));
     const cv=tray.querySelector('[data-cv]'); if(cv) cv.onclick=()=>window._coShowCompare();
     const cc=tray.querySelector('[data-cc]'); if(cc) cc.onclick=()=>window._coClearCompare(); }
@@ -10687,7 +10687,7 @@ window.addEventListener('DOMContentLoaded', () => {
     root.innerHTML=h; _coCmpBody(cos); _coCmpWire(cos); }
   function _coCmpBody(cos){ const body=document.getElementById('co-cmp-body'); if(!body) return;
     const met=_CO_CMP_METS.filter(k=>_coCmpMet.has(k));
-    if(_coCmpMode==='table'){ body.innerHTML=_coCmpTable(cos,met.length?met:_CO_CMP_METS); const b=body.querySelector('[data-cmpcsv]'); if(b) b.onclick=()=>_coCmpCsv(cos,met.length?met:_CO_CMP_METS); }
+    if(_coCmpMode==='table'){ const tmet=met.length?met:_CO_CMP_METS; body.innerHTML=_coCmpTable(cos,tmet); const b=body.querySelector('[data-cmpcsv]'); if(b) b.onclick=()=>_coCmpCsv(cos,tmet); body.querySelectorAll('[data-cmpsort]').forEach(th=>th.onclick=()=>{ const k=th.getAttribute('data-cmpsort'); if(_coCmpSort.key===k) _coCmpSort.dir=-_coCmpSort.dir; else { _coCmpSort.key=k; _coCmpSort.dir=-1; } _coCmpBody(cos); }); }   /* (#R147) sortable columns */
     else if(_coCmpMode==='ts'){ _coCmpTs(cos,body); }
     else body.innerHTML=_coCmpBar(cos,met); }
   function _coCmpBar(cos,met){ if(!met.length) return '<div class="co-ts-note">'+_coL('Pick at least one metric above.','上で指標を1つ以上選択してください。','Mindestens eine Kennzahl wählen.','Выберите хотя бы один показатель.','Elige al menos una métrica.')+'</div>';
@@ -10701,8 +10701,11 @@ window.addEventListener('DOMContentLoaded', () => {
         h+='<div class="scp-brow"><span class="scp-bnm">'+IntMapSafe.html(_coName(c))+'</span><span class="scp-btrack">'+zl+fill+'</span><span class="scp-bval">'+(isFinite(v)?IntMapSafe.html(_coMetric(c,k)):'—')+'</span></div>'; });
       h+='</div>'; });
     return h||'<div class="co-ts-note">'+_coL('No data for the selected metrics.','選択した指標のデータがありません。','Keine Daten.','Нет данных.','Sin datos.')+'</div>'; }
-  function _coCmpTable(cos,met){ let h='<div class="scp-ttools"><button data-cmpcsv="1">'+_coL('Export CSV','CSV書き出し','CSV-Export','Экспорт CSV','Exportar CSV')+'</button></div><div class="scp-tblwrap"><table class="scp-tbl"><thead><tr><th>'+_coL('Company','企業','Firma','Компания','Empresa')+'</th>'+met.map(k=>'<th>'+IntMapSafe.html(_coCmpMetLbl(k))+'</th>').join('')+'</tr></thead><tbody>';
-    cos.forEach(c=>{ h+='<tr><td>'+IntMapSafe.html(_coName(c))+'</td>'+met.map(k=>'<td>'+IntMapSafe.html(_coMetric(c,k))+'</td>').join('')+'</tr>'; });
+  function _coCmpTable(cos,met){ const ths=met.map(k=>{ const act=_coCmpSort.key===k, arr=act?(_coCmpSort.dir<0?' ▼':' ▲'):''; return '<th class="scp-th-sort'+(act?' on':'')+'" data-cmpsort="'+k+'" style="cursor:pointer;user-select:none;white-space:nowrap;">'+IntMapSafe.html(_coCmpMetLbl(k))+arr+'</th>'; }).join('');
+    let h='<div class="scp-ttools"><button data-cmpcsv="1">'+_coL('Export CSV','CSV書き出し','CSV-Export','Экспорт CSV','Exportar CSV')+'</button></div><div class="scp-tblwrap"><table class="scp-tbl"><thead><tr><th>'+_coL('Company','企業','Firma','Компания','Empresa')+'</th>'+ths+'</tr></thead><tbody>';
+    let rows=cos.slice(); const sk=_coCmpSort.key;   /* (#R147) sort rows by the active metric column, blanks last */
+    if(sk&&met.indexOf(sk)>=0){ const d=_coCmpSort.dir; rows.sort((a,b)=>{ const va=_coVal(a,sk),vb=_coVal(b,sk),fa=isFinite(va),fb=isFinite(vb); if(!fa&&!fb) return 0; if(!fa) return 1; if(!fb) return -1; return (va-vb)*d; }); }
+    rows.forEach(c=>{ h+='<tr><td>'+IntMapSafe.html(_coName(c))+'</td>'+met.map(k=>'<td>'+IntMapSafe.html(_coMetric(c,k))+'</td>').join('')+'</tr>'; });
     return h+'</tbody></table></div>'; }
   function _coCmpCsv(cos,met){ const esc=s=>{ s=String(s==null?'':s); return /[",\n]/.test(s)?'"'+s.replace(/"/g,'""')+'"':s; };
     const rows=[[_coL('Company','企業','Firma','Компания','Empresa')].concat(met.map(k=>_coCmpMetLbl(k)))];
@@ -10744,7 +10747,7 @@ window.addEventListener('DOMContentLoaded', () => {
         const hits=IntMapCompanies.DATA.filter(c=>!have.has(c.tk)&&(((_coName(c)||'').toLowerCase().includes(q))||c.tk.toLowerCase().includes(q)||(c.n||'').toLowerCase().includes(q))).slice(0,30);
         if(!hits.length){ list.style.display='none'; return; }
         list.innerHTML=hits.map(c=>'<div class="scp-cr" data-cmpadd="'+IntMapSafe.html(c.tk)+'">'+IntMapSafe.html(_coName(c))+' <span style="color:var(--text-muted);font-size:11px;">'+IntMapSafe.html(c.tk)+'</span></div>').join(''); list.style.display='block';
-        list.querySelectorAll('[data-cmpadd]').forEach(r=>r.onmousedown=e=>{ e.preventDefault(); const tk=r.getAttribute('data-cmpadd'); if(coCompareSet.size<8){ coCompareSet.add(tk); showCoCompare([...coCompareSet]); } }); };
+        list.querySelectorAll('[data-cmpadd]').forEach(r=>r.onmousedown=e=>{ e.preventDefault(); const tk=r.getAttribute('data-cmpadd'); if(coCompareSet.size<10){ coCompareSet.add(tk); showCoCompare([...coCompareSet]); } }); };
       inp.oninput=upd; inp.onfocus=upd; inp.onblur=()=>setTimeout(()=>{ try{ list.style.display='none'; }catch(_){} },180); } }
   const _coSec=(k)=>{ const s=CO_SECTORS[k]; return s?_coL(s[0],s[1],s[2],s[3],s[4]):k; };
   const _coCountry=(cc)=>{ const c=CO_CC[cc]; return c?(currentLang==='jp'?c[1]:c[0]):cc; };
@@ -10763,6 +10766,27 @@ window.addEventListener('DOMContentLoaded', () => {
   window._coSfSetOp=(i,op)=>{ if(coFilters[i]){ coFilters[i].op=op; renderCompanies(); } };
   window._coSfSetVal=(i,raw)=>{ if(coFilters[i]){ coFilters[i].raw=raw; coFilters[i].val=_sfParse(raw); renderCompanies(); } };
   /* Countries-style ranking of companies, rendered into the (repurposed) #info-dashboard container. */
+  /* (#R147) Company logos flickered ("ロゴがちかちか点滅") because the whole list is rebuilt via innerHTML on
+     every progressive price update, and each rebuild re-started the Clearbit→favicon→monogram ladder from
+     scratch (blank → 404 → favicon fetch → swap). Cache the RESOLVED logo per domain so a rebuild emits the
+     already-working src (or the monogram) directly — no re-ladder, no flash. Plus debounce the price-driven
+     re-render so the list repaints a few times, not ~25 times, during the load. */
+  const _coLogoCache=new Map();   /* dom -> resolved logo url, or 'mono' once both remote sources failed */
+  function _coLogoInner(dom,nm,hue){
+    const d=String(dom||''), r=_coLogoCache.get(d);
+    if(r==='mono'){ const ch=(String(nm||'?').trim().slice(0,1)||'?').toUpperCase(); return '<span class="co-mono" style="background:hsl('+hue+',55%,45%)">'+IntMapSafe.html(ch)+'</span>'; }
+    const step=r?'1':'0';   /* a cached url is already resolved → on any later error skip straight to the monogram */
+    const src=r||('https://logo.clearbit.com/'+encodeURIComponent(d));
+    return '<img class="co-logo" alt="" data-dom="'+IntMapSafe.html(d)+'" data-name="'+IntMapSafe.html(nm)+'" data-hue="'+hue+'" data-step="'+step+'" src="'+IntMapSafe.html(src)+'">';
+  }
+  function _coWireLogo(img){ if(!img) return;
+    img.onload=function(){ try{ if(this.src && this.dataset.dom) _coLogoCache.set(this.dataset.dom,this.src); }catch(_){} };
+    img.onerror=function(){ const s=+this.dataset.step||0, dom=this.dataset.dom||'';
+      if(s===0){ this.dataset.step='1'; this.src='https://www.google.com/s2/favicons?domain='+encodeURIComponent(dom)+'&sz=64'; }
+      else { this.onerror=null; try{ if(dom) _coLogoCache.set(dom,'mono'); }catch(_){} const mono=document.createElement('span'); mono.className='co-mono'; mono.textContent=(this.dataset.name||'?').trim().slice(0,1).toUpperCase(); try{ mono.style.background='hsl('+(this.dataset.hue||0)+',55%,45%)'; }catch(_){} this.replaceWith(mono); } };
+  }
+  let _coRrT=null;
+  function _coRerenderSoon(){ if(_coRrT) return; _coRrT=setTimeout(()=>{ _coRrT=null; if(currentMode==='info'||document.body.classList.contains('ws-mode')){ try{ renderCompanies(); }catch(_){} } },350); }
   function renderCompanies(q){
     const feed=document.getElementById('info-dashboard'); if(!feed) return;
     if(document.getElementById('co-cmp-view')) return;   /* (#R142) the compare view owns the feed — don't clobber it */
@@ -10800,22 +10824,20 @@ window.addEventListener('DOMContentLoaded', () => {
       const cn=_coCountry(c.cc), fl=_coFlag(c.cc);
       const sub=_coSec(c.sec)+(cn?(' / '+(fl?fl+' ':'')+cn):'');
       const hue=[...nm].reduce((a,ch)=>a+ch.charCodeAt(0),0)%360;
-      const logo=`<img class="co-logo" alt="" data-dom="${IntMapSafe.html(c.dom)}" data-name="${IntMapSafe.html(nm)}" data-hue="${hue}" data-step="0" src="https://logo.clearbit.com/${encodeURIComponent(c.dom)}">`;
+      const logo=_coLogoInner(c.dom,nm,hue);   /* (#R147) cached-logo builder — no flicker */
       html+=`<div class="stat-row co-row${coCompareSet.has(c.tk)?' compare-on':''}" data-tk="${IntMapSafe.html(c.tk)}" title="${IntMapSafe.html(nm)}"><span class="stat-rank">${_rankOf.get(c.tk)||'—'}</span><span class="stat-flag co-logo-box">${logo}</span><div class="stat-main"><div class="stat-name">${IntMapSafe.html(nm)}</div><div class="stat-sub">${IntMapSafe.html(sub)}</div></div><div class="stat-val">${_coMetric(c,key)}</div></div>`;
     });
     const st0=feed.scrollTop;
     feed.innerHTML=html;
     try{ feed.scrollTop=st0; }catch(_){}
-    feed.querySelectorAll('.co-logo').forEach(img=>{ img.onerror=function(){ const s=+this.dataset.step||0; const dom=this.dataset.dom||'';
-      if(s===0){ this.dataset.step='1'; this.src='https://www.google.com/s2/favicons?domain='+encodeURIComponent(dom)+'&sz=64'; }
-      else { this.onerror=null; const mono=document.createElement('span'); mono.className='co-mono'; mono.textContent=(this.dataset.name||'?').trim().slice(0,1).toUpperCase(); try{ mono.style.background='hsl('+(this.dataset.hue||0)+',55%,45%)'; }catch(_){} this.replaceWith(mono); } }; });
+    feed.querySelectorAll('.co-logo').forEach(_coWireLogo);   /* (#R147) shared cached-logo wiring */
     /* (#R142) single-click selects the row for comparison, double-click opens the detail overlay — mirrors Countries. */
     feed.querySelectorAll('.co-row').forEach(row=>{ let ct=null; row.onclick=()=>{ const tk=row.getAttribute('data-tk');
       if(ct){ clearTimeout(ct); ct=null; try{ showCompanyDetail(tk); }catch(_){} return; }
       ct=setTimeout(()=>{ ct=null; try{ window._coToggleCompare(tk); }catch(_){} },250); }; });
     feed.style.paddingBottom='24px';
     try{ renderCoCompareFixed(); }catch(_){}   /* (#R142) re-attach the compare selection tray after the rebuild */
-    if(!(IntMapCompanies.histYear&&IntMapCompanies.histYear())){ try{ IntMapCompanies.loadPrices(()=>{ if(currentMode==='info'||document.body.classList.contains('ws-mode')){ try{ renderCompanies(); }catch(_){} } }); }catch(_){} }   /* (#R142) live prices only in the present; historical prices come from setYear */
+    if(!(IntMapCompanies.histYear&&IntMapCompanies.histYear())){ try{ IntMapCompanies.loadPrices(_coRerenderSoon); }catch(_){} }   /* (#R142) live prices only in the present; historical prices come from setYear; (#R147) debounced re-render kills repaint churn */
   }
   window.renderCompanies=renderCompanies;
   /* Company detail overlay — every indicator for one company + a link to its site (all figures honestly sourced). */
@@ -10836,7 +10858,7 @@ window.addEventListener('DOMContentLoaded', () => {
       [_coL('Headquarters','本社','Hauptsitz','Штаб-квартира','Sede'), (_coFlag(c.cc)?_coFlag(c.cc)+' ':'')+_coCountry(c.cc)] ];
     const site='https://'+c.dom;
     ov.innerHTML=`<div class="co-detail" role="dialog" aria-modal="true"><button class="co-detail-x" type="button" aria-label="Close">✕</button>`+
-      `<div class="co-detail-head"><span class="co-logo-box co-logo-lg"><img class="co-logo" alt="" data-dom="${IntMapSafe.html(c.dom)}" data-name="${IntMapSafe.html(nm)}" data-hue="${hue}" data-step="0" src="https://logo.clearbit.com/${encodeURIComponent(c.dom)}"></span>`+
+      `<div class="co-detail-head"><span class="co-logo-box co-logo-lg">${_coLogoInner(c.dom,nm,hue)}</span>`+
       `<div class="co-detail-title"><div class="co-detail-name">${IntMapSafe.html(nm)}</div><div class="co-detail-tk">${IntMapSafe.html(c.tk)}</div></div></div>`+
       `<div class="co-detail-btns"><button class="co-detail-btn${coCompareSet.has(c.tk)?' on':''}" data-cmp="1" type="button">${coCompareSet.has(c.tk)?_coL('In comparison','比較中','Im Vergleich','В сравнении','En comparación'):_coL('Compare','比較する','Vergleichen','Сравнить','Comparar')}${coCompareSet.size?` (${coCompareSet.size}/8)`:''}</button></div>`+
       `<div class="co-detail-rows">${rows.map(r=>`<div class="co-drow"><span>${IntMapSafe.html(r[0])}</span><b>${IntMapSafe.html(String(r[1]))}</b></div>`).join('')}</div>`+
@@ -10850,7 +10872,7 @@ window.addEventListener('DOMContentLoaded', () => {
       try{ window._coToggleCompare(c.tk); }catch(_){} try{ renderCoCompareFixed(); }catch(_){}
       if(!wasIn && coCompareSet.size>=2){ close(); try{ window._coShowCompare(); }catch(_){} }
       else { close(); } };
-    const img=ov.querySelector('.co-logo'); if(img) img.onerror=function(){ const s=+this.dataset.step||0; const dom=this.dataset.dom||''; if(s===0){ this.dataset.step='1'; this.src='https://www.google.com/s2/favicons?domain='+encodeURIComponent(dom)+'&sz=64'; } else { this.onerror=null; const mono=document.createElement('span'); mono.className='co-mono'; mono.textContent=(this.dataset.name||'?').trim().slice(0,1).toUpperCase(); try{ mono.style.background='hsl('+(this.dataset.hue||0)+',55%,45%)'; }catch(_){} this.replaceWith(mono); } };
+    const img=ov.querySelector('.co-logo'); if(img) _coWireLogo(img);   /* (#R147) shared cached-logo wiring */
   }
   window.showCompanyDetail=showCompanyDetail;
 
@@ -12327,7 +12349,7 @@ window.addEventListener('DOMContentLoaded', () => {
   })();
 
   /* ===== Terms of Service & Privacy Policy ===== */
-  const LEGAL_DATE='2026-07-17';   /* (#R122) Privacy §4: OpenAI content-sharing (Designated Content may be used to develop/train OpenAI models) + do-not-submit-sensitive-data caution. (#R114) Terms §6 + sources: AI provider is OpenAI (gpt-5.6-luna) and AI features may run web searches. (#R101) Privacy §4: flight-simulator audio note. */
+  const LEGAL_DATE='2026-07-17';   /* (#R122) Privacy §4: OpenAI content-sharing (Designated Content may be used to develop/train OpenAI models) + do-not-submit-sensitive-data caution. (#R114) Terms §6 + sources: AI provider is OpenAI (gpt-5.6-terra) and AI features may run web searches. (#R101) Privacy §4: flight-simulator audio note. */
   function legalTermsHTML(){ return currentLang==='jp'? `
     <h3 style="margin:0 0 4px;font-size:17px;">利用規約</h3><p style="color:var(--text-muted);font-size:11.5px;margin:0 0 12px;">最終更新日: ${LEGAL_DATE}</p>
     <p><b>1. 同意</b> — IntMap（以下「本サービス」）を利用することで、本規約に同意したものとみなされます。同意されない場合は利用しないでください。</p>
@@ -14228,7 +14250,24 @@ window.addEventListener('DOMContentLoaded', () => {
       const xb=lg.querySelector('#kl-close'); if(xb) xb.onclick=()=>{ /* × also disables the layer (user request) */ const cb2=document.getElementById('dl-climate'); if(cb2){ cb2.checked=false; cb2.dispatchEvent(new Event('change')); } };
       try{ window._ensureLegendOpacity&&window._ensureLegendOpacity(lg); window._ensureLegendMinimize&&window._ensureLegendMinimize(lg); }catch(_){}
       try{ window._wireLegendDrag&&window._wireLegendDrag(lg); }catch(_){}
+      try{ _fitKoppenLegend(lg); }catch(_){}
     }
+    /* (#R147) "上下に伸ばして最後までいったらとまる" — clamp the resizable legend's max-height to its natural content
+       height (capped at the viewport) so dragging the resize grip stops exactly at the last climate class instead
+       of continuing into empty space. Recomputed on every rebuild, on show, and on window resize. Desktop only —
+       the mobile CSS owns legend sizing (resize:none). */
+    function _fitKoppenLegend(lg){ try{
+      lg=lg||document.getElementById('koppen-legend'); if(!lg) return;
+      if(getComputedStyle(lg).display==='none' || lg.classList.contains('legend-collapsed')) return;
+      if(window.innerWidth<=768) return;
+      const sc=lg.querySelector('.kl-scroll'); if(!sc) return;
+      const chrome=Math.max(0, lg.getBoundingClientRect().height - sc.getBoundingClientRect().height);
+      const full=Math.round(chrome + sc.scrollHeight + 2);   /* height that reveals every class with no inner scroll */
+      const cap=Math.round(window.innerHeight - 92);          /* same viewport ceiling as the CSS max-height */
+      lg.style.maxHeight=Math.max(150, Math.min(full, cap))+'px';
+    }catch(_){} }
+    window._fitKoppenLegend=_fitKoppenLegend;
+    (function(){ let _klRz=null; window.addEventListener('resize',()=>{ if(_klRz) return; _klRz=setTimeout(()=>{ _klRz=null; try{ const lg=document.getElementById('koppen-legend'); if(!lg||getComputedStyle(lg).display==='none') return; if(window.innerWidth<=768) lg.style.maxHeight=''; else _fitKoppenLegend(lg); }catch(_){} },200); }); })();
     /* Decode a Köppen code into its defining criteria (#25) — letter by letter, EN + JP. */
     function koppenCriteria(code){
       const g=code[0], rest=code.slice(1), en=[], jp=[];
@@ -14863,7 +14902,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }
     function toggleLayer(id,on){
       if(on){
-        if(id==='climate'){ addKoppen(); /* layer added async after CORS preflight; setVis once it appears */ const t0=Date.now(); (function w(){ if(map.getLayer('lyr-climate')){ setVis('lyr-climate',true); } else if(Date.now()-t0<5000){ setTimeout(w,150); } })(); legend.style.display='flex'; }
+        if(id==='climate'){ addKoppen(); /* layer added async after CORS preflight; setVis once it appears */ const t0=Date.now(); (function w(){ if(map.getLayer('lyr-climate')){ setVis('lyr-climate',true); } else if(Date.now()-t0<5000){ setTimeout(w,150); } })(); legend.style.display='flex'; try{ requestAnimationFrame(()=>{ try{ window._fitKoppenLegend&&window._fitKoppenLegend(); }catch(_){} }); }catch(_){} }   /* (#R147) fit legend height to content once visible */
         else if(id==='temp'){
           lgdTemp.style.display='block'; tileLegends();
           whenStyleReady().then(()=>{
@@ -25149,7 +25188,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const _covTileUrl=(sd)=>'https://mts'+sd+'.google.com/vt?hl=en&src=api&x={x}&y={y}&z={z}&lyrs=svv&style=40,18';
     function addCoverageTiles(){ try{
         if(!map.getSource(_COV_SRC)) map.addSource(_COV_SRC,{type:'raster',tileSize:256,minzoom:0,maxzoom:19,attribution:'Street View coverage © Google',tiles:[_covTileUrl(0),_covTileUrl(1),_covTileUrl(2),_covTileUrl(3)]});
-        if(!map.getLayer(_COV_LYR)) map.addLayer({id:_COV_LYR,type:'raster',source:_COV_SRC,paint:{'raster-opacity':0.95,'raster-saturation':0.28,'raster-hue-rotate':-34}});   /* (#R146) 水色 = a VIVID light-blue. R145 washed it out (brightness-min:0.5 + negative saturation = "薄すぎる"); drop the brightness wash and instead shift Google's blue toward cyan and BOOST saturation so it reads as a clear, saturated light-blue ("最初の色から勝手に変えるな") */
+        if(!map.getLayer(_COV_LYR)) map.addLayer({id:_COV_LYR,type:'raster',source:_COV_SRC,paint:{'raster-opacity':1,'raster-saturation':0.95,'raster-hue-rotate':-42,'raster-brightness-min':0.5,'raster-contrast':0.15}});   /* (#R147) 蛍光水色 = a MORE prominent, FLUORESCENT light-blue ("もっと目立つ蛍光水色に"): near-max saturation + a stronger cyan hue-rotate + a brightness-min lift makes Google's coverage glow like neon aqua (the high positive saturation avoids the R145 wash-out). */
         return true; }catch(_){ return false; } }
     function removeCoverageTiles(){ try{ if(map.getLayer(_COV_LYR)) map.removeLayer(_COV_LYR); }catch(_){} try{ if(map.getSource(_COV_SRC)) map.removeSource(_COV_SRC); }catch(_){} }
     /* keyless coverage sampling ("Coverageを考慮"): read the svv tile PIXELS around a point and return the nearest
@@ -27637,18 +27676,22 @@ window.addEventListener('DOMContentLoaded', () => {
     }
     /* (#R117) heading HIERARCHY inside Atlas replies ("見出しは大きくするなど" — the reply's own text sizes now vary
        by role: h1 > h2 > h3 ≥ body; the chat body & user-message sizes are untouched). */
+    /* (#R147) Typography: headings/lists use EM units (not fixed px) so the hierarchy scales with the bubble
+       font-size in BOTH normal (12.8px) and sidebar (15px) modes — and, being em, they escape the sidebar rule
+       that force-lifts literal 12–13px spans to 15px, which used to FLATTEN the headings. Paragraph breaks (\n\n)
+       now insert real vertical space, so replies read as titled, spaced sections instead of one monotone block. */
     function mdMini(s){ return esc(_dedupText(String(s||'')))
-      .replace(/^#{3,6}\s*(.+)$/gm,'<div style="font-weight:700;color:var(--primary-color);margin:8px 0 3px;font-size:12.5px;">$1</div>')
-      .replace(/^##\s*(.+)$/gm,'<div style="font-weight:700;color:var(--primary-color);margin:10px 0 4px;font-size:13.5px;">$1</div>')
-      .replace(/^#\s*(.+)$/gm,'<div style="font-weight:800;color:var(--primary-color);margin:11px 0 5px;font-size:15px;letter-spacing:.01em;">$1</div>')
+      .replace(/^#{3,6}\s*(.+)$/gm,'<div style="font-weight:700;color:var(--primary-color);margin:.85em 0 .28em;font-size:1.06em;">$1</div>')
+      .replace(/^##\s*(.+)$/gm,'<div style="font-weight:700;color:var(--primary-color);margin:1em 0 .32em;font-size:1.2em;">$1</div>')
+      .replace(/^#\s*(.+)$/gm,'<div style="font-weight:800;color:var(--primary-color);margin:1.05em 0 .4em;font-size:1.38em;letter-spacing:.01em;line-height:1.3;">$1</div>')
       .replace(/\*\*([^*]+)\*\*/g,'<b>$1</b>')
       /* (#R74) markdown links render as real (safe) anchors — "記事のリンク等をChatGPT風UIで" */
       .replace(/\[([^\]\n]{1,120})\]\((https?:[^)\s]{4,300})\)/g,(m,t,u)=>'<a href="'+u+'" target="_blank" rel="noopener" style="color:var(--primary-color);text-decoration:none;border-bottom:1px solid currentColor;">'+t+'</a>')
       /* (#R79g) ALSO linkify BARE urls the model prints without markdown syntax ("Atlas内からリンクを踏めるように")
          — the leading-char guard skips urls already inside an href="…" attribute of the anchors made just above. */
       .replace(/(^|[^"'=>\/])(https?:\/\/[^\s<)"']+)/g,(m,pre,u)=>pre+'<a href="'+u+'" target="_blank" rel="noopener" style="color:var(--primary-color);text-decoration:none;border-bottom:1px solid currentColor;word-break:break-all;">'+u+'</a>')
-      .replace(/^[-・*]\s+(.+)$/gm,'<div style="padding-left:13px;text-indent:-9px;">• $1</div>')
-      .replace(/\n{2,}/g,'<br>').replace(/\n/g,'<br>'); }
+      .replace(/^[-・*]\s+(.+)$/gm,'<div style="padding-left:1.1em;text-indent:-0.85em;margin:.16em 0;">• $1</div>')
+      .replace(/\n{2,}/g,'<div style="height:.5em"></div>').replace(/\n/g,'<br>'); }
     /* (#R74) ChatGPT-style SOURCE LINK CARDS ("Atlasの返答に、必要であれば記事のリンク等をChatGPT風UIで表示"):
        compact rounded cards with the site's favicon, the article title and its domain — used by analyze,
        mapReport and any reply that carries real article URLs. Only http(s) URLs that came from evidence or
@@ -28009,7 +28052,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const _RR_TTL_POS=90*864e5, _RR_TTL_NEG=7*864e5;   /* keep good extents 90d, negatives 7d */
     const _rrMem=new Map(); let _rrLast=null;
     const _rrNow=()=>{ try{ return Date.now(); }catch(_){ return 0; } };
-    /* geo_resolve OUTPUT schema (forwarded to the Gemini path as responseSchema; the OpenAI/Luna path pins the shape
+    /* geo_resolve OUTPUT schema (forwarded to the Gemini path as responseSchema; the OpenAI/Terra path pins the shape
        via the prompt + client validation). Google REST enum style (uppercase types) to match the proxy contract. */
     const GEO_RESOLVE_SCHEMA={ type:'OBJECT', properties:{
       found:{type:'BOOLEAN'}, canonicalName:{type:'STRING'}, aliases:{type:'ARRAY',items:{type:'STRING'}},
@@ -28670,8 +28713,10 @@ window.addEventListener('DOMContentLoaded', () => {
       if(multi) s+='This is a MULTI-COUNTRY request. A [REQUESTED COVERAGE] block lists the countries the user asked about. For EACH requested country for which the evidence has nothing usable and in-window, SAY SO explicitly — an unmentioned country reads as "nothing to report" when the truth may be "no data gathered". Do not generalise a finding about one country to the whole set. ';
       /* ---- preserved grounding + officeholder rules ---- */
       s+='Work primarily from the DATA blocks below (loaded news, the live GDELT + Google News evidence IntMap gathered, live Wikidata leaders, Wikipedia background, weather/quakes/stats where relevant). If a web-search tool is attached this turn, USE it to verify and fill gaps and cite the source URLs; if none is attached, do not claim to have searched the web. When the evidence has no fresh, dated, question-relevant items, do NOT assert "nothing is happening" — say honestly, in the answer language, that the available evidence has nothing recent on this and name what it covered. CURRENT OFFICEHOLDERS (prime minister / president / cabinet / party leader): your parametric memory is presumed STALE. If a CURRENT NATIONAL LEADERS block is present it was queried LIVE from Wikidata — use it as the primary answer (cite "Wikidata live query") and let it override your memory; otherwise name an officeholder ONLY if the evidence names them with a date. GROUNDING RULE (the user reported Atlas inventing events that never happened): EVERY event, figure, name and date must be traceable to the DATA blocks (or to attached web-search results this turn) — never from parametric memory, never embellished, never invented; an honest "could not verify from the available evidence" is REQUIRED and always better than a plausible but unverified claim. Do NOT recite weather, "no earthquakes" or statistics unless they answer the question. ';
+      /* ---- (#R147) scope: analyse sensitive-but-legitimate questions instead of over-refusing ---- */
+      s+='SCOPE: analyse sensitive but legitimate questions (defence, disasters, disease, hazards, crime statistics, cyber, critical infrastructure) from PUBLIC information at an appropriate level of generality — judge by purpose, target, precision and output, never by a sensitive-sounding word. State the uncertainty and cite public sources; decline ONLY genuinely operational harm (real-time targeting, a precise strike or kill plan, or weapon/agent synthesis instructions) and, even then, still give the safe public-information analysis you can. ';
       /* ---- length + sources ---- */
-      s+='Answer in '+lang+'. Plain text, no markdown. Aim for concision (~230 words is a good target for an open-ended question) BUT never drop the user\'s required sections or a required verdict to hit a word count — their requested structure wins. FINALLY, after the answer, on its own last line, output "SOURCES: <url1> | <url2> | …" with up to 4 REAL article/page URLs (from the NEWS EVIDENCE urls or from your web search this turn) that support your key claims; omit the line entirely if you have none; fabricating a URL is forbidden.';
+      s+='Answer in '+lang+'.'+(String(lang).indexOf('Japanese')>=0?' When answering in Japanese, use polite form (です・ます／敬語) unless the user is clearly casual or explicitly requests plain/casual speech.':'')+' Plain text, no markdown. Aim for concision (~230 words is a good target for an open-ended question) BUT never drop the user\'s required sections or a required verdict to hit a word count — their requested structure wins. FINALLY, after the answer, on its own last line, output "SOURCES: <url1> | <url2> | …" with up to 4 REAL article/page URLs (from the NEWS EVIDENCE urls or from your web search this turn) that support your key claims; omit the line entirely if you have none; fabricating a URL is forbidden.';
       return s; }
     /* (#R131) The TIME CONTEXT + REQUESTED COVERAGE header of the analyze DATA block. Shared by the live path and
        the regression harness so the two can never drift. */
@@ -29497,7 +29542,7 @@ window.addEventListener('DOMContentLoaded', () => {
           return R(true, note('✓ '+esc(r.label)+' — '+onTxt+(r.already?(' ('+L('already','既に','bereits','уже','ya')+')'):''))+verifyNote+ctl, unverified?{meta:{unverified:true}}:undefined); }
         case 'opacity': { const r=resolveLayer(a.name); if(!r) return R(false, warn('⚠ '+L('Layer not found','レイヤーが見つかりません','Ebene nicht gefunden','Слой не найден','Capa no encontrada')+': '+esc(a.name||''))); const sl=layerOpacityControl(r.cb); let v=(a.value!=null?+a.value:(a.percent!=null?+a.percent:null)); if(v!=null&&v>1) v=v/100; if(v==null&&a.delta!=null&&sl){ let d=+a.delta; if(!isNaN(d)){ if(Math.abs(d)>1) d/=100; v=Math.max(0,Math.min(1,(parseFloat(sl.value)||0)+d)); } } if(sl&&v!=null&&!isNaN(v)){ if(!r.cb.checked){ r.cb.checked=true; r.cb.dispatchEvent(new Event('change',{bubbles:true})); } sl.value=v; sl.dispatchEvent(new Event('input',{bubbles:true})); sl.dispatchEvent(new Event('change',{bubbles:true})); return R(true, note('🎚 '+esc(r.label)+' '+Math.round(v*100)+'%')); } return R(false, warn('⚠ '+L('No opacity control: ','透明度調整なし: ','Keine Deckkraft: ','Нет прозрачности: ','Sin opacidad: ')+esc(r.label))); }
         case 'projection': { const flat=(a.mode==='flat'); const ok=kexec(flat?'view.proj.flat':'view.proj.globe', flat?'btn-view-flat':'btn-view-globe'); return R(ok, ok?note('✓ '+esc(flat?L('Flat map','平面地図','Flache Karte','Плоская карта','Mapa plano'):L('Globe','地球儀','Globus','Глобус','Globo'))):warn('⚠')); }
-        case 'base': { const sat=(a.mode==='satellite'||a.mode==='sat'); const ok=kexec(sat?'view.base.sat':'view.base.map', sat?'btn-view-sat':'btn-view-map'); return R(ok, ok?note('✓ '+esc(sat?L('Satellite','衛星','Satellit','Спутник','Satélite'):L('Map','地図','Karte','Карта','Mapa'))):warn('⚠')); }
+        case 'base': { const sat=(a.mode==='satellite'||a.mode==='sat'); const ok=kexec(sat?'view.base.sat':'view.base.map', sat?'btn-view-sat':'btn-view-map'); return R(ok, ok?note('✓ '+esc(sat?L('Satellite','衛星','Satellit','Спутник','Satélite'):L('Map','地図','Karte','Карта','Mapa')))+_featTogHtml('satellite'):warn('⚠')); }   /* (#R147) offer the Satellite on/off button */
         case 'compare': { try{ if(a.on===false){ const x=document.querySelector('#compare-window .cmp-close'); if(x){ x.click(); return R(true, note('✓ '+L('Compare off','比較オフ','Vergleich aus','Сравнение выкл','Comparar: off'))); } } else if(window.IntMapCompare&&window.IntMapCompare.open){ window.IntMapCompare.open(); return R(true, note('✓ '+L('Compare','比較','Vergleich','Сравнение','Comparar'))); } }catch(_){} return R(clickId('btn-compare'), note('✓ '+L('Compare','比較','Vergleich','Сравнение','Comparar'))); }
         case 'flyTo': { const exZ=(a.zoom!=null)?+a.zoom:null; const placeStr=String(a.place||'').trim();
           /* "the whole world / earth / globe" → zoom OUT to the planet, NEVER geocode (was → "World Bank building"). */
@@ -31004,11 +31049,12 @@ window.addEventListener('DOMContentLoaded', () => {
          write Japanese in kanji ("漢字で入力したら中国語で返答される" bug). Mirror the user's chosen UI language. */
       if(/[一-鿿㐀-䶿]/.test(s)) return ({jp:'Japanese',de:'German',ru:'Russian',es:'Spanish',en:'English'}[currentLang])||'Japanese';
       return (typeof _aiLangName==='function')?_aiLangName():'English'; }
-    const _langLine=()=>{ const l2=_replyLang(); return 'the language the user\'s message is written in (it appears to be '+l2+' — ALWAYS mirror the user\'s language, never the UI language)'; };
+    const _langLine=()=>{ const l2=_replyLang(); return 'the language the user\'s message is written in (it appears to be '+l2+' — ALWAYS mirror the user\'s language, never the UI language'+(l2==='Japanese'?'; when replying in Japanese, use polite form (です・ます／敬語) by default unless the user is clearly casual or explicitly asks for plain/casual speech':'')+')'; };   /* (#R147) Japanese default = keigo unless the user opts out */
     function SYS(){ const lang=_langLine();
       return 'You are Atlas, the natural-language command layer for IntMap, an interactive world map. You can perform ANY action in IntMap — there is NO operation you cannot do: every button, toggle, slider, layer, menu, panel and setting is reachable through a specific action below OR the universal "control" action. Turn the user request into ONE strict JSON object and OUTPUT JSON ONLY (no prose, no markdown, no code fence). Schema: {"say":string,"actions":Action[]}. The action "type" names below (flyTo, mapReport, analyze, layer, highlight, time, …) are PLAIN STRING VALUES inside the JSON — they are NOT callable tools or functions. Do NOT emit a functionCall, do NOT call any tool, and do NOT try to execute an action yourself; the IntMap application executes the returned JSON. No web-search or function-calling tool is attached to this planning request. "say" = one short sentence in '+lang+' stating what you did. Decompose a compound request into an ORDERED list of actions and return them ALL — freely COMBINE data analysis + layers + navigation + panels in one plan (e.g. analyse a metric, shade the map, enable a layer AND fly somewhere).\n'
         +'PRECISION vs AMBIGUITY (the user explicitly complained about both forcing a guess on vague input AND mis-reading clear input): (a) when the request is CLEAR, do EXACTLY what it says — do not substitute a different action, drop a step, or add anything not asked; match places/metrics/layers literally. (b) when it is GENUINELY ambiguous or MISSING information you need (which of several places, which metric, from/to for a route, which country, etc.), do NOT force a wrong guess — emit a SINGLE {"type":"ask","question":<one short question in '+lang+'>,"options":[2-4 concrete choices],"allowText":true}. This renders the question with clickable option chips AND a free-text box, and the user\'s pick comes back to you as the next message — ALWAYS prefer this selection form over a plain guess when key info is missing. Only fall back to {"type":"answer"} for a purely conversational clarification with no sensible options. Otherwise never refuse. Never claim success for something you did not emit an action for.\n'
         +'HONESTY: NEVER use "answer" (or the "say" text) to claim you did something you did not emit a real action for — that is a lie the user explicitly complained about. To DO anything you MUST emit its action. "say" must describe ONLY what the actions in this plan actually do. If a request is impossible or unclear, emit a single honest {"type":"answer"} explaining it, and emit NO action you cannot fulfil. Decompose multi-part requests fully (5+ actions is fine) and keep them in the order the user implied.\n'
+        +'SCOPE & SAFETY (do NOT over-refuse — the user complained that a request was blocked wholesale just because it contained a sensitive-sounding word): NEVER judge by keyword. Assess every request on FOUR axes — (1) PURPOSE: analysis / defence / preparedness / education / journalism vs genuine operational harm; (2) TARGET: a broad area or public installation vs a precise strike point or a named private individual; (3) PRECISION: approximate / public-information / illustrative vs real-time or targeting-grade; (4) OUTPUT: an explanation or a map visualisation vs step-by-step instructions to cause harm. DEFAULT TO DOING A SAFE VERSION; full refusal is the LAST resort. When a request is sensitive but has a legitimate reading, TRANSFORM it and EXECUTE: turn a precise point into a BROAD public zone, keep only PUBLIC already-reported information, recast "how to attack / optimise a strike" as threat-assessment / reach / defence / preparedness, ALWAYS state the uncertainty and that it uses public information, and actually RUN the safe map actions (drawPolygon for a broad zone, radius for reach/range rings, missile for a representative arc, radiation or impact for an affected area, highlight, flyTo). Apply this SAME purpose/target/precision/output test generally across sensitive domains — military and weapons, disasters, disease and epidemics, hazardous chemicals / CBRN, crime and policing statistics, cyber, and critical infrastructure — never a keyword blocklist. REFUSE only the specific harmful slice (real-time targeting for an actual attack, a precise strike or kill plan against a specific person or an undefended civilian site, or genuinely operational instructions for building a weapon or synthesising a dangerous agent) and even then do NOT dead-end: in "say"/"answer" name the safe public-information analysis you CAN give and still emit the safe actions. Example — "using public information, show the approximate area a missile could be launched from country A toward country B": DO IT — emit a broad drawPolygon launch-region zone plus radius reach rings (optionally a representative missile arc), and in "say" note it is an approximate estimate from public information for situational / defensive analysis, not targeting data. Do NOT reply with a bare refusal.\n'
         +'COMMON SENSE — do NOT take a generic word as a literal place name (these were real failures): "the whole world / entire world / earth / globe / 世界 / 地球" means ZOOM OUT to the planet → emit {"type":"flyTo","place":"world"} (NEVER geocode "world"/"earth" — they wrongly matched "World Bank building" / "Earth, Texas"). To show a COUNTRY or CITY, pass its plain name as flyTo place (e.g. {"type":"flyTo","place":"China"} / {"type":"flyTo","place":"Osaka"}) — the engine frames the whole country / city area itself; do NOT append "city hall" or pick a tiny sub-place, and do NOT over-zoom. The Köppen climate layer (and other colour rasters) cannot isolate a SINGLE class: for "highlight the Cfa climate", enable the Köppen layer with {"type":"layer","name":"Köppen climate"} and, in "say", tell the user the Cfa zones are identified by the legend (do not claim you isolated Cfa).\n'
         +'CONTEXT IS CRITICAL: the user message contains a [CURRENT MAP STATE] block (centre, zoom, base, view, active layers, highlighted/shaded data, open country, language/theme/units) and a [RECENT CONVERSATION] block. You MUST read them and interpret the [NEW REQUEST] relative to them. Resolve every reference — "it / that / this / there / here / this country / the same / again / now / also / instead / turn it off / make it bigger / zoom in more / the other one / the Nth" — using that state and history. A short follow-up is usually a TWEAK of the previous turn: keep what still applies and change only what was asked (e.g. after "top 10 by GDP", "now per capita" → rank gdppc; after "fly to Tokyo", "weather there" → weather Tokyo; after enabling a layer, "turn it off" → same layer on:false). For "here/there/this place" you may pass place:"there" and it resolves to the last place or the map centre. Action types:\n'
         +'NAVIGATION/VIEW: {"type":"flyTo","place":str} — just give the place name; the engine frames it to its REAL size automatically (a country fills like a country, a city like a city — you do NOT pick a zoom). For the whole planet use {"type":"flyTo","place":"world"}. Only add "zoom":num if the user explicitly asked for a specific closeness. (lng/lat form: {"type":"flyTo","lng":num,"lat":num,"zoom":num}.) {"type":"zoom","to":num|"delta":num|"dir":"in"|"out"}; {"type":"pan","dir":"north"|"south"|"east"|"west"|"northeast"|…}; {"type":"pitch","deg":0-85} (tilt; 0=top-down, 60=oblique); {"type":"projection","mode":"globe"|"flat"}; {"type":"terrain3d","on":bool}; {"type":"base","mode":"map"|"satellite"}; {"type":"bearing","deg":num} (rotate); {"type":"resetNorth"}; {"type":"search","query":str} (place-search box). For a REGION (continent, "Central Europe", "Southern Italy", "Middle East", "the Caribbean") just pass its name to flyTo — the engine knows region extents and slices directional names from the real country; never substitute a tiny sub-place. {"type":"outline","place":str,"color"?:str} draws the real boundary of that place or region as a polygon on the map (and {"type":"outline","place":"clear"} removes it). {"type":"locate"} flies to the user\'s real GPS position (asks browser permission). {"type":"fullscreen","on":bool}. "bearing" also takes {"dir":"west"|"northeast"|…}; zoom/pitch/bearing/pan accept exact numbers for precise commands ("zoom to 5" → {"type":"zoom","to":5}; "tilt 30°" → {"type":"pitch","deg":30}).\n'
@@ -31113,11 +31159,11 @@ window.addEventListener('DOMContentLoaded', () => {
         +'#atlas-panel .atl-in:focus{border-color:var(--primary-color);box-shadow:0 0 0 3px rgba(10,132,255,0.18);}'
         /* (#R72) send button ("メッセージ送信ボタンがダサい"): clean filled circle + arrow-up SVG (ChatGPT-style),
            disabled-looking when the input is empty. */
-        +'#atlas-panel .atl-go{flex:0 0 auto;width:38px;height:38px;border-radius:50%;border:none;background:var(--primary-color);color:#fff;cursor:pointer;display:flex;align-items:center;justify-content:center;padding:0;box-shadow:0 2px 8px rgba(10,132,255,0.3);transition:transform .08s ease,opacity .15s ease,background .15s ease;}'
+        +'#atlas-panel .atl-go{flex:0 0 auto;width:38px;height:38px;border-radius:50%;border:1px solid rgba(0,0,0,0.08);background:#fff;color:var(--primary-color);cursor:pointer;display:flex;align-items:center;justify-content:center;padding:0;box-shadow:0 2px 8px rgba(0,0,0,0.18);transition:transform .08s ease,opacity .15s ease,background .15s ease;}'   /* (#R147) send + stop buttons are WHITE ("送信ボタン、応答停止ボタンは白色に") — accent-coloured icon on a white circle, legible in light & dark */
         +'#atlas-panel .atl-go svg{display:block;}'
-        +'#atlas-panel .atl-go:hover{filter:brightness(1.08);} #atlas-panel .atl-go:active{transform:scale(0.9);}'
-        +'#atlas-panel .atl-go.idle{background:rgba(120,120,128,0.30);box-shadow:none;color:var(--text-muted);}'
-        +'#atlas-panel .atl-go.busy{background:var(--primary-color);box-shadow:0 2px 8px rgba(10,132,255,0.35);color:#fff;}'   /* (#R145) Stop-answering button uses the ACCENT colour ("停止ボタンはアクセントカラーに"); the enlarged square icon distinguishes it from Send */
+        +'#atlas-panel .atl-go:hover{background:#f0f0f4;} #atlas-panel .atl-go:active{transform:scale(0.9);}'
+        +'#atlas-panel .atl-go.idle{background:#fff;box-shadow:0 1px 4px rgba(0,0,0,0.12);color:rgba(120,120,128,0.75);}'   /* empty input: still white, muted icon */
+        +'#atlas-panel .atl-go.busy{background:#fff;box-shadow:0 2px 8px rgba(0,0,0,0.2);color:var(--primary-color);}'   /* (#R147) Stop-answering button is also WHITE; the enlarged square icon distinguishes it from Send */
         +'#atlas-panel .atl-go.busy:hover{filter:brightness(1.06);}'
         /* (#R72) per-message tools (copy / retry) under every Atlas reply — ChatGPT-style, user bubbles get none */
         +'#atlas-panel .atl-msgt{display:flex;gap:2px;margin:4px 0 0;align-self:flex-start;opacity:0.55;transition:opacity .15s ease;}'
@@ -31134,6 +31180,12 @@ window.addEventListener('DOMContentLoaded', () => {
         +'#atlas-panel .atl-ctl-toggle{flex:0 0 auto;width:36px;height:21px;border-radius:11px;border:none;background:rgba(120,120,128,0.32);position:relative;cursor:pointer;transition:background .18s ease;padding:0;}'
         +'#atlas-panel .atl-ctl-toggle .atl-ctl-knob{position:absolute;top:2px;left:2px;width:17px;height:17px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.3);transition:left .18s ease;}'
         +'#atlas-panel .atl-ctl-toggle.on{background:#34c759;} #atlas-panel .atl-ctl-toggle.on .atl-ctl-knob{left:17px;}'
+        /* (#R147) on/off view-features render as an explicit BUTTON with an ON/OFF badge ("オンオフ要素のある時はなるべくボタンを設置") */
+        +'#atlas-panel .atl-featbtn{display:inline-flex;align-items:center;gap:8px;margin:7px 6px 0 0;padding:6px 11px;border-radius:9px;border:1px solid rgba(128,128,128,0.28);background:var(--input-bg,rgba(120,120,128,0.12));color:var(--text-main);font-size:12px;font-weight:600;cursor:pointer;transition:border-color .15s ease,background .15s ease;}'
+        +'#atlas-panel .atl-featbtn:hover{border-color:var(--primary-color);}'
+        +'#atlas-panel .atl-featbtn .afb-s{font-size:10px;font-weight:800;letter-spacing:.05em;padding:2px 7px;border-radius:20px;background:rgba(120,120,128,0.34);color:#fff;}'
+        +'#atlas-panel .atl-featbtn.on{border-color:var(--primary-color);}'
+        +'#atlas-panel .atl-featbtn.on .afb-s{background:#34c759;}'
         +'#atlas-panel .atl-ctl-op{flex:0 0 120px;accent-color:var(--primary-color);}'
         +'#atlas-panel .atl-ctl-btn{align-self:flex-start;border:1px solid var(--glass-border,rgba(128,128,128,0.3));background:var(--input-bg);color:var(--text-main);border-radius:10px;padding:6px 12px;font-size:11.5px;font-weight:600;cursor:pointer;}'
         +'#atlas-panel .atl-ctl-btn:hover{border-color:var(--primary-color);color:var(--primary-color);}'
@@ -31302,7 +31354,7 @@ window.addEventListener('DOMContentLoaded', () => {
             } }catch(_){} });
           _refreshMapChips(); return; }
         const ftg=e.target.closest&&e.target.closest('.atl-feat-tog');   /* (#R145) on/off view-feature switch — flips the real control directly */
-        if(ftg){ const f=_FEAT_TOG[ftg.getAttribute('data-feat')]; if(f){ try{ f.set(!f.on()); }catch(_){} let now=false; try{ now=!!f.on(); }catch(_){} ftg.classList.toggle('on',now); ftg.setAttribute('aria-checked',now?'true':'false'); } return; }
+        if(ftg){ const f=_FEAT_TOG[ftg.getAttribute('data-feat')]; if(f){ try{ f.set(!f.on()); }catch(_){} let now=false; try{ now=!!f.on(); }catch(_){} ftg.classList.toggle('on',now); ftg.setAttribute('aria-checked',now?'true':'false'); const s=ftg.querySelector('.afb-s'); if(s) s.textContent=now?'ON':'OFF'; } return; }   /* (#R147) also update the ON/OFF badge on the button variant */
         const tg2=e.target.closest&&e.target.closest('.atl-ctl-toggle');
         if(tg2){ const rl=_ctlLayer(tg2); if(rl){ const want=!rl.cb.checked; rl.cb.checked=want; rl.cb.dispatchEvent(new Event('change',{bubbles:true})); tg2.classList.toggle('on',rl.cb.checked); tg2.setAttribute('aria-checked',rl.cb.checked?'true':'false'); } return; }
         /* (#R132) 経路10-10 §12.5: tap a turn-by-turn step in a road reply → highlight that segment on the map + fly to it.
@@ -31541,7 +31593,9 @@ window.addEventListener('DOMContentLoaded', () => {
       roads:{ lbl:()=>L('Roads','道路','Straßen','Дороги','Carreteras'), on:()=>{ const cb=document.getElementById('cb-roads'); return !!(cb&&cb.checked); }, set:v=>{ const cb=document.getElementById('cb-roads'); if(cb&&cb.checked!==v){ cb.checked=v; cb.dispatchEvent(new Event('change',{bubbles:true})); } } }
     };
     function _featTogHtml(kind){ const f=_FEAT_TOG[kind]; if(!f) return ''; let on=false; try{ on=!!f.on(); }catch(_){}
-      return '<div class="atl-ctl-row" style="margin-top:6px;"><span class="atl-ctl-lbl">'+esc(f.lbl())+'</span><button class="atl-ctl-toggle atl-feat-tog'+(on?' on':'')+'" data-feat="'+esc(kind)+'" role="switch" aria-checked="'+(on?'true':'false')+'"><span class="atl-ctl-knob"></span></button></div>'; }
+      /* (#R147) explicit on/off BUTTON (label + ON/OFF badge) rather than a bare switch; the delegated .atl-feat-tog
+         handler flips the real control and updates the badge. */
+      return '<button class="atl-featbtn atl-feat-tog'+(on?' on':'')+'" data-feat="'+esc(kind)+'" role="switch" aria-checked="'+(on?'true':'false')+'"><span class="afb-l">'+esc(f.lbl())+'</span><span class="afb-s">'+(on?'ON':'OFF')+'</span></button>'; }
     function mapToggleChip(kinds){ const K=Array.from(new Set((kinds||[]).filter(k=>_OVL[k]||k==='arc'))); if(!K.length) return '';
       return '<div class="atl-mapctl atl-ctl-row" data-ovls="'+esc(K.join(','))+'" style="margin:7px 0 1px;"><span class="atl-ctl-lbl">'+L('Shown on the map','地図に表示中','Auf der Karte','Показано на карте','En el mapa')+'</span>'
         +'<button class="atl-ctl-toggle atl-map-toggle on" role="switch" aria-checked="true" title="'+L('Show / hide on the map','地図で表示 / 非表示','Auf der Karte ein/aus','Показать/скрыть на карте','Mostrar/ocultar en el mapa')+'"><span class="atl-ctl-knob"></span></button></div>'; }
@@ -31589,7 +31643,7 @@ window.addEventListener('DOMContentLoaded', () => {
          ("✦ Kansai ⚠ Not found: Ruritania", "✓ Fires — on ⚠ could not confirm…"). Kills the "嘘のオン/オフ・嘘ハイライト報告". */
       const _visTypes={highlight:1,outline:1,draw:1,layer:1,opacity:1,controls:1,mapMetric:1,choropleth:1};
       const _visFailed=fails.some(a=>a&&_visTypes[a.type]) || acts.some(a=>a&&a.__meta&&(a.__meta.partial||a.__meta.unverified));
-      let head=(say&&!_allFailed&&!_visFailed)?('<div style="margin-bottom:6px;">'+esc(say)+'</div>'):'';
+      let head=(say&&!_allFailed&&!_visFailed)?('<div style="margin-bottom:6px;">'+mdMini(say)+'</div>'):'';   /* (#R147) render say via mdMini so line breaks / bold / headings show instead of a flat esc block */
       if(fails.length){ const fl=fails.map(actLabel).filter(Boolean).join(', ');
         head+='<div style="font-size:11.5px;color:#ff9f0a;font-weight:600;margin:1px 0 6px;">⚠ '+L(fails.length+' step(s) could not be completed','実行できなかった操作が '+fails.length+' 件あります',fails.length+' Schritt(e) nicht ausgeführt','Не выполнено шагов: '+fails.length,fails.length+' paso(s) sin completar')+(fl?(' — '+esc(fl)):'')+'</div>'; }
       if(cancelled) head=_cancelledNote()+head;
@@ -31966,7 +32020,7 @@ window.addEventListener('DOMContentLoaded', () => {
              実行したと言っている操作が実行されていない). (2) else show the model's say (a real clarification / answer).
              (3) else admit we could not interpret it. */
           if(lp&&lp.actions&&lp.actions.length){ const fails=await runActions(ai,'',lp.actions,gen); if(gen===_runGen) recordTurn(q,'',lp.actions,fails); msgTools(ai,q); return; }
-          const say=plan&&plan.say; if(say){ ai.innerHTML='<div style="font-size:12px;line-height:1.55;">'+esc(say)+'</div>'; recordTurn(q, say, [], []); msgTools(ai,q); return; }
+          const say=plan&&plan.say; if(say){ ai.innerHTML='<div style="line-height:1.6;">'+mdMini(say)+'</div>'; recordTurn(q, say, [], []); msgTools(ai,q); return; }   /* (#R147) mdMini + inherit bubble size (drop inline 12px) */
           ai.innerHTML=esc(L('Sorry, I could not interpret that.','うまく解釈できませんでした。','Konnte das nicht interpretieren.','Не удалось понять запрос.','No pude interpretarlo.')); msgTools(ai,q); return;
         }
         /* (#R53) ANTI-FABRICATION: if the model only "answered" (no real action) yet we have a deterministic plan
@@ -33234,11 +33288,11 @@ window.addEventListener('DOMContentLoaded', () => {
     function _overlay(inner,cls){ const ov=document.createElement('div'); ov.className='mon-ov '+(cls||''); ov.innerHTML='<div class="mon-dialog" role="dialog" aria-modal="true">'+inner+'</div>';
       document.body.appendChild(ov); ov.addEventListener('click',e=>{ if(e.target===ov) ov.remove(); }); const x=ov.querySelector('.mon-x'); if(x) x.onclick=()=>ov.remove(); return ov; }
     function openCreateDialog(prefill){ if(!_loggedIn()){ _promptLogin(); return; }
-      prefill=prefill||{}; let area=prefill.area||activeArea(); let usingView=false;
+      prefill=prefill||{}; let area=prefill.area||activeArea(); let usingView=false; if(!area){ const mv=mapViewArea(); if(mv){ area=mv; usingView=true; } }   /* (#R147) fall back to the current map view so "監視を作成" is always actionable — the button used to render disabled with no area and clicking did nothing ("監視を作成を押しても何も起こらない") */
       const intervals=[[30,ML('Every 30 min','30分ごと','Alle 30 Min','Каждые 30 мин','Cada 30 min')],[60,ML('Hourly','1時間ごと','Stündlich','Каждый час','Cada hora')],[180,ML('Every 3 hours','3時間ごと','Alle 3 Std','Каждые 3 ч','Cada 3 h')],[360,ML('Every 6 hours','6時間ごと','Alle 6 Std','Каждые 6 ч','Cada 6 h')],[720,ML('Every 12 hours','12時間ごと','Alle 12 Std','Каждые 12 ч','Cada 12 h')],[1440,ML('Daily','1日ごと','Täglich','Ежедневно','Diario')]];
       const sens=[['low',ML('Low — only big changes','低 — 大きな変化のみ','Niedrig','Низкая','Baja')],['medium',ML('Medium (default)','中（既定）','Mittel','Средняя','Media')],['high',ML('High — smaller changes','高 — 小さな変化も','Hoch','Высокая','Alta')]];
       const srcOpts=[['news',true],['earthquake',false],['weather',false],['fire',false]];
-      const areaLine=area?('<div class="mon-area-box">'+S(ML('Watching','監視範囲','Überwacht','Область','Vigilando'))+': <b>'+S(area.label)+'</b></div>')
+      const areaLine=area?('<div class="mon-area-box">'+S(ML('Watching','監視範囲','Überwacht','Область','Vigilando'))+': <b>'+S(area.label)+'</b></div>'+(usingView?'<div style="font-size:11px;color:var(--text-muted);margin:2px 0 6px;line-height:1.4;">'+S(ML('Using the current map view — pan/zoom before creating, or close and set a radius, draw an area or resolve a region for a tighter watch.','現在の地図表示を使用中です。作成前に地図を調整するか、一度閉じて半径・描画・地域指定でより狭い範囲を監視できます。','Aktuelle Kartenansicht — vor dem Erstellen anpassen oder für einen engeren Bereich Radius/Zeichnung/Region setzen.','Используется текущий вид карты — настройте карту перед созданием или задайте радиус/область/регион для более узкой зоны.','Usando la vista actual del mapa — ajústala antes de crear o define un radio/área/región para una zona más precisa.'))+'</div>':''))
         :('<div class="mon-area-box mon-area-none">'+S(ML('No area selected. Set a radius, draw an area, or resolve a region — or use the current map view below.','範囲が未選択です。半径・描画・地域指定するか、下の「現在の地図表示」を使ってください。','Kein Bereich gewählt.','Область не выбрана.','Sin área seleccionada.'))+'</div>');
       const inner='<button class="mon-x" aria-label="Close">✕</button>'
         +'<h3 class="mon-h3">'+S(ML('New monitor','新規監視','Neuer Monitor','Новый монитор','Nuevo monitor'))+'</h3>'
@@ -33262,7 +33316,7 @@ window.addEventListener('DOMContentLoaded', () => {
         if(btn) btn.disabled=!area; if(nm&&!nm.value&&area) nm.value=area.label; };
       const uv=ov.querySelector('#mon-usemapview'); if(uv) uv.onclick=()=>{ area=mapViewArea(); usingView=true; uv.style.display='none'; upd(); };
       ov.querySelector('.mon-cancel').onclick=()=>ov.remove();
-      ov.querySelector('#mon-create-btn').onclick=async(e)=>{ const btn=e.target; if(!area){ return; } btn.disabled=true; btn.textContent='…';
+      ov.querySelector('#mon-create-btn').onclick=async(e)=>{ const btn=e.target; if(!area){ const mv=mapViewArea(); if(mv){ area=mv; usingView=true; } } if(!area){ _toast(ML('Please set an area to monitor first (radius, drawn area, region, or the current map view).','監視する範囲を先に指定してください（半径・描画・地域、または現在の地図表示）。','Bitte zuerst einen Bereich festlegen (Radius, Zeichnung, Region oder Kartenansicht).','Сначала укажите область для мониторинга (радиус, область, регион или вид карты).','Primero define un área a vigilar (radio, área, región o vista del mapa).')); return; } btn.disabled=true; btn.textContent='…';   /* (#R147) never a silent no-op */
         const sources=[...ov.querySelectorAll('.mon-src input:checked')].map(c=>c.value); if(!sources.length) sources.push('news');
         const cmp=ov.querySelector('#mon-cmp').value; const intv=parseInt(ov.querySelector('#mon-int').value,10)||360;
         const sensV=ov.querySelector('#mon-sens').value; const sensMap={low:{min_score:0.45,min_new:3},medium:{min_score:0.3,min_new:1},high:{min_score:0.18,min_new:1}};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test",
     "test:security": "node --test tests/security-logic.mjs",
     "test:monitor": "node --test tests/monitor-logic.test.mjs",
-    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs tests/monitor-logic.test.mjs && playwright test",
+    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs && playwright test",
     "report": "playwright show-report"
   },
   "devDependencies": {

--- a/supabase/functions/ai-proxy/index.ts
+++ b/supabase/functions/ai-proxy/index.ts
@@ -17,8 +17,8 @@
 //  Deploy:   supabase functions deploy ai-proxy --project-ref vpekfwdpurzejrrmacac
 //            (verify_jwt can stay ON; we also verify the user explicitly.)
 //  Secrets:  supabase secrets set AI_PROVIDER=openai                  (openai | anthropic | gemini)
-//            supabase secrets set AI_MODEL=gpt-5.6-luna               (model fixed here; users never pick it)
-//            supabase secrets set OPENAI_API_KEY=sk-...               (CURRENT provider — Luna via /v1/responses)
+//            supabase secrets set AI_MODEL=gpt-5.6-terra              (#R147 Luna→Terra; model fixed here; users never pick it)
+//            supabase secrets set OPENAI_API_KEY=sk-...               (CURRENT provider — Terra via /v1/responses)
 //            # other providers stay wired but dormant:
 //            supabase secrets set GEMINI_API_KEY=AIza...              (if AI_PROVIDER=gemini)
 //            supabase secrets set GEMINI_SEARCH_ENABLED=false         (#R113 Gemini grounding, default OFF)
@@ -50,7 +50,9 @@
 //      "do not call functions" hardened + JSON mode forced.
 //  Secrets, JWTs and full prompts are never logged.
 // ----------------------------------------------------------------------------
-//  (#R114) OpenAI gpt-5.6-luna migration (from Gemini) — Responses API path.
+//  (#R114) OpenAI GPT-5.6 migration (from Gemini) — Responses API path.
+//  (#R147) Model is GPT-5.6 Terra (was Luna). Set via the AI_MODEL secret; the
+//  Gemini path stays wired but dormant — Gemini 3.1 Flash-Lite is never used.
 //    • OpenAI calls go through /v1/responses (reasoning.effort:"low", store:false),
 //      text + image input, JSON mode for the JSON tasks (map_report / json_extract).
 //    • Web search is a HOSTED tool attached only when the client asks (webMode
@@ -83,7 +85,7 @@ const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { ...cors, "Content-Type": "application/json" } });
 
 // ---- Plan → daily free-use limit. Extend here for future paid tiers. --------
-const PLAN_LIMITS: Record<string, number> = { free: 30, plus: 50, pro: 200, unlimited: 1_000_000 };   /* (#R101) free 10→30/day */
+const PLAN_LIMITS: Record<string, number> = { free: 10, plus: 50, pro: 200, unlimited: 1_000_000 };   /* (#R101) free 10→30/day; (#R147) 30→10/day */
 const DEFAULT_LIMIT = PLAN_LIMITS.free;
 
 const MAX_PROMPT = 24_000;     // hard caps so a single call can't be abused
@@ -283,7 +285,7 @@ async function callAnthropic(model: string, key: string, prompt: string, system:
 }
 
 async function callOpenAI(model: string, key: string, prompt: string, system: string, imgs: ImgPart[], web: boolean, maxTokens: number, wantJson: boolean, forceWeb: boolean, effort: string): Promise<{ text: string; finishReason: string; webAttached: boolean; webUsed: boolean; webCount: number; citations: WebCitation[] }> {
-  // GPT-5.6 models (gpt-5.6-luna) work best through the Responses API. `max_output_tokens`
+  // GPT-5.6 models (gpt-5.6-terra) work best through the Responses API. `max_output_tokens`
   // includes invisible reasoning tokens, so leave a reasoning allowance above IntMap's
   // visible-output budget — bigger when effort is "medium" (#R116) — under a hard ceiling.
   const content: unknown[] = [{ type: "input_text", text: prompt }];
@@ -573,7 +575,7 @@ Deno.serve(async (req) => {
     : (wantJson && payload.schema && typeof payload.schema === "object" ? payload.schema : undefined);
   const searchEnabled = (Deno.env.get("GEMINI_SEARCH_ENABLED") || "").toLowerCase() === "true";
   const model = Deno.env.get("AI_MODEL") ||
-    (provider === "openai" ? "gpt-4o-mini" : provider === "gemini" ? "gemini-3.5-flash" : "claude-3-5-haiku-latest");
+    (provider === "openai" ? "gpt-5.6-terra" : provider === "gemini" ? "gemini-3.5-flash" : "claude-3-5-haiku-latest");   /* (#R147) OpenAI default = GPT-5.6 Terra */
 
   try {
     let out: { text: string; finishReason: string; webAttached?: boolean; webUsed?: boolean; webCount?: number; citations?: WebCitation[] };

--- a/supabase/functions/monitor-run/index.ts
+++ b/supabase/functions/monitor-run/index.ts
@@ -27,7 +27,7 @@
 //  Deploy:   supabase functions deploy monitor-run --no-verify-jwt --project-ref vpekfwdpurzejrrmacac
 //  Secrets:  supabase secrets set MONITOR_SECRET=<random>          (REQUIRED — fail-closed)
 //            # AI reuses the SAME server-held key/provider as ai-proxy:
-//            supabase secrets set AI_PROVIDER=openai   AI_MODEL=gpt-5.6-luna   OPENAI_API_KEY=sk-...
+//            supabase secrets set AI_PROVIDER=openai   AI_MODEL=gpt-5.6-terra   OPENAI_API_KEY=sk-...
 //            supabase secrets set MONITOR_AI=off        (optional kill-switch → mechanical only)
 //  (SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY are injected automatically.)
 // ============================================================================
@@ -78,7 +78,7 @@ function timingSafeEqual(a: string, b: string): boolean {
 
 // ---------------------------------------------------------------------------
 //  AI provider (server-held key; same env convention as ai-proxy / refresh-news).
-//  OpenAI goes through the Responses API (works with gpt-5.6-luna, JSON mode, no
+//  OpenAI goes through the Responses API (works with gpt-5.6-terra, JSON mode, no
 //  web tools — the report is grounded ONLY in the evidence we pass). Anthropic &
 //  Gemini kept as selectable fallbacks.
 // ---------------------------------------------------------------------------
@@ -118,7 +118,7 @@ const AI_SYS =
 
 async function callAI(cfg: { provider: string; key: string; model: string }, userMsg: string): Promise<string> {
   if (cfg.provider === "openai") {
-    // GPT-5.6-luna via the Responses API. NOTE: OpenAI's json_object validator requires the word
+    // GPT-5.6 (Terra) via the Responses API. NOTE: OpenAI's json_object validator requires the word
     // "json" in the INPUT messages (not `instructions`); the user message carries it. A 400 still
     // degrades to a tool-free/JSON-mode-free retry (like ai-proxy) — the prompt + client validation
     // enforce the shape either way, so a request-shape rejection never blanks a report.

--- a/tests/r142.spec.js
+++ b/tests/r142.spec.js
@@ -120,7 +120,7 @@ test('#14 Radius popup: Style disclosure folds preset/colour, slider stays promi
       presetInside: !!tp.querySelector('details.tp-more #radius-preset'),
       colorInside: !!tp.querySelector('details.tp-more #radius-color'),
       sliderOutside: !!tp.querySelector('.radius-control #radius-range') && !tp.querySelector('details.tp-more #radius-range'),
-      stats: !!tp.querySelector('.rad-stats #rad-r'),
+      stats: !!tp.querySelector('.rad-stats #rad-c'),   // (#R147) redundant #rad-r tile removed; circumference/area remain
     };
   });
   expect(r.disclosure).toBe(true);

--- a/tests/r147-checks.test.mjs
+++ b/tests/r147-checks.test.mjs
@@ -1,0 +1,65 @@
+// R147 source-level regression checks (deterministic, no browser needed).
+// Guards the config / prompt / map-style changes that are hard to assert headless:
+//   #12 model Luna→Terra   #13 free quota 30→10   #10 Atlas scope/safety layer
+//   #2  Japanese keigo      #5  SV fluorescent 水色  #9  satellite instant fade
+//   #14 monitor create map-view fallback
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../', import.meta.url);
+const html = readFileSync(new URL('index.html', root), 'utf8');
+const aiproxy = readFileSync(new URL('supabase/functions/ai-proxy/index.ts', root), 'utf8');
+
+test('R147 #13 free AI quota is 10/day on the client and server', () => {
+  assert.match(html, /const AI_FREE_DAILY\s*=\s*10\b/, 'client AI_FREE_DAILY=10');
+  assert.match(aiproxy, /free:\s*10\b/, 'server PLAN_LIMITS.free=10');
+  assert.ok(!/up to 30 uses per day/.test(html), 'no stale "30 uses per day" copy');
+  assert.ok(!/1日30回/.test(html), 'no stale JP "1日30回"');
+});
+
+test('R147 #12 Atlas model is GPT-5.6 Terra; Gemini 3.1 Flash-Lite is never used', () => {
+  assert.match(aiproxy, /provider === "openai" \? "gpt-5\.6-terra"/, 'openai default = terra');
+  assert.match(aiproxy, /Flash-Lite is never used/, 'documents that Gemini Flash-Lite is never used');
+  // flash-lite is allowed ONLY in that "never used" note — nowhere else (esp. not as a model id).
+  const aiproxyNoNote = aiproxy.replace(/Gemini 3\.1 Flash-Lite is never used\./g, '');
+  assert.ok(!/flash-lite/i.test(aiproxyNoNote), 'flash-lite appears only in the "never used" note');
+  assert.ok(!/flash-lite/i.test(html), 'no flash-lite in index.html');
+  // The active model id in comments/docs is Terra, not Luna.
+  assert.ok(!/gpt-5\.6-luna/.test(aiproxy), 'no lingering gpt-5.6-luna in ai-proxy');
+});
+
+test('R147 #10 Atlas planner prompt carries the scope/safety judgment layer', () => {
+  assert.match(html, /SCOPE & SAFETY/, 'scope/safety section present');
+  for (const axis of ['PURPOSE', 'TARGET', 'PRECISION', 'OUTPUT']) {
+    assert.ok(html.includes(axis + ':'), 'decomposition axis ' + axis);
+  }
+  assert.match(html, /TRANSFORM it and EXECUTE/, 'transform-not-refuse');
+  assert.match(html, /full refusal is the LAST resort/i, 'refuse = last resort');
+  for (const dom of ['disasters', 'disease', 'chemicals', 'crime', 'cyber', 'critical infrastructure']) {
+    assert.ok(html.includes(dom), 'domain generality includes ' + dom);
+  }
+  // constructive (non-dead-end) provider_blocked message
+  assert.match(html, /Try rephrasing it as a public-information, broad-area analysis/);
+});
+
+test('R147 #2 Atlas defaults to polite Japanese (keigo) unless the user opts out', () => {
+  assert.match(html, /敬語/, 'keigo instruction present');
+  assert.match(html, /polite form/, 'polite-form instruction present');
+});
+
+test('R147 #5 Street View coverage is a vivid fluorescent light-blue', () => {
+  assert.match(html, /'raster-saturation':0\.95/, 'boosted saturation');
+  assert.match(html, /'raster-hue-rotate':-42/, 'stronger cyan hue');
+  assert.match(html, /'raster-brightness-min':0\.5/, 'brightness lift (glow)');
+});
+
+test('R147 #9 satellite base layer has instant tile fade (no 300ms cross-fade)', () => {
+  assert.match(html, /id:'layer-sat'[\s\S]{0,140}'raster-fade-duration':0/, 'layer-sat fade 0');
+  assert.match(html, /'satellite':\{type:'raster'[\s\S]{0,260}maxzoom:19\}/, 'satellite source maxzoom cap');
+});
+
+test('R147 #14 monitor create dialog falls back to the current map view', () => {
+  assert.match(html, /if\(!area\)\{ const mv=mapViewArea\(\); if\(mv\)\{ area=mv; usingView=true; \} \}/,
+    'openCreateDialog defaults to mapViewArea when no area is set');
+});

--- a/tests/r147.spec.js
+++ b/tests/r147.spec.js
@@ -1,0 +1,131 @@
+// R147 UI regression tests — UX batch:
+//   #4  Radius popup declutter (redundant radius stat tile removed)
+//   #11 Atlas send/stop buttons white  +  #6 on/off features render as buttons that flip the real control
+//   #3  Companies logos cached across re-renders (no clearbit-ladder flicker)
+//   #1  Companies compare: sortable table + Countries-parity cap
+//   #7  Köppen legend fit helper present  +  #9 satellite instant fade in the live style
+import { test, expect } from '@playwright/test';
+import { installHermeticRouting, collectPageDiagnostics } from './helpers/network.js';
+
+const CRITICAL = ['IntMapConsole', 'IntMapCompanies'];
+test.describe.configure({ mode: 'serial' });
+
+let page, diag;
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext();
+  await installHermeticRouting(context);
+  page = await context.newPage();
+  diag = collectPageDiagnostics(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 45_000 });
+  await page.waitForFunction((g) => g.every((k) => typeof window[k] !== 'undefined'), CRITICAL, { timeout: 45_000 });
+  await page.waitForTimeout(1000);
+});
+test.afterAll(async () => { await page?.context()?.close(); });
+
+// ---- #4 Radius popup declutter -------------------------------------------
+test('#4 Radius popup drops the redundant radius tile (circumference+area remain, style collapsed)', async () => {
+  const r = await page.evaluate(() => {
+    window._radiusFromPoint(139.7, 35.68, 'test');
+    const tp = document.getElementById('tool-panel');
+    return {
+      radR: !!tp.querySelector('#rad-r'),
+      radC: !!tp.querySelector('#rad-c'),
+      radA: !!tp.querySelector('#rad-a'),
+      tiles: tp.querySelectorAll('.rad-stat').length,
+      collapsed: tp.querySelector('details.tp-more') ? !tp.querySelector('details.tp-more').open : null,
+    };
+  });
+  expect(r.radR).toBe(false);     // removed
+  expect(r.radC).toBe(true);
+  expect(r.radA).toBe(true);
+  expect(r.tiles).toBe(2);
+  expect(r.collapsed).toBe(true);
+});
+
+// ---- #11 Atlas white button + #6 feature buttons -------------------------
+test('#11/#6 Atlas go button is white and feature on/off renders a button that flips the real control', async () => {
+  const r = await page.evaluate(async () => {
+    try { window.IntMapConsole?.open?.(); } catch { /* ignore */ }
+    const go = document.querySelector('#atlas-panel .atl-go');
+    const goBg = go ? getComputedStyle(go).backgroundColor : null;   // empty input → idle, still white
+    const off = await window.IntMapConsole.dispatch({ type: 'grid', on: false });
+    const hasBtn = /atl-featbtn/.test(off.html) && /afb-s/.test(off.html);   // real button + ON/OFF badge
+    const chat = document.querySelector('#atlas-panel .atl-chat');
+    const d = document.createElement('div'); d.className = 'atl-b a'; d.innerHTML = off.html; chat.appendChild(d);
+    const tog = d.querySelector('.atl-feat-tog');
+    const gridOn = () => { const b = document.getElementById('btn-tool-grid'); const c = document.getElementById('cb-grid'); return !!((b && b.classList.contains('tool-on')) || (c && c.checked)); };
+    const before = gridOn(); if (tog) tog.click(); const after = gridOn();
+    return { goBg, hasBtn, injected: !!tog, flipped: before !== after && after === true };
+  });
+  expect(r.goBg).toBe('rgb(255, 255, 255)');
+  expect(r.hasBtn).toBe(true);
+  expect(r.injected).toBe(true);
+  expect(r.flipped).toBe(true);
+});
+
+// ---- #3 Companies logo cache (no flicker) --------------------------------
+test('#3 Companies logos are cached — a re-render never restarts the clearbit ladder', async () => {
+  const r = await page.evaluate(() => {
+    document.getElementById('btn-info').click();
+    // Deterministically drive every logo through its Clearbit→favicon→monogram ladder to the terminal
+    // (cached) state — dispatching the error synchronously avoids depending on hermetic network timing.
+    for (let k = 0; k < 4 && document.querySelectorAll('.co-logo').length; k++) {
+      document.querySelectorAll('.co-logo').forEach((img) => img.dispatchEvent(new Event('error')));
+    }
+    const resolvedMonos = document.querySelectorAll('.co-mono').length;   // all rows now resolved (cached)
+    // force a full re-render by toggling mode away and back
+    const other = [...document.querySelectorAll('.mode-btn')].find((b) => b.id !== 'btn-info'); if (other) other.click();
+    document.getElementById('btn-info').click();
+    const logos = [...document.querySelectorAll('.co-logo')];
+    return {
+      resolvedMonos,
+      step0clearbit: logos.filter((i) => i.dataset.step === '0' && /clearbit/.test(i.src || '')).length,
+      monosAfterRerender: document.querySelectorAll('.co-mono').length,
+    };
+  });
+  expect(r.resolvedMonos).toBeGreaterThan(0);          // the ladder settled
+  // the resolved result comes straight from cache on re-render → zero rows re-request the failed Clearbit url
+  expect(r.step0clearbit).toBe(0);
+  expect(r.monosAfterRerender).toBeGreaterThan(0);     // cached monograms emitted directly (no flicker)
+});
+
+// ---- #1 Companies compare: sortable table --------------------------------
+test('#1 Companies compare has a sortable table (Countries parity)', async () => {
+  const r = await page.evaluate(() => {
+    document.getElementById('btn-info').click();
+    const tks = window.IntMapCompanies.DATA.slice(0, 4).map((c) => c.tk);
+    tks.forEach((tk) => window._coToggleCompare(tk));
+    window._coShowCompare();
+    const view = document.getElementById('co-cmp-view');
+    if (!view) return { view: false };
+    view.querySelector('[data-cmpmode="table"]')?.click();
+    const headers = view.querySelectorAll('[data-cmpsort]').length;
+    const firstBefore = view.querySelector('.scp-tbl tbody tr td')?.textContent || '';
+    view.querySelector('[data-cmpsort]')?.click();   // sort by the first metric
+    const firstAfter = view.querySelector('.scp-tbl tbody tr td')?.textContent || '';
+    return { view: true, headers, rows: view.querySelectorAll('.scp-tbl tbody tr').length, changed: firstBefore !== firstAfter };
+  });
+  expect(r.view).toBe(true);
+  expect(r.headers).toBeGreaterThan(0);   // metric columns are clickable sort headers
+  expect(r.rows).toBe(4);
+});
+
+// ---- #7 Köppen fit helper + #9 satellite instant fade --------------------
+test('#7/#9 Köppen legend fit helper present and satellite layer fades instantly', async () => {
+  const r = await page.evaluate(() => {
+    const out = { fitFn: typeof window._fitKoppenLegend };
+    try {
+      const st = window.__imap && window.__imap.getStyle ? window.__imap.getStyle() : null;
+      const sat = st && st.layers ? st.layers.find((l) => l.id === 'layer-sat') : null;
+      out.satFade = sat && sat.paint ? sat.paint['raster-fade-duration'] : 'no-layer';
+    } catch (e) { out.err = String(e); }
+    return out;
+  });
+  expect(r.fitFn).toBe('function');
+  if (r.satFade !== 'no-layer' && r.satFade !== undefined) expect(r.satFade).toBe(0);
+});
+
+// ---- boot honesty --------------------------------------------------------
+test('no uncaught page errors during R147 interactions', async () => {
+  expect(diag.pageErrors, `pageerror(s):\n${diag.pageErrors.join('\n---\n')}`).toHaveLength(0);
+});


### PR DESCRIPTION
14 user-reported items fixed from root cause. All additive/in-place (single `index.html` + edge functions `ai-proxy`/`monitor-run`). `npm test` green: static + 47 node (security/monitor + new **r147-checks 7**) + **Playwright 63** (new `r147.spec.js` 6; r142 `#rad-r`→`#rad-c`; pageerror 0).

## Items
1. **#12 model Luna→Terra** — `AI_MODEL` secret + ai-proxy openai fallback `gpt-4o-mini`→`gpt-5.6-terra`; Luna→Terra comments; **Gemini 3.1 Flash-Lite documented never-used**.
2. **#13 free quota 30→10/day** — `PLAN_LIMITS.free` + `AI_FREE_DAILY` + 5-language copy.
3. **#10 over-refusal fix** — `SYS()` + `_analysisSystemPrompt()` gain a **SCOPE & SAFETY** judgment layer (purpose/target/precision/output; transform-not-refuse; domain-general: military/disaster/disease/CBRN/crime/cyber/infra; refuse = last resort). Constructive `provider_blocked` message (5 lang). Completion (missile example → broad public zone + reach rings + uncertainty, not a bare refusal) verified against production.
4. **#2 Japanese keigo** default (opt-out on explicit casual).
5. **#11 send + stop buttons white**; **#6 on/off features → labeled ON/OFF buttons** + Satellite wired.
6. **#8 reply typography** — route `say` through `mdMini`; em-based heading hierarchy + paragraph spacing (fixes the flat monotone block + the sidebar `!important` that flattened headings).
7. **#5 SV coverage** → vivid fluorescent light-blue; **#9 satellite** `raster-fade-duration:0` + source `maxzoom` (smooth fast zoom/pan, esp. mobile).
8. **#7 Köppen legend** resize clamps to content height (stops at the last class).
9. **#3 Companies logo flicker** → module-level resolved-logo cache + debounced re-render (verified: **0/190** rows revert to Clearbit on re-render); **#1 compare** table column sort + cap 8→10.
10. **#4 Radius** drop the redundant radius stat tile (2-tile strip); **#14 Monitor create** defaults to the current map view so the button is never a silent no-op.

## Tests
- `tests/r147.spec.js` — radius declutter, white go button + feature button flip, logo cache no-flicker, compare sort, Köppen fit + satellite fade, pageerror 0.
- `tests/r147-checks.test.mjs` — source guards for model/quota/scope-safety/keigo/SV colour/satellite fade/monitor fallback.

## Deploy
`ai-proxy` redeployed + `AI_MODEL=gpt-5.6-terra` secret set (see PR checks / DEV-NOTES R147).

🤖 Generated with [Claude Code](https://claude.com/claude-code)