### PR TITLE
R150: UX/feature batch (10) — monitor-save root cause, Köppen stretch, Atlas ambiguity-gate unification, research-mapping audit, GPT-5.6 Terra, flight-sim satellite prefetch

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -720,7 +720,7 @@ supabase/
   - ai-proxy は (1)JWTでユーザー確認（要ログイン）→ (2)`profiles.plan` で上限決定（free=**10/日** `PLAN_LIMITS`。#R40=10→#R101=30→**#R147=10へ戻す**）→
     (3)`increment_ai_usage` RPC で当日分を原子的に消費（超過は 429）→ (4)**サーバー保持の鍵**でプロバイダ呼び出し →
     (5)失敗時は `refund_ai_usage` で消費分を返金。
-  - プロバイダは `AI_PROVIDER`（`anthropic`|`openai`|`gemini`）。モデルは `AI_MODEL`（既定はプロバイダ毎、**現行=`openai` / `gpt-5.6-luna`（Responses API `/v1/responses`）**。#R147でTerraへ切替えたが**このOpenAIプロジェクトはTerraにアクセス権が無く（403 model_not_found）Atlasが全滅→#R148でLunaへ戻し**、ai-proxyに`FALLBACK_MODEL`（不在モデルは403/404で1回Lunaへリトライ）を追加。Gemini/Anthropic経路は温存・切替可だが**Gemini 3.1 Flash‑Liteは不使用**）。
+  - プロバイダは `AI_PROVIDER`（`anthropic`|`openai`|`gemini`）。モデルは `AI_MODEL`（既定はプロバイダ毎、**現行=`openai` / `gpt-5.6-terra`（Responses API `/v1/responses`）**。#R147でTerraへ切替→#R148で403 no-accessのためLunaへ差戻し→**#R150で`refresh-news`プロキシ再検証(ai 61/104成功)によりTerra到達可を確認しTerraを採用**。ai-proxy `OPENAI_DEFAULT_MODEL=terra`＋`FALLBACK_MODEL=luna`（不在モデルは403/404で1回Lunaへリトライ＝耐障害）。Gemini/Anthropic経路は温存・切替可だが**Gemini 3.1 Flash‑Liteは不使用**）。
   - **#R147 Atlas scope/safety 判定層**：`SYS()` プランナー（＋`_analysisSystemPrompt()`）に「SCOPE & SAFETY」節。機微語の単語一致で全面拒否せず、**目的/対象/精度/出力の4軸**で分解→既定で**安全版を実行**（精密点→広域公開ゾーン、公開情報限定、攻撃最適化→脅威評価/到達圏/防災、不確実性・出典明示、`drawPolygon`/`radius`/`missile`/`radiation`/`impact` 等で実描画）。**全面拒否は真に有害なスライスのみ**の最終手段で、それでも「できる安全な分析」を提示。軍事/災害/感染症/化学(CBRN)/犯罪統計/サイバー/重要インフラに汎用適用。`provider_blocked` 文言も建設的（言い換え提案）に5言語。**日本語は既定で敬語**（ユーザーがくだけた口調を明示した時のみ例外）。
   - 用途：ニュースタイトル翻訳、ビューの要約、画像解析など**ユーザー操作のAI機能**。
   - **#R113 Gemini 3.5 Flash / `thinkingLevel:"low"` 移行 — 責任分離。** クライアントは**タスク種別**
@@ -990,6 +990,18 @@ supabase/
 - **歴史Wiki拡充**: `_ERA_WIKI` に HRV(独立国1941-45)・SGP/BLZ/GUY/SUR/ZMB/MWI/BWA/LSO/SWZ/UGA の植民地期実記事（全て新規キー・ポップアップが存在プローブ）。実測: 1943 Zagreb→`Independent_State_of_Croatia`。
 
 ---
+
+## #R150 補足（UX/機能バッチ10件：モニター保存の真因user_id欠落／ケッペン下端伸縮／Atlas曖昧性ゲート統一／調査回答マッピングのコード側検証／Terra採用／衛星飛行プリフェッチ）
+
+- **モニター保存（#6）**: `IntMapMonitors.create()` の挿入行が `user_id` を欠落（`area_monitors.user_id` は `not null`＋insert RLS `user_id=auth.uid()`）→ UIからの作成は毎回失敗し「Could not save the monitor.」。修正＝client が `row.user_id=currentUser.id`（他の user-owned insert と同型）＋ migration `20260721140000` で `alter column user_id set default auth.uid()`（本番適用済み・冪等）。**この機能は service_role 経由でしか検証されておらず、ログインclientの挿入経路は未検証だった**のが盲点。
+- **ケッペン凡例（#3）**: `_fitKoppenLegend` の `maxHeight` を**ビューポート基準**(`innerHeight - top - 12`、content-box分減算)に。従来の**内容高クランプは伸縮を阻害**（背の高い画面/区分少で画面下端まで引けない＝「一番下まで伸ばせない」）。CSS `max-height:calc(100dvh - 84px)` は温存、内側 `.kl-scroll` が全区分を担保。
+- **Atlas地理対象の曖昧性ゲート（#7）**: 共有 `_hlAmbigConfirm` で**単一の確認**を生成し、multi-region/single 両経路が**描画前にゲート**（曖昧が1つでもあれば `R(false,…,{meta:{partial:true}})` で停止＝何も塗らない・planner say 抑止）。従来は塗った成功の隣に `gAmbig`/`ambig` を警告として追記＝「候補確認・部分実行・成功報告・失敗警告」の同時表示が真因。個別地名ハードコード無し＝`resolveHlTarget` の `ambiguous` 判定に駆動。
+- **調査回答マッピングのコード側検証（#10）**: PURE基盤（`IntMapAtlasDebug` 公開でhermeticテスト可）＝`_atlExtractPlaces`(本文抽出=省略時安全網)／`_atlAuditSources`＋`_atlRegDomain`＋`_atlIsOfficial`(出典正規化・単一集中検出・官公庁/一次優先)／`_atlMappingVerdict`(mapped/unplaced/ambiguous)／`_atlGeocodeStrict`(同名≥2でambiguous・place型＋名称一致のみ・座標推測なし)。orchestrator `_pinReplyPlaces` は**既存ピンとMERGE**(clearしない・スキップ廃止・空catch廃止→console.warn＋正直な注記)。
+- **Atlas使用モデル（#9）**: `refresh-news`（同キー・同AI_MODEL・**モデルfallback無**）で `AI_MODEL=gpt-5.6-terra` → ai 61/63(en)・104/116(jp)成功＝**Terra再検証で到達可**。`AI_MODEL` secret=terra・ai-proxy default=terra・`FALLBACK_MODEL=luna`。
+- **タイポ（#4）**: `_atlStanza`(改行無し長塊を~2文stanzaへ)＋mdMiniで文末＋単一改行→ソフト段落余白。構造化済みは不介入。
+- **衛星3D飛行（#8）**: `predictivePrefetch` が `moveend` のみ発火→**飛行中(連続移動)は先読み皆無**が真因。`window._imPredictivePrefetch` 公開＋飛行ループで~2.6回/秒スロットル呼出。`sat-labels` を Esri 2ホストでラウンドロビン。既存最適化(2/5ホスト分散・native-max DEM・fade0・8192キャッシュ)温存。
+- **停止四角(#5)** rect 17.5→15.5。**Companies(#1)** は既に Countries 同型・`.co-logo-box` 32→30px で国旗枠と画素一致。**SVオフ(#2)** にも `_featTogHtml('streetview')`。
+- テスト: `tests/r150-checks.test.mjs`(node 12・ソース保証) ＋ `tests/r150.spec.js`(Playwright 7・業務委託の全ケースを純関数でruntime検証)。r147/r149-checksをR150差分へ更新。PR #23。
 
 ## #R143 補足（Atlas地理対象解決の汎用基盤：UN M49国集合＝実国境／多地域＝グループ別色＋凡例／描画前ジオメトリ検証／実状態検証／正直返答）
 

--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -5,6 +5,42 @@
 
 ---
 
+## R150 — UX/機能バッチ10件：モニター保存の真因(**client insertがuser_id欠落**)／ケッペン凡例を画面下端まで伸縮／Atlasタイポ(コード側で階層生成)／停止四角を微縮小／**GPT-5.6 Terra再検証→採用**／**Atlas地理対象の曖昧性ゲート統一**／**調査回答マッピングのコード側検証(業務委託)**／衛星3D飛行プリフェッチ／Companiesアイコン枠一致／SVオフにもトグル (tag `#R150`)
+
+ユーザー指摘**10件**を根本原因から修正。`index.html`＋Edge Function `ai-proxy`＋新規migration＋新規テスト2本。`npm test` 緑（static＋node **68**＝security/monitor/r147/r149/**新r150-checks 12**＋Playwright＝**新 r150.spec.js 7**、pageerror 0）。ローカル(Browserペイン 8781)で純関数・ケッペン下端伸縮・監査挙動を実測。Edge Fn(ai-proxy/refresh-news)本番deploy済み・prod migration適用済み。
+
+### ⑥ モニター「監視を作成」→ Could not save the monitor. の**真因**＝client insertが`user_id`を渡していない
+R147〜R149はトースト/ボタンdisabledを直したが、**保存そのものが失敗**していた。真因＝`area_monitors.user_id`は`not null`＋insert RLS `with check (user_id = auth.uid())`なのに、`IntMapMonitors.create()`の挿入行が**user_idを含めていなかった**（`feedback`/`bug_reports`/`donations`は全て`row.user_id=currentUser.id`を設定済み＝この機能だけ抜けていた）。この機能はservice_role経由(R141/R144)でしか検証されず、**ログインclientの挿入経路は一度も成功していなかった**。修正＝`create()`で`row.user_id=currentUser.id`を設定＋belt-and-suspendersで**migration `20260721140000` が`alter column user_id set default auth.uid()`**（prod適用済み）。両層でRLS WITH CHECKを満たす。
+
+### ③ ケッペン凡例「一番下まで伸ばせない」＝**content高クランプが伸縮を阻害**（4回目・激怒）
+R147〜R149は`_fitKoppenLegend`の`maxHeight`を**内容高**にクランプしていた→`resize:vertical`が内容高を超えられず、**背の高い画面や区分が少ない時にグリップを画面下端まで引けない**＝まさに「一番下まで伸ばせない」。修正＝ceilingを**ビューポート基準**に（`renderedMax=innerHeight - top - 12`、content-box分を減算）。グリップは画面下端の約12px上まで伸び、そこで停止（CSS max-height）。内側`.kl-scroll`が30区分を担保。実測：900px画面で height=4000px にしても bottom=888/900。
+
+### ⑦ Atlas地理対象解決の**曖昧性ゲート統一**（業務委託）
+**真因**＝候補確認が**成功描画と同時表示**されていた（multi-region L30325旧・single L30407旧で `gAmbig`/`ambig` を**塗った成功の隣に警告**として追記）→「候補確認・部分実行・成功報告・失敗警告」が同時表示。修正＝共有`_hlAmbigConfirm`で**単一の確認メッセージ**を作り、**両経路が描画前にゲート**（曖昧が1つでもあれば`R(false,…,{meta:{partial:true}})`で停止・何も塗らない・plannerのsayも抑止）。曖昧が無い時のみ描画（成功＋正直な未発見注記）。個別地名ハードコード無し＝`resolveHlTarget`の`ambiguous`判定に駆動され行政/歴史/自然/同名に汎用適用。
+
+### ⑩ 調査回答マッピングの**コード側検証**（業務委託）
+R149はプロンプト＋構造化`places`頼みで、モデルが省略すると0ピン・既存ピン1件で全処理スキップ・空catchで握り潰し。修正＝**PURE検証基盤**（`IntMapAtlasDebug`公開でhermeticテスト可）：`_atlExtractPlaces`(本文から実在固有名詞抽出=省略時の安全網)／`_atlAuditSources`(ドメイン正規化`_atlRegDomain`＋単一集中検出＋官公庁/一次`_atlIsOfficial`)／`_atlMappingVerdict`(mapped/unplaced/ambiguous)／`_atlGeocodeStrict`(同名≥2でambiguous・place型＋名称一致のみ・**座標推測しない**)。orchestrator `_pinReplyPlaces`は**既存ピンとMERGE**(clearしない)・スキップ廃止・**空catch廃止**(console.warn＋正直な注記)。出典は集中時に正直な警告。テスト＝業務委託の全ケース(省略/部分/同名/単一ドメイン/text↔pins不一致)をruntime検証。
+
+### ⑨ Atlas使用モデル GPT-5.6 **Terra**（再検証で採用）
+R148はTerra 403 no-accessでLunaへ戻していた。**2026-07-21再検証**＝`refresh-news`プロキシ(同キー・同AI_MODEL・モデルfallback無)で `AI_MODEL=gpt-5.6-terra` → ai 61/63(en)・104/116(jp) **成功**＝Terra到達可に。`AI_MODEL` secret=terra・ai-proxy `OPENAI_DEFAULT_MODEL=terra`＋`FALLBACK_MODEL=luna`(耐障害)。ai-proxy/refresh-news本番deploy済み。
+
+### ④ Atlas返信タイポ＝**コード側で階層生成**（再報告）
+R147〜R149はmdMini見出しem拡大＋プロンプト強化だが**モデルが`##`/空行を出さないと無反応**。修正＝`_atlStanza`(改行の無い長い塊を~2文ずつのstanzaへ・EN/CJK・内容保存)＋mdMiniで**文末＋単一改行→ソフト段落余白**。構造化済み(見出し/箇条書き/空行)は不介入。
+
+### ⑧ 衛星2D/3D画質・速度（特に3D飛行）
+**飛行中の追いつかない真因**＝`predictivePrefetch`が`moveend`のみ発火だが飛行中はカメラ連続移動で`moveend`が出ず**先読み皆無**。修正＝`window._imPredictivePrefetch`公開＋飛行ループで~2.6回/秒スロットル呼出(進行方向の衛星タイルを先読み)。加えて`sat-labels`参照ソースをEsri2ホストでラウンドロビン。既存の広範な最適化(2/5ホスト分散・native-max DEM z15・fade0・8192タイルキャッシュ)は温存。
+
+### ⑤①② 停止四角/Companies/トグル
+⑤停止四角 rect 17.5→**15.5**(24 viewBox・ほんの少し小)。①Companies=Countries は既に同型(`stat-row`/`stats-toolbar`/sort/filter/compare)＝実測確認、唯一の差`.co-logo-box`を32→**30px**で国旗枠と画素一致。②SV**オフ**返信にも`_featTogHtml('streetview')`(既存トグル網羅の穴埋め)。
+
+### 罠・教訓
+- **「保存できない」は保存経路の実挙動を疑え**＝ボタン/トーストでなく**RLS+NOT NULL違反**(user_id欠落)。service_role検証だけでは**clientパスの成功を保証しない**。
+- **「伸ばせない」＝maxHeightを内容にクランプすると伸縮不能**。ビューポート基準にすれば画面下端まで伸びる。
+- **曖昧性は"ブロッキングゲート"**＝描画前に判定し確認だけ返す。成功と混在させない。
+- **プロンプト頼みでなくコードで検証**＝PURE関数化→`IntMapAtlasDebug`公開→hermeticテスト(業務委託の要件)。
+- **Terra到達性は`refresh-news`(fallback無)で判定**＝ai count 0=失敗/>0=成功。ai-proxyのfallbackがある間はsecret一時変更も安全。
+- **PORT=4188 npx playwright**(4173/8781常駐と競合回避)。
+
 ## R149 — UX/機能バッチ10件：モニター作成の真因(**window.imToastがundefined→トースト全滅**)／ケッペン凡例の余白削減で30区分が収まる／Atlasタイポ強化／送信↑=黒・停止四角拡大・選択欄送信=白+SVG／**画像ペースト(ビジョン)**／**調査回答の地点マッピング(業務委託)** (tag `#R149`)
 
 ユーザー指摘**10件**を根本原因から修正。全て `index.html`（＋新規テスト2本）の**加算的/微修正**（単一HTML・ビルド無し温存）。`npm test` 緑（static＋node **56**＝security/monitor/r147/**新r149-checks 9**＋Playwright **67**＝新 `r149.spec.js` 4、pageerror 0）。Edge Function変更なし＝deploy不要。ローカル(Browserペイン 127.0.0.1:4173)で送信ボタン色・画像ドロップ→サムネ・ケッペン30区分実測・タイポ階層を実測確認。

--- a/index.html
+++ b/index.html
@@ -390,7 +390,7 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
     .tp-prog.indet .tp-prog-fill{ width:100% !important; background:linear-gradient(90deg, rgba(10,132,255,0) 0%, #0a84ff 42%, #5e5ce6 58%, rgba(94,92,230,0) 100%) !important; background-size:42% 100% !important; background-repeat:no-repeat !important; animation:imProgSweep 1.05s linear infinite; transition:none !important; }
     @keyframes imProgSweep{ 0%{ background-position:-45% 0; } 100%{ background-position:145% 0; } }
     /* (#R139) Companies tab — logo (where the country flag sat in Countries), sector/HQ subline, detail overlay. */
-    .co-logo-box{ display:inline-flex; align-items:center; justify-content:center; width:32px; height:32px; flex:0 0 auto; }
+    .co-logo-box{ display:inline-flex; align-items:center; justify-content:center; width:30px; height:30px; flex:0 0 auto; }   /* (#R150) exact-match the Countries flag slot (30×30) so the icon column is pixel-identical between the two tabs */
     .co-logo{ width:30px; height:30px; border-radius:8px; object-fit:contain; background:#fff; box-shadow:0 1px 3px rgba(0,0,0,0.14); }
     .co-mono{ width:30px; height:30px; border-radius:8px; display:inline-flex; align-items:center; justify-content:center; color:#fff; font-weight:700; font-size:15px; }
     .co-banner{ opacity:0.85; }
@@ -4224,7 +4224,7 @@ window.addEventListener('DOMContentLoaded', () => {
          at 18 — the extra tile set is pure GPU/RAM cost there ("ブラウザが落ちることがないように"). */
       center:[10,20], zoom:1.7, minZoom:0, maxZoom:(isMobile()?18:19),
       style:{ version:8, glyphs:'https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf',
-        sources:{ 'bl':{type:'raster',tiles:carto('light_all'),tileSize:256},'bln':{type:'raster',tiles:carto('light_nolabels'),tileSize:256},'bd':{type:'raster',tiles:carto('dark_all'),tileSize:256},'bdn':{type:'raster',tiles:carto('dark_nolabels'),tileSize:256},'sat-labels':{type:'raster',tiles:['https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}'],tileSize:256},'satellite':{type:'raster',tiles:['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}','https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],tileSize:256,maxzoom:19},'tool-source':{type:'geojson',data:{type:'FeatureCollection',features:[]}},'grid-source':{type:'geojson',data:{type:'FeatureCollection',features:[]}} },
+        sources:{ 'bl':{type:'raster',tiles:carto('light_all'),tileSize:256},'bln':{type:'raster',tiles:carto('light_nolabels'),tileSize:256},'bd':{type:'raster',tiles:carto('dark_all'),tileSize:256},'bdn':{type:'raster',tiles:carto('dark_nolabels'),tileSize:256},'sat-labels':{type:'raster',tiles:['https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}','https://services.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}'],tileSize:256},'satellite':{type:'raster',tiles:['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}','https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],tileSize:256,maxzoom:19},'tool-source':{type:'geojson',data:{type:'FeatureCollection',features:[]}},'grid-source':{type:'geojson',data:{type:'FeatureCollection',features:[]}} },
         layers:[ {id:'layer-sat',type:'raster',source:'satellite',layout:{visibility:'none'},paint:{'raster-fade-duration':0}},   /* (#R147) instant satellite tiles (no 300ms cross-fade) so fast zoom/pan is comfortable, esp. on mobile ("衛星画像の読み込みが…快適に") — matches every other raster overlay */
           {id:'layer-sat-labels',type:'raster',source:'sat-labels',layout:{visibility:'none'},paint:{'raster-opacity':0.95,'raster-fade-duration':0}},
           /* (#R24) START on the NO-LABEL carto base (we ALWAYS use crisp vector labels now) so the old
@@ -4450,6 +4450,10 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   registerTileSW();
   if(map) map.on('moveend',()=>{ clearTimeout(_prefetchT); _prefetchT=setTimeout(predictivePrefetch,90); });
+  /* (#R150) expose the directional prefetch so the flight simulator can warm satellite tiles AHEAD of the aircraft
+     every few hundred ms — during flight the camera moves CONTINUOUSLY so `moveend` never fires and the imagery
+     couldn't keep up ("3D衛星画像の生成が飛行に追い付いていない"). The flight loop throttles the calls. */
+  try{ window._imPredictivePrefetch=predictivePrefetch; }catch(_){}
 
   function angDist(lo1,la1,lo2,la2){ const r=Math.PI/180; const a=Math.sin(la1*r)*Math.sin(la2*r)+Math.cos(la1*r)*Math.cos(la2*r)*Math.cos((lo2-lo1)*r); return Math.acos(Math.max(-1,Math.min(1,a)))/r; }
   let _occAllVis=false;
@@ -12349,7 +12353,7 @@ window.addEventListener('DOMContentLoaded', () => {
   })();
 
   /* ===== Terms of Service & Privacy Policy ===== */
-  const LEGAL_DATE='2026-07-17';   /* (#R122) Privacy §4: OpenAI content-sharing (Designated Content may be used to develop/train OpenAI models) + do-not-submit-sensitive-data caution. (#R114) Terms §6 + sources: AI provider is OpenAI (gpt-5.6-luna; #R148 reverted from Terra — Terra had no project access) and AI features may run web searches. (#R101) Privacy §4: flight-simulator audio note. */
+  const LEGAL_DATE='2026-07-17';   /* (#R122) Privacy §4: OpenAI content-sharing (Designated Content may be used to develop/train OpenAI models) + do-not-submit-sensitive-data caution. (#R114) Terms §6 + sources: AI provider is OpenAI (gpt-5.6-terra; #R150 Terra re-verified reachable, Luna is the fallback) and AI features may run web searches. (#R101) Privacy §4: flight-simulator audio note. */
   function legalTermsHTML(){ return currentLang==='jp'? `
     <h3 style="margin:0 0 4px;font-size:17px;">利用規約</h3><p style="color:var(--text-muted);font-size:11.5px;margin:0 0 12px;">最終更新日: ${LEGAL_DATE}</p>
     <p><b>1. 同意</b> — IntMap（以下「本サービス」）を利用することで、本規約に同意したものとみなされます。同意されない場合は利用しないでください。</p>
@@ -14252,27 +14256,26 @@ window.addEventListener('DOMContentLoaded', () => {
       try{ window._wireLegendDrag&&window._wireLegendDrag(lg); }catch(_){}
       try{ _fitKoppenLegend(lg); }catch(_){}
     }
-    /* (#R147) "上下に伸ばして最後までいったらとまる" — clamp the resizable legend's max-height to its natural content
-       height (capped at the viewport) so dragging the resize grip stops exactly at the last climate class instead
-       of continuing into empty space. Recomputed on every rebuild, on show, and on window resize. Desktop only —
-       the mobile CSS owns legend sizing (resize:none). */
+    /* (#R150) "上下に伸ばして…一番下まで伸ばせない" — the user wants to DRAG the legend all the way down to the
+       BOTTOM OF THE SCREEN and have it stop there. R147–R149 clamped max-height to the CONTENT height, so
+       resize:vertical could never exceed the content: on a tall display (or with only a few classes selected)
+       the grip stopped short of the bottom and the box refused to grow — exactly "一番下まで伸ばせない". The fix
+       is to base the ceiling on the VIEWPORT, not the content: from the legend's own top edge down to ~12px
+       above the screen bottom. Now the grip stretches to the very bottom and STOPS at the screen edge (the CSS
+       max-height cap), while the inner .kl-scroll keeps every one of the ~30 classes reachable when the box is
+       shorter than the content. Recomputed on rebuild / show / window-resize. Desktop only (mobile CSS owns it). */
     function _fitKoppenLegend(lg){ try{
       lg=lg||document.getElementById('koppen-legend'); if(!lg) return;
       const cs=getComputedStyle(lg);
       if(cs.display==='none' || lg.classList.contains('legend-collapsed')) return;
       if(window.innerWidth<=768) return;
-      const sc=lg.querySelector('.kl-scroll'); if(!sc) return;
-      const chrome=Math.max(0, lg.getBoundingClientRect().height - sc.getBoundingClientRect().height);
-      const full=Math.round(chrome + sc.scrollHeight + 2);   /* border-box height that reveals every class with no inner scroll */
-      const cap=Math.round(window.innerHeight - 84);          /* (#R149) match the trimmed CSS ceiling (was 92) so the fit uses the same, larger budget */
-      const target=Math.max(150, Math.min(full, cap));        /* the RENDERED (border-box) height we want the resize grip to stop at */
-      /* (#R148) `full`/`target` are BORDER-BOX heights (getBoundingClientRect), but the legend is box-sizing:content-box,
-         so setting them straight as a max-height rendered ~18px (padding+border) TALLER → the grip dragged a row PAST the
-         last class into empty space and "最後までいったらとまる" still failed (R147). Subtract padding+border for content-box
-         so the RENDERED box stops EXACTLY at the last class. Border-box (future-proof) uses the value directly. */
-      let mh=target;
-      if(cs.boxSizing!=='border-box'){ const pb=(parseFloat(cs.paddingTop)||0)+(parseFloat(cs.paddingBottom)||0)+(parseFloat(cs.borderTopWidth)||0)+(parseFloat(cs.borderBottomWidth)||0); mh=Math.max(0, target-pb); }
-      lg.style.maxHeight=mh+'px';
+      const top=lg.getBoundingClientRect().top;                 /* rendered top edge (top-anchored: stable as it grows) */
+      const renderedMax=Math.round(window.innerHeight - top - 12);   /* how tall the border-box may be before it hits the screen bottom */
+      /* max-height on a content-box element sizes the CONTENT box; the rendered border-box is that + padding + border.
+         Subtract the chrome so the RENDERED bottom edge lands ~12px above the screen bottom (not 18px past it). */
+      let mh=renderedMax;
+      if(cs.boxSizing!=='border-box'){ const pb=(parseFloat(cs.paddingTop)||0)+(parseFloat(cs.paddingBottom)||0)+(parseFloat(cs.borderTopWidth)||0)+(parseFloat(cs.borderBottomWidth)||0); mh=Math.max(0, renderedMax-pb); }
+      lg.style.maxHeight=Math.max(150, mh)+'px';
     }catch(_){} }
     window._fitKoppenLegend=_fitKoppenLegend;
     (function(){ let _klRz=null; window.addEventListener('resize',()=>{ if(_klRz) return; _klRz=setTimeout(()=>{ _klRz=null; try{ const lg=document.getElementById('koppen-legend'); if(!lg||getComputedStyle(lg).display==='none') return; if(window.innerWidth<=768) lg.style.maxHeight=''; else _fitKoppenLegend(lg); }catch(_){} },200); }); })();
@@ -26726,6 +26729,10 @@ window.addEventListener('DOMContentLoaded', () => {
       if(!st._pathT || now-st._pathT>(st._pathIntv||350)){ st._pathT=now; if(st._path){ st._path.push([st.lng,st.lat,st.alt]);
         if(st._path.length>1600){ st._path=st._path.filter((_,i)=>i%2===0); st._pathIntv=(st._pathIntv||350)*2; } } }   /* (#R99) DECIMATE (keep the whole route coarser) instead of dropping the oldest — a long flight kept losing its start & under-counting distance */
       if(f.landed){ showResult('landed'); return; }   /* completed landing → result screen */
+      /* (#R150) warm satellite tiles AHEAD of the aircraft (~2.6×/s). `moveend` never fires while the camera moves
+         continuously in flight, so without this the imagery streamed in BEHIND the aircraft; predictivePrefetch
+         self-gates to satellite mode + uses the center delta (flight direction) to prefetch the tiles just ahead. */
+      if(now-(st._pfT||0)>380){ st._pfT=now; try{ window._imPredictivePrefetch&&window._imPredictivePrefetch(); }catch(_){} }
       raf=requestAnimationFrame(loop); }
     /* switch aircraft mid-flight — keep position/attitude, reset speed to the new type's cruise + clear rates */
     function selectAircraft(k){ if(!AIRCRAFT[k]) return; acKey=k; if(st){ st.V=AIRCRAFT[k].Vcruise; st.om=[0,0,0]; st.elev=0; st.ail=0; st.rud=0; st.flaps=0; st.gear=0; computeTrim(); } try{ syncHUDChrome(); }catch(_){} }
@@ -27688,11 +27695,25 @@ window.addEventListener('DOMContentLoaded', () => {
        font-size in BOTH normal (12.8px) and sidebar (15px) modes — and, being em, they escape the sidebar rule
        that force-lifts literal 12–13px spans to 15px, which used to FLATTEN the headings. Paragraph breaks (\n\n)
        now insert real vertical space, so replies read as titled, spaced sections instead of one monotone block. */
-    function mdMini(s){ return esc(_dedupText(String(s||'')))
-      /* (#R149) STRONGER visual hierarchy — the user keeps reporting Atlas replies read as a monotonous wall of
-         same-size text. Bigger, accent-coloured headings with clear top spacing so any structure the model emits
-         (## sections / # title / ### sub) is unmistakable, plus more room between blocks. Sizes are em, so they
-         scale off the bubble font on both desktop (12.5px) and the mobile 15px override. */
+    /* (#R150) CODE-SIDE typographic rhythm — the user keeps reporting Atlas replies read as a monotonous wall of
+       same-size text with no spacing between groups, even after R147–R149 strengthened the prompt + heading em
+       sizes. The gap: those only help when the MODEL emits ## headings / blank lines. When it returns flat prose
+       they do nothing. So we structure it in code: (a) _atlStanza groups a long single-block run-on into ~2-sentence
+       stanzas (content-preserving, sentence-aware, EN + CJK); (b) a single newline after a sentence end becomes a
+       soft paragraph gap. Structured replies (headings/bullets/blank-line paragraphs) are left exactly as the model
+       wrote them. Pure/deterministic → unit-tested via IntMapAtlasDebug.mdMini / _atlStanza. */
+    function _atlStanza(raw){ raw=String(raw||'');
+      if(/^\s*#{1,6}\s|^\s*[-・*]\s|\n\s*\n/m.test(raw)) return raw;          /* already structured (heading / bullet / paragraph) */
+      if((raw.match(/\n/g)||[]).length>1) return raw;                        /* model already used line breaks — respect them */
+      const plain=raw.replace(/\s+/g,' ').trim(); if(plain.length<=280) return raw;   /* short enough to read as one block */
+      const parts=plain.match(/[^.!?。！？…]+(?:[.!?。！？…]+["”』）)]*|$)/g);
+      if(!parts||parts.length<4) return raw;                                 /* too few sentences to bother grouping */
+      const out=[]; for(let i=0;i<parts.length;i+=2) out.push(parts.slice(i,i+2).join(' ').trim());
+      return out.join('\n\n'); }
+    function mdMini(s){ return esc(_dedupText(_atlStanza(String(s||''))))
+      /* (#R149) STRONGER visual hierarchy — bigger, accent-coloured headings with clear top spacing so any structure
+         the model emits (## sections / # title / ### sub) is unmistakable. Sizes are em, so they scale off the bubble
+         font on both desktop (12.5px) and the mobile 15px override. */
       .replace(/^#{3,6}\s*(.+)$/gm,'<div style="font-weight:700;color:var(--primary-color);margin:1em 0 .3em;font-size:1.14em;line-height:1.32;">$1</div>')
       .replace(/^##\s*(.+)$/gm,'<div style="font-weight:700;color:var(--primary-color);margin:1.2em 0 .4em;font-size:1.32em;line-height:1.3;letter-spacing:.005em;">$1</div>')
       .replace(/^#\s*(.+)$/gm,'<div style="font-weight:800;color:var(--primary-color);margin:1.15em 0 .45em;font-size:1.55em;letter-spacing:.01em;line-height:1.26;">$1</div>')
@@ -27703,7 +27724,9 @@ window.addEventListener('DOMContentLoaded', () => {
          — the leading-char guard skips urls already inside an href="…" attribute of the anchors made just above. */
       .replace(/(^|[^"'=>\/])(https?:\/\/[^\s<)"']+)/g,(m,pre,u)=>pre+'<a href="'+u+'" target="_blank" rel="noopener" style="color:var(--primary-color);text-decoration:none;border-bottom:1px solid currentColor;word-break:break-all;">'+u+'</a>')
       .replace(/^[-・*]\s+(.+)$/gm,'<div style="padding-left:1.15em;text-indent:-0.9em;margin:.24em 0;">• $1</div>')
-      .replace(/\n{2,}/g,'<div style="height:.7em"></div>').replace(/\n/g,'<br>'); }   /* (#R149) more breathing room between blocks + bullets */
+      .replace(/\n{2,}/g,'<div style="height:.72em"></div>')                                       /* explicit paragraph → generous gap */
+      .replace(/([.!?。！？…”"』）)])\n(?=\S)/g,'$1<div style="height:.5em"></div>')                  /* (#R150) sentence-end + single newline = soft paragraph gap ("まとまりの間に余白") */
+      .replace(/\n/g,'<br>'); }
     /* (#R74) ChatGPT-style SOURCE LINK CARDS ("Atlasの返答に、必要であれば記事のリンク等をChatGPT風UIで表示"):
        compact rounded cards with the site's favicon, the article title and its domain — used by analyze,
        mapReport and any reply that carries real article URLs. Only http(s) URLs that came from evidence or
@@ -28846,7 +28869,18 @@ window.addEventListener('DOMContentLoaded', () => {
       expandCompound:function(l){ try{ return _expandRegionCompound(Array.isArray(l)?l:[l]); }catch(_){ return l; } },
       paletteColor:function(i){ try{ return _hlPaletteColor(i); }catch(_){ return null; } },
       legendHtml:function(g){ try{ return _hlLegendHtml(g); }catch(_){ return ''; } },
-      polyState:function(){ try{ return { polys:_hlPolys.map(p=>{ let bb=null,gt=(p.geo&&p.geo.type)||null,vd=false; try{ bb=fbbox(p.geo); }catch(_){} try{ vd=_validGeo(p.geo,{trusted:true}).ok; }catch(_){} return {name:p.name,color:p.color,comp:p.comp,geoType:gt,valid:vd,bbox:bb}; }), n:_hlPolys.length }; }catch(_){ return {polys:[],n:0}; } } }; }catch(_){}
+      polyState:function(){ try{ return { polys:_hlPolys.map(p=>{ let bb=null,gt=(p.geo&&p.geo.type)||null,vd=false; try{ bb=fbbox(p.geo); }catch(_){} try{ vd=_validGeo(p.geo,{trusted:true}).ok; }catch(_){} return {name:p.name,color:p.color,comp:p.comp,geoType:gt,valid:vd,bbox:bb}; }), n:_hlPolys.length }; }catch(_){ return {polys:[],n:0}; } },
+      /* (#R150) research-mapping audit — PURE building blocks, exposed for the hermetic node tests (model-omitted
+         list, partial placement, same-name ambiguity, one-domain sources, text↔pins mismatch) + typography stanza. */
+      norm:function(s){ try{ return _atlNorm(s); }catch(_){ return ''; } },
+      nameOk:function(a,b){ try{ return _atlNameOk(a,b); }catch(_){ return false; } },
+      extractPlaces:function(t){ try{ return _atlExtractPlaces(t); }catch(_){ return []; } },
+      regDomain:function(u){ try{ return _atlRegDomain(u); }catch(_){ return ''; } },
+      auditSources:function(c){ try{ return _atlAuditSources(c); }catch(_){ return null; } },
+      mappingVerdict:function(s){ try{ return _atlMappingVerdict(s); }catch(_){ return null; } },
+      mappingNote:function(v,s,m){ try{ return _atlMappingNoteHtml(v,s,m); }catch(_){ return ''; } },
+      stanza:function(t){ try{ return _atlStanza(t); }catch(_){ return t; } },
+      mdMini:function(t){ try{ return mdMini(t); }catch(_){ return ''; } } }; }catch(_){}
     async function _leaderData(codes){ try{
       const iso=(codes||[]).filter(Boolean).slice(0,4); if(!iso.length) return null;
       const langQ=(currentLang==='jp'?'ja':currentLang)+',en';
@@ -29520,31 +29554,121 @@ window.addEventListener('DOMContentLoaded', () => {
         else if(ctr){ map.flyTo({center:ctr,zoom:(opt.zoom||4),duration:1000}); rendered=true; method=method||'center'; } }catch(_){}
       return { rendered, method, name, pinCount:pins.length, hasExtent:!!(ext&&(ext.box||isFinite(ext.lng))), pinIdx }; }
 
-    /* (#R149 · Atlas mapping-quality commission) A location-rich Atlas answer must deliver MAP value, not just prose:
-       the specific real places it names get pinned, and the reply honestly reports which spots were placed and which
-       could not be. `places` is a list the model emits INLINE with its answer (no extra AI call / no extra quota):
-       [{n:name, c:modern country, k:kind, s:one-line why}] — coordinates are NEVER from the model; the shared
-       geocode ladder (_tryMapResearch → placeExtent/geocode) resolves them, and anything it can't uniquely place is
-       reported as "not placed", never guessed. Returns the self-audit note HTML (or '' when nothing was mappable). */
-    async function _pinReplyPlaces(places, ctx){ ctx=ctx||{};
-      const items=(Array.isArray(places)?places:[]).slice(0,16).map(p=>({
-        name:String((p&&(p.n||p.name))||'').slice(0,90), locationName:String((p&&(p.n||p.locationName||p.name))||'').slice(0,90),
-        country:String((p&&(p.c||p.country))||'').slice(0,60), kind:String((p&&(p.k||p.kind))||'').slice(0,40),
-        summary:String((p&&(p.s||p.summary))||'').slice(0,240) })).filter(it=>it.locationName && it.locationName.length>1);
-      if(!items.length) return '';
-      let res=null; try{ res=await _tryMapResearch(ctx.place||'', items, {mode:'current', zoom:ctx.zoom||5}); }catch(_){ return ''; }
-      const idx=(res&&res.pinIdx)||[]; const mapped=[], failed=[];
-      items.forEach((it,i)=>{ (idx[i]!=null&&idx[i]>=0)?mapped.push(it.name):failed.push(it.name); });
-      const n=(res&&res.pinCount)||mapped.length; if(!n && !failed.length) return '';
-      let h='';
+    /* ═══════════ (#R150 · Atlas research-mapping commission) CODE-SIDE VERIFICATION ═══════════
+       A location-rich answer must deliver MAP value AND honestly reconcile its prose with the map — NOT rely on
+       the model to emit a perfect structured list. The prior design (R149) pinned only the model's inline `places`
+       list AND skipped entirely when any pin already existed, so: (a) if the model omitted the list → 0 pins;
+       (b) an existing plan pin suppressed the whole audit; (c) a failure was swallowed by an empty catch. The
+       redesign below is PURE + testable at its core and NEVER guesses a coordinate:
+         · _atlNorm / _atlNameOk   — name normalization + confident-match gate (blocks "Roman"→"Roman, Romania").
+         · _atlExtractPlaces       — pull the major real proper-noun spots out of the FINAL TEXT (safety net when
+                                       the model under-supplies the list). Heuristic; only CONFIDENT geocodes pin.
+         · _atlRegDomain / _atlAuditSources — normalize citation domains, detect single-domain concentration, flag
+                                       official/primary (gov/mil/edu/int/go.jp/gob.*), so sources aren't one site.
+         · _atlMappingVerdict      — pure: turn per-spot resolution outcomes into mapped / unplaced / ambiguous.
+       Everything is exposed on IntMapAtlasDebug for the hermetic node tests (model-omitted list, partial placement,
+       same-name ambiguity, one-domain sources, text/pins mismatch). No per-place hardcoding anywhere. */
+    function _atlNorm(s){ return String(s||'').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'')
+      .replace(/^(the|a|an|la|le|el|los|las|les|der|die|das|il|lo)\s+/,'').replace(/[^\p{L}\p{N} ]+/gu,' ').replace(/\s+/g,' ').trim(); }
+    function _atlNameOk(query, got){ const a=_atlNorm(query), b=_atlNorm(got); if(!a||!b) return false;
+      if(a===b) return true; if(b.indexOf(a)===0||a.indexOf(b)===0) return true;
+      const ta=a.split(' '), tb=new Set(b.split(' ')); return ta.length>=2 && ta.every(w=>tb.has(w)); }
+    /* Extract candidate place names from prose. Over-captures (sentence-initial words, some person names) — precision
+       is enforced downstream by the confident-geocode gate, so a non-place simply resolves to nothing and is dropped,
+       never mis-pinned. Latin scripts only (CJK relies on the structured list + already-placed pins). */
+    const _ATL_STOP=new Set('the this that these those it he she they we you i a an in on at by for from to as but and or however meanwhile today yesterday now here there its their his her our your my one two three first then also while when where what which who why how according reuters ap afp bbc cnn'.split(' '));
+    /* Leading words that are sentence-initial verbs/adverbs, NEVER part of a place name — safe to strip from a
+       multi-word candidate. Deliberately EXCLUDES directional/qualifier words (North/South/New/Old/Upper/Central…)
+       because those ARE real place components ("North Korea", "New York", "Western Sahara") — stripping them corrupts. */
+    const _ATL_LEAD=new Set('visit see explore discover today yesterday meanwhile however then also both either neither near around throughout during despite'.split(' '));
+    function _atlExtractPlaces(text){ let t=String(text||'').replace(/`[^`]*`/g,' ').replace(/https?:\/\/\S+/g,' ').replace(/\[([^\]]*)\]\([^)]*\)/g,'$1');
+      const re=/[A-ZÀ-Þ][\p{L}'’\-]*(?:\s+(?:of|de|del|della|di|du|des|da|do|dos|van|von|la|le|los|las|el|al|the|and|upon|on)\s+[A-ZÀ-Þ][\p{L}'’\-]*|\s+[A-ZÀ-Þ][\p{L}'’\-]*){0,3}/gu;   /* no '.' in the class → a phrase never bridges a sentence boundary ("Italy. The Colosseum") */
+      const seen=new Set(), out=[]; let m;
+      while((m=re.exec(t))){ let s=m[0].replace(/[.,;:''’]+$/,'').trim(); if(s.length<3) continue;
+        let toks=s.split(/\s+/); while(toks.length>1 && _ATL_LEAD.has(toks[0].toLowerCase())) toks=toks.slice(1); s=toks.join(' ');   /* drop a sentence-initial verb/adverb prefix */
+        if(toks.length===1 && _ATL_STOP.has(s.toLowerCase())) continue;
+        const key=_atlNorm(s); if(!key||key.length<3||seen.has(key)) continue; seen.add(key); out.push(s); if(out.length>=24) break; }
+      return out; }
+    function _atlRegDomain(url){ let h=''; try{ h=new URL(String(url)).hostname.toLowerCase(); }catch(_){ h=String(url||'').toLowerCase().replace(/^.*\/\//,'').split('/')[0]; }
+      h=h.replace(/^www\d?\./,''); const p=h.split('.').filter(Boolean); if(p.length<=2) return h;
+      const two=new Set(['co','com','org','net','gov','gob','gouv','go','ac','edu','or','ne','mil']);
+      return (two.has(p[p.length-2])) ? p.slice(-3).join('.') : p.slice(-2).join('.'); }
+    function _atlIsOfficial(dom){ return /(^|\.)(gov|mil|int)(\.[a-z]{2,3})?$/.test(dom)||/\.(gov|gob|gouv|go|gc|edu|ac)\.[a-z]{2,3}$/.test(dom)||/\.(edu|int)$/.test(dom); }
+    function _atlAuditSources(cites){ const urls=(Array.isArray(cites)?cites:[]).map(c=>String((c&&(c.url||c))||'')).filter(u=>/^https?:\/\//i.test(u));
+      const by={}; urls.forEach(u=>{ const d=_atlRegDomain(u); if(d) by[d]=(by[d]||0)+1; });
+      const domains=Object.keys(by); const total=urls.length; let dominant='',dmax=0; domains.forEach(d=>{ if(by[d]>dmax){ dmax=by[d]; dominant=d; } });
+      const official=domains.filter(_atlIsOfficial);
+      const concentrated = total>=2 && (domains.length===1 || (dmax/total)>=0.75 && domains.length<=2);
+      return { total, distinct:domains.length, byDomain:by, dominant, dominantShare:total?dmax/total:0, official, concentrated }; }
+    /* PURE: fold per-spot resolution outcomes into the three honest buckets. `spots`=[{name,src,verdict}] where
+       verdict ∈ mapped|unplaced|ambiguous. Text-source unplaced items are only surfaced when multi-word (a lone
+       failed capitalized token is far more likely a non-place than a spot we failed to map — don't cry wolf). */
+    function _atlMappingVerdict(spots){ const mapped=[],unplaced=[],ambiguous=[]; (Array.isArray(spots)?spots:[]).forEach(s=>{ if(!s||!s.name) return;
+      if(s.verdict==='mapped') mapped.push(s.name);
+      else if(s.verdict==='ambiguous') ambiguous.push(s.name);
+      else if(s.verdict==='unplaced'){ if(s.src==='structured' || /\s/.test(s.name)) unplaced.push(s.name); } });   /* text-source: only multi-word failures are surfaced (a lone capitalized word is likely not a place — don't cry wolf) */
+      return { mapped, unplaced, ambiguous }; }
+    function _atlMappingNoteHtml(v, src, meta){ meta=meta||{}; let h='';
+      const n=v.mapped.length;
       if(n) h+='<div style="font-size:11px;color:var(--text-muted);margin-top:8px;">📍 '+L(
         n+' place'+(n===1?'':'s')+' from this answer mapped — tap a pin for details',
         '本文の主要スポット '+n+' 件を地図にマッピングしました（ピンをタップで詳細）',
         n+' Ort'+(n===1?'':'e')+' aus dieser Antwort auf der Karte — Pin antippen',
         'На карте '+n+' объект(ов) из этого ответа — нажмите метку',
         n+' lugar'+(n===1?'':'es')+' de esta respuesta en el mapa — toca un pin')+'</div>';
-      if(failed.length) h+='<div style="font-size:10.5px;color:var(--text-muted);margin-top:2px;opacity:.85;">'+L('Not placed (couldn’t locate precisely): ','未配置（正確に特定できませんでした）: ','Nicht verortet: ','Не размещены: ','Sin ubicar: ')+esc(failed.slice(0,6).join(', '))+(failed.length>6?'…':'')+'</div>';
+      if(v.ambiguous.length) h+='<div style="font-size:10.5px;color:var(--text-muted);margin-top:2px;opacity:.85;">'+L('Ambiguous (several places share this name — not placed): ','曖昧（同名地が複数あり未配置）: ','Mehrdeutig (nicht verortet): ','Неоднозначно (не размещены): ','Ambiguo (sin ubicar): ')+esc(v.ambiguous.slice(0,6).join(', '))+(v.ambiguous.length>6?'…':'')+'</div>';
+      if(v.unplaced.length) h+='<div style="font-size:10.5px;color:var(--text-muted);margin-top:2px;opacity:.85;">'+L('Named in the answer but not placed (couldn’t locate precisely): ','本文に登場したが未配置（正確に特定できませんでした）: ','Genannt, aber nicht verortet: ','Упомянуты, но не размещены: ','Mencionados pero sin ubicar: ')+esc(v.unplaced.slice(0,6).join(', '))+(v.unplaced.length>6?'…':'')+'</div>';
+      if(meta.infraFail && !n) h+='<div style="font-size:10.5px;color:var(--text-muted);margin-top:2px;opacity:.85;">'+L('Map lookup was unavailable — places could not be verified on the map right now.','地図検索が利用できず、地点を地図上で検証できませんでした。','Kartensuche nicht verfügbar.','Поиск по карте недоступен.','La búsqueda en el mapa no está disponible.')+'</div>';
+      if(src && src.concentrated && !src.official.length) h+='<div style="font-size:10.5px;color:var(--warn-color,#c98a00);margin-top:4px;opacity:.95;">⚠ '+L(
+        'Sources here concentrate on one site ('+esc(src.dominant)+') — treat with caution and seek an independent or official source.',
+        '出典が1サイト（'+esc(src.dominant)+'）に集中しています。独立した情報源や公的情報での裏取りを推奨します。',
+        'Quellen konzentrieren sich auf eine Seite ('+esc(src.dominant)+') — mit Vorsicht behandeln.',
+        'Источники сосредоточены на одном сайте ('+esc(src.dominant)+') — проверьте по независимому источнику.',
+        'Las fuentes se concentran en un sitio ('+esc(src.dominant)+') — verifica con una fuente independiente.')+'</div>';
       return h; }
+    /* Strict geocode with ambiguity detection (limit=5). Returns {ok,lng,lat,name} | {ok:false,reason,ambiguous?}.
+       Only place-type, name-matching results count; ≥2 distinct locations with no country hint = ambiguous (not placed). */
+    async function _atlGeocodeStrict(name, country){ name=String(name||'').trim(); if(name.length<2) return {ok:false,reason:'empty'};
+      const q=[name,String(country||'').trim()].filter(Boolean).join(', '); let arr=null;
+      try{ const r=await fetch('https://nominatim.openstreetmap.org/search?format=json&addressdetails=0&limit=5&q='+encodeURIComponent(q),{headers:{Accept:'application/json'}}); arr=await r.json(); }
+      catch(e){ return {ok:false,reason:'network'}; }
+      if(!Array.isArray(arr)||!arr.length) return {ok:false,reason:'not_found'};
+      const matches=arr.filter(j=>{ const okType=/^(place|boundary|natural|waterway|landuse|tourism|historic|leisure|amenity)$/.test(String(j.class||''))||!!j.addresstype; return okType && _atlNameOk(name,(j.display_name||'').split(',')[0]); });
+      if(!matches.length) return {ok:false,reason:'no_name_match'};
+      const cells=new Set(); matches.forEach(j=>cells.add(Math.round(+j.lat*10)+','+Math.round(+j.lon*10)));
+      if(!country && cells.size>=2) return {ok:false,reason:'ambiguous',ambiguous:true};
+      const b=matches[0]; return { ok:true, lng:+b.lon, lat:+b.lat, name:(b.display_name||'').split(',')[0] }; }
+    /* Orchestrator: resolve the answer's places (structured list + text safety-net), MERGE with any existing plan
+       pins (never wipes them), pin only confident/unique hits, and return an honest self-audit note. */
+    async function _pinReplyPlaces(places, ctx){ ctx=ctx||{}; const text=String(ctx.text||'');
+      try{
+        const struct=(Array.isArray(places)?places:[]).slice(0,16).map(p=>({
+          name:String((p&&(p.n||p.name||p.locationName))||'').slice(0,90), country:String((p&&(p.c||p.country))||'').slice(0,60),
+          kind:String((p&&(p.k||p.kind))||'').slice(0,40), summary:String((p&&(p.s||p.summary))||'').slice(0,240), src:'structured' })).filter(it=>it.name&&it.name.length>1);
+        const structKeys=new Set(struct.map(it=>_atlNorm(it.name)));
+        const textBudget=struct.length?4:8;   /* text extraction is the SAFETY NET — used hard only when the model under-supplied the list */
+        const textCands=_atlExtractPlaces(text).filter(s=>!structKeys.has(_atlNorm(s))).slice(0,textBudget).map(s=>({name:s,country:'',kind:'',summary:'',src:'text'}));
+        if(!struct.length && textCands.length<2 && !(Array.isArray(_pois)&&_pois.length)) return '';   /* not a place-rich answer — don't geocode incidental capitalized words */
+        const pre=(Array.isArray(_pois)?_pois:[]).map(p=>({lng:+p.lng,lat:+p.lat,name:String(p.name||''),kind:String(p.kind||''),sum:String(p.sum||''),url:String(p.url||''),src:String(p.src||'')})).filter(p=>isFinite(p.lng));
+        const preKeys=new Set(pre.map(p=>_atlNorm(p.name)).filter(Boolean));
+        const seenCell=new Set(pre.map(p=>Math.round(p.lng*20)+','+Math.round(p.lat*20)));
+        const spots=[]; const newPins=[]; let infraFail=0;
+        for(const it of struct.concat(textCands)){ const key=_atlNorm(it.name);
+          if(preKeys.has(key)){ spots.push({name:it.name,verdict:'mapped',src:it.src}); continue; }   /* already on the map from the plan — counts as mapped, not re-pinned */
+          if(newPins.length>=14){ spots.push({name:it.name,verdict:'unplaced',src:it.src}); continue; }
+          let g=null;
+          if(it.src==='structured'){ try{ const r=await geocode([it.name,it.country].filter(Boolean).join(', ')); if(r&&isFinite(+r.lng)&&_atlNameOk(it.name,r.name)) g={lng:+r.lng,lat:+r.lat,name:r.name}; }catch(_){ infraFail++; }
+            if(!g){ const s=await _atlGeocodeStrict(it.name,it.country); if(s.ok) g={lng:s.lng,lat:s.lat,name:s.name}; else if(s.ambiguous){ spots.push({name:it.name,verdict:'ambiguous',src:it.src}); continue; } else if(s.reason==='network') infraFail++; } }
+          else { const s=await _atlGeocodeStrict(it.name,''); if(s.ok) g={lng:s.lng,lat:s.lat,name:s.name}; else if(s.ambiguous){ spots.push({name:it.name,verdict:'ambiguous',src:it.src}); continue; } else if(s.reason==='network') infraFail++; }
+          if(g){ const cell=Math.round(g.lng*20)+','+Math.round(g.lat*20); if(seenCell.has(cell)){ spots.push({name:it.name,verdict:'mapped',src:it.src}); continue; } seenCell.add(cell);
+            newPins.push({lng:g.lng,lat:g.lat,name:String(it.name).slice(0,90),kind:String(it.kind||'').slice(0,60),sum:String(it.summary||'')}); spots.push({name:it.name,verdict:'mapped',src:it.src}); }
+          else spots.push({name:it.name,verdict:'unplaced',src:it.src}); }
+        if(newPins.length){ const merged=pre.concat(newPins.map(p=>({lng:p.lng,lat:p.lat,name:p.name,kind:p.kind,sum:p.sum,url:'',src:''})));
+          try{ _pois=merged; let ok=paintPois(); for(let i=0;i<5&&!ok;i++){ await new Promise(r=>setTimeout(r,500)); ok=paintPois(); } }catch(_){}
+          if(pre.length===0){ try{ let a=180,b=90,c=-180,d=-90; newPins.forEach(p=>{a=Math.min(a,p.lng);b=Math.min(b,p.lat);c=Math.max(c,p.lng);d=Math.max(d,p.lat);}); if(isFinite(a)&&(c-a)<340){ if((c-a)<0.05&&(d-b)<0.05) map.flyTo({center:[a,b],zoom:ctx.zoom||6,duration:1000}); else map.fitBounds([[a,b],[c,d]],{padding:80,maxZoom:9,duration:1000}); } }catch(_){} } }
+        return _atlMappingNoteHtml(_atlMappingVerdict(spots), _atlAuditSources(ctx.citations||[]), {infraFail, hadNew:newPins.length>0});
+      }catch(e){ try{ console.warn('reply-mapping audit failed',e); }catch(_){}   /* (#R150) NEVER an empty catch — record the cause + surface an honest note */
+        return '<div style="font-size:10.5px;color:var(--text-muted);margin-top:6px;opacity:.85;">'+L('Could not run the map self-check for this answer.','この回答の地図セルフチェックを実行できませんでした。','Karten-Selbstprüfung nicht möglich.','Не удалось выполнить самопроверку карты.','No se pudo verificar el mapa.')+'</div>'; } }
 
     /* ---- dispatch (every action maps to REAL existing engine code — "IntMapの全動作") ---- */
     async function dispatch(a){ if(!a||!a.type) return R(true,'');
@@ -29892,7 +30016,7 @@ window.addEventListener('DOMContentLoaded', () => {
           return R(true, h); }
         case 'streetview': case 'streetView': case 'pano': {
           /* (#R84) coverage mode: with no place, or when explicitly asked, tint roads blue + make the map clickable */
-          if(a.on===false||/^(off|hide|stop)$/i.test(String(a.mode||''))){ try{ window.IntMapStreetView&&window.IntMapStreetView.coverage&&window.IntMapStreetView.coverage(false); }catch(_){} try{ window.IntMapStreetView&&window.IntMapStreetView.close&&window.IntMapStreetView.close(); }catch(_){} return R(true, note('✓ '+L('Street View off','ストリートビューをオフ','Street View aus','Просмотр улиц выкл','Street View apagado'))); }
+          if(a.on===false||/^(off|hide|stop)$/i.test(String(a.mode||''))){ try{ window.IntMapStreetView&&window.IntMapStreetView.coverage&&window.IntMapStreetView.coverage(false); }catch(_){} try{ window.IntMapStreetView&&window.IntMapStreetView.close&&window.IntMapStreetView.close(); }catch(_){} return R(true, note('✓ '+L('Street View off','ストリートビューをオフ','Street View aus','Просмотр улиц выкл','Street View apagado'))+_featTogHtml('streetview')); }   /* (#R150) offer the toggle to flip it back on */
           const wantCov=/^(coverage|layer|mode|map|roads?)$/i.test(String(a.mode||''))||a.coverage===true||(!a.place&&a.lng==null&&!(_herePoint&&isFinite(_herePoint.lng)));
           if(wantCov){ let on=false; try{ if(window.IntMapStreetView&&window.IntMapStreetView.coverage) on=window.IntMapStreetView.coverage(true); }catch(_){} return R(!!on, on?note('🧍 '+L('Street View mode on — the light-blue lines are Google\'s real coverage; click one to open its panorama','ストリートビュー・モードをオン — 水色の線はGoogleの実際のカバレッジです。クリックでパノラマを表示','Street-View-Modus an — die hellblauen Linien sind Googles echte Abdeckung; zum Öffnen anklicken','Режим панорам включён — голубые линии это реальное покрытие Google; кликните для просмотра','Modo Street View activado — las líneas celestes son la cobertura real de Google; haz clic para abrir'))+_featTogHtml('streetview'):warn('⚠')); }
           let ll=null; if(a.lng!=null&&isFinite(+a.lng)) ll={lng:+a.lng,lat:+a.lat,name:a.place||''}; else if(a.place) ll=await geocode(a.place); else if(_herePoint&&isFinite(_herePoint.lng)) ll={lng:_herePoint.lng,lat:_herePoint.lat,name:_herePoint.name||''};
@@ -30099,6 +30223,28 @@ window.addEventListener('DOMContentLoaded', () => {
              the live paint, and if we cannot parse it SAY SO instead of silently claiming success. */
           let cwarn=''; if(a.color!=null&&String(a.color).trim()!==''){ const pc=parseColor(a.color); if(pc) setHlColor(pc); else cwarn=warn('⚠ '+L('Unknown color','色を認識できません','Unbekannte Farbe','Неизвестный цвет','Color desconocido')+': '+esc(a.color)); }
           await ensureData();
+          /* (#R150 · geo-target unification) SINGLE ambiguity decision shared by BOTH the multi-region and the
+             single-colour paths below. ROOT CAUSE the user reported: candidate-confirmation ("did you mean the
+             country or the US state?") was appended as a mere WARNING *alongside* the painted success + not-found
+             failures — so confirmation, partial execution, success and failure all showed at once. The spec:
+             "意味が排他的なら確認質問を出して実行を停止" — an exclusive/ambiguous name must produce ONE coherent
+             confirmation that STOPS execution (paints nothing), never mixed with a success/partial. This helper
+             renders that single confirmation; both paths gate on it BEFORE painting. No per-name hardcoding — it is
+             driven entirely by resolveHlTarget's ambiguous verdict, so it applies uniformly to admin regions,
+             historical regions, natural regions and same-name places. */
+          const _hlAmbigConfirm=(ambigArr, clearNames)=>{
+            const body=(ambigArr||[]).map(t=>'<b>'+esc(t.name)+'</b>:<br>• '+((t.candidates||[]).slice(0,4).map(c=>esc(String((c&&c.name)||c||'')+((c&&c.country)?(' — '+c.country):'')+((c&&c.note)?(' ('+c.note+')'):''))).join('<br>• ')||esc(String(t.name)))).join('<br>');
+            const head=(ambigArr&&ambigArr.length>1)
+              ? L('These names are ambiguous — which did you mean for each?','これらの名称には複数の候補があります。それぞれどれを指しますか？','Diese Namen sind mehrdeutig — welchen jeweils?','Названия неоднозначны — какой в каждом случае?','Estos nombres son ambiguos — ¿cuál en cada caso?')
+              : L('That name is ambiguous — which did you mean?','その名称には複数の候補があります。どれを指しますか？','Der Name ist mehrdeutig — welchen meinen Sie?','Название неоднозначно — какой вариант?','Ese nombre es ambiguo — ¿cuál quiere decir?');
+            let extra=''; const cn=(clearNames||[]).filter(Boolean);
+            if(cn.length) extra='<div style="font-size:11px;color:var(--text-muted);margin-top:5px;">'+L(
+              'Nothing was drawn on a guess — clarify the above and I\'ll highlight everything (incl. '+esc(cn.slice(0,4).join(', '))+') together.',
+              '推測では描画していません。上記を確定いただければ '+esc(cn.slice(0,4).join(', '))+' などまとめてハイライトします。',
+              'Nichts wurde geraten — nach der Klärung hebe ich alles (auch '+esc(cn.slice(0,4).join(', '))+') zusammen hervor.',
+              'Ничего не нарисовано наугад — уточните, и я выделю всё (включая '+esc(cn.slice(0,4).join(', '))+') сразу.',
+              'No se dibujó nada por conjetura — aclara y resaltaré todo (incl. '+esc(cn.slice(0,4).join(', '))+') junto.')+'</div>';
+            return warn('⚠ '+head)+note(body)+extra; };
           /* (#R104) RANK + FILTER → highlight ("人口5M未満は除外したGDP per capita上位10ヵ国をハイライトして"): when a
              ranking metric is given instead of explicit country names, compute the ranked, optionally
              population-filtered top/bottom-N DETERMINISTICALLY from the real country data and highlight exactly
@@ -30165,6 +30311,10 @@ window.addEventListener('DOMContentLoaded', () => {
                 : approx?('⬡ '+L('approx.','近似','ca.','прибл.','aprox.'))
                 : (kind==='country'||kind==='set')?L('national borders','国境','Staatsgrenzen','госграницы','fronteras'):'';
               G.push({name:nm4,displayName:_regionLabel(nm4),kind,geo:gj,codes,nCountries:nC,composed,osm,derived,approx,verified,basis,basisShort}); }
+            /* (#R150) AMBIGUITY GATE — an exclusive/ambiguous target STOPS the whole request: ask ONE confirmation,
+               paint nothing (no partial + confirmation co-display). Gate before the paint so it applies whether or
+               not the multi-region branch would have drawn. */
+            if(gAmbig.length){ if(_hlMyGen!==_hlGen) return R(true,''); return R(false, _hlAmbigConfirm(gAmbig, G.map(g=>g.displayName||g.name).concat(gMiss)), {meta:{partial:true}}); }
             if(G.length>=2 && G.some(g=>g.kind==='set'||g.kind==='region')){
               if(_hlMyGen!==_hlGen) return R(true,'');   /* superseded by a newer highlight → don't overwrite it */
               clearHl(); clearLineHl(); _hlLines=[]; clearPolyHl();
@@ -30179,12 +30329,13 @@ window.addEventListener('DOMContentLoaded', () => {
               if(G.some(g=>g.composed)) hh+=note(L('Some regions built from member administrative boundaries','一部の地域は構成行政区画の境界から構築','Einige Regionen aus Verwaltungsgrenzen der Teilgebiete','Некоторые регионы построены из адм. границ','Algunas regiones a partir de límites administrativos'));
               if(G.some(g=>g.osm)) hh+=note(L('Some regions from real OpenStreetMap boundaries','一部の地域は実際のOpenStreetMap境界','Einige Regionen aus realen OpenStreetMap-Grenzen','Некоторые регионы — реальные границы OSM','Algunas regiones de límites reales de OpenStreetMap'));
               if(G.some(g=>g.derived||g.approx)) hh+=note(L('⬡ = approximate extent (no official boundary exists)','⬡ = 近似範囲（公式境界が存在しない）','⬡ = ungefähre Ausdehnung (keine offizielle Grenze)','⬡ = приблизительный контур (нет офиц. границы)','⬡ = extensión aproximada (sin límite oficial)'));
+              /* (#R150) gAmbig is now impossible here — the ambiguity gate above returned before painting. Only
+                 honest "drawn, but these couldn't be located/were invalid" disclosure remains (no pending question). */
               if(gRej.length) hh+=warn('⚠ '+L('Rejected — invalid/degenerate shape (not drawn)','不正・退化した形状のため未描画','Abgelehnt — ungültige/entartete Form','Отклонено — некорректная форма','Rechazado — forma inválida')+': '+esc(gRej.map(r=>r.name).join(', ')));
-              if(gAmbig.length) hh+=warn('⚠ '+L('Ambiguous (not drawn) — clarify','曖昧なため未描画 — 指定してください','Mehrdeutig (nicht gezeichnet)','Неоднозначно (не нарисовано)','Ambiguo (no dibujado)')+': '+esc(gAmbig.map(a2=>a2.name).join(', ')));
               if(gMiss.length) hh+=warn('⚠ '+L('Not found','見つからず','Nicht gefunden','Не найдено','No encontrado')+': '+esc(gMiss.join(', ')));
               if(ver&&!ver.ok) hh+=warn('⚠ '+L('Could not verify the drawn shapes on the map','描画結果を地図上で確認できませんでした','Gezeichnete Formen nicht verifizierbar','Не удалось проверить фигуры на карте','No se pudieron verificar las formas'));
               try{ _wctx.highlight={ name:G.map(g=>g.displayName||g.name).join(', ').slice(0,160), n:G.length, basis:(G.map(g=>g.basis).filter(Boolean).join(' / ')||null) }; }catch(_){}
-              const partial=!!(gRej.length||gAmbig.length||gMiss.length||(ver&&!ver.ok));
+              const partial=!!(gRej.length||gMiss.length||(ver&&!ver.ok));
               return R(true, hh+cwarn, partial?{meta:{partial:true}}:undefined);
             }
             /* not multi-region-eligible (1 shape drew, or a plain country list) → single-colour path below */
@@ -30222,9 +30373,10 @@ window.addEventListener('DOMContentLoaded', () => {
                 /* (#R132) precise BASIS per method — real OSM boundary vs web-anchor-derived vs curated gazetteer/AI outline */
                 if(t2.rrMethod==='osm_polygon') anyOsm=true; else if(t2.rrMethod==='derived_anchors') anyDerived=true; else if(t2.soft||t2.approx) anyApprox=true; } }
             else miss.push(nm2); }
-          /* (#R132) if the ONLY results were ambiguous, ask which one — never paint a guess */
-          const _ambHtml=arr=>arr.map(t=>'<b>'+esc(t.name)+'</b>:<br>• '+(t.candidates||[]).slice(0,4).map(c=>esc(String(c.name||'')+(c.country?(' — '+c.country):'')+(c.note?(' ('+c.note+')'):''))).join('<br>• ')).join('<br>');
-          if(!found.length&&!polys.length&&!lines.length&&ambig.length) return R(false, warn('⚠ '+L('That name is ambiguous — which did you mean?','その名称には複数の候補があります。どれを指しますか？','Der Name ist mehrdeutig — welchen meinen Sie?','Название неоднозначно — какой вариант?','Ese nombre es ambiguo — ¿cuál quiere decir?'))+note(_ambHtml(ambig))+cwarn);
+          /* (#R150) AMBIGUITY GATE (shared decision with the multi-region path via _hlAmbigConfirm): ANY ambiguous
+             target STOPS the request with ONE confirmation and paints nothing — never "highlighted A" + "did you
+             mean B or C?" + "not found: D" at once. What WOULD be drawn is listed so the user sees nothing was guessed. */
+          if(ambig.length){ if(_hlMyGen!==_hlGen) return R(true,''); const clear=found.filter(c=>!c._grp).map(c=>c.name).concat(grpNames).concat(polys.map(p=>p.name)).concat(lineNames).concat(miss); return R(false, _hlAmbigConfirm(ambig, clear)+cwarn, {meta:{partial:true}}); }
           if(!found.length&&!polys.length&&!lines.length){
             if(rejected.length) return R(false, warn('⚠ '+L('The shape resolved for that region was invalid (degenerate/self-intersecting) and was not drawn','その地域の形状が不正（退化・自己交差）なため描画しませんでした','Die aufgelöste Form dieser Region war ungültig (entartet/selbstschneidend)','Форма региона оказалась недействительной (вырожденная/самопересекающаяся)','La forma resuelta para esa región no era válida (degenerada/autointersecante)')+': '+esc(rejected.map(r=>r.name).join(', ')))+cwarn);
             return R(false, warn('⚠ '+L('Nothing found for','見つかりません','Nichts gefunden für','Ничего не найдено','Nada encontrado para')+': '+esc(raw.join(', ')))+cwarn); }
@@ -30260,7 +30412,7 @@ window.addEventListener('DOMContentLoaded', () => {
           if(anyPartial) hh+=warn('⚠ '+L('Some member boundaries could not be fetched — the shape may be missing pieces','一部の構成区画の境界を取得できませんでした（欠けがある可能性）','Einige Teilgrenzen fehlen','Часть границ получить не удалось','Faltan algunos límites'));
           if(anyApprox) hh+=note(L('⬡ = approximate extent (no official boundary exists — AI-traced outline)','⬡ = 近似輪郭（公式境界が存在しない地域のAIトレース）','⬡ = ungefähre Ausdehnung (KI-Umriss)','⬡ = приблизительный контур (ИИ)','⬡ = contorno aproximado (IA)'));
           if(anyVerified) hh+=note('✓ '+L('location web-verified','位置をWeb検索で照合','Standort per Websuche geprüft','местоположение проверено веб-поиском','ubicación verificada con búsqueda web'));
-          if(ambig.length) hh+=warn('⚠ '+L('Ambiguous (not drawn) — clarify','曖昧なため未描画 — 指定してください','Mehrdeutig (nicht gezeichnet)','Неоднозначно (не нарисовано)','Ambiguo (no dibujado)')+':<br>'+_ambHtml(ambig));
+          /* (#R150) ambig is impossible here — the ambiguity gate above stopped and asked before any painting. */
           if(miss.length) hh+=warn('⚠ '+L('Not found','見つからず','Nicht gefunden','Не найдено','No encontrado')+': '+esc(miss.join(', ')));
           if(rejected.length) hh+=warn('⚠ '+L('Rejected — invalid/degenerate shape (not drawn)','不正・退化した形状のため未描画','Abgelehnt — ungültige/entartete Form','Отклонено — некорректная форма','Rechazado — forma inválida')+': '+esc(rejected.map(r=>r.name).join(', ')));   /* (#R143) */
           /* (#R142) PARTIAL result → the planner's pre-written "…をハイライトしました" over-claims the targets that were NOT
@@ -30765,7 +30917,10 @@ window.addEventListener('DOMContentLoaded', () => {
           html+='<div style="font-size:12.5px;line-height:1.62;">'+mdMini(String(txt).trim())+'</div>';
           /* (#R149 · mapping commission) pin the specific real places the analysis named (unless the plan already
              pinned) so an integrated analysis delivers MAP value, not just prose — with an honest placed/not-placed note. */
-          if(replyPlaces.length && !(_pois&&_pois.length)){ try{ html+=await _pinReplyPlaces(replyPlaces,{}); }catch(_){} }
+          /* (#R150) ALWAYS reconcile prose↔map — pass the final text (so places the model omitted from the list are
+             still checked) + the real citations (source-concentration audit); the audit MERGES with any plan pins
+             instead of being suppressed by them. Non-empty catch surfaces an honest note (never silent). */
+          try{ html+=await _pinReplyPlaces(replyPlaces,{text:String(txt).trim(),citations:_aCites}); }catch(e){ try{ console.warn('analyze map audit',e); }catch(_){} }
           /* (#R131) Freshness-critical question but live web verification did NOT run: label the answer a PROVISIONAL
              assessment built mainly on already-gathered headlines, so headline-only leads are never presented as
              confirmed direct evidence (the Central-Asia failure). Applies equally when the web search timed out into
@@ -31071,7 +31226,10 @@ window.addEventListener('DOMContentLoaded', () => {
         }
         case 'control': return doControl(a);
         case 'answer': { let _ah='<div style="font-size:12.5px;line-height:1.62;">'+mdMini(a.text||'')+'</div>';   /* (#R149) if the answer NAMED mappable places, pin them (unless the plan already pinned) so a location-rich reply always delivers map value */
-          if(Array.isArray(a.places)&&a.places.length&&!(_pois&&_pois.length)){ try{ _ah+=await _pinReplyPlaces(a.places,{}); }catch(_){} }
+          /* (#R150) same code-side reconciliation for the planner's direct `answer`: audit the answer text (safety net
+             for an omitted places list), merge with existing pins, honest self-audit + source-concentration note. */
+          { const _acit=(Array.isArray(window._aiLastCitations)?window._aiLastCitations:[]).filter(c=>c&&/^https?:\/\//i.test(String(c.url||'')));
+            try{ _ah+=await _pinReplyPlaces(a.places||[],{text:String(a.text||''),citations:_acit}); }catch(e){ try{ console.warn('answer map audit',e); }catch(_){} } }
           return R(true, _ah); }
         default: { if(a.target||a.name){ const c=doControl({target:a.target||a.name,value:a.value,on:a.on}); if(c.ok) return c; } return R(false, warn('⚠ '+L('Unknown action','不明な操作','Unbekannte Aktion','Неизвестное действие','Acción desconocida')+': '+esc(a.type||''))); }
       } }
@@ -31515,7 +31673,7 @@ window.addEventListener('DOMContentLoaded', () => {
        _stopRun paints THIS same note so an in-flight abort that repaints it stays visually identical (no flicker). */
     function _cancelledNote(){ return '<span style="color:var(--text-muted);font-size:11.5px;">⏹ '+esc(L('Stopped','停止しました','Angehalten','Остановлено','Detenido'))+'</span>'; }
     const _GO_SEND_SVG='<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="M5.5 11.5 12 5l6.5 6.5"/></svg>';
-    const _GO_STOP_SVG='<svg viewBox="0 0 24 24" width="20" height="20"><rect x="3.25" y="3.25" width="17.5" height="17.5" rx="3.5" fill="currentColor"/></svg>';   /* (#R149) bigger stop square again ("四角はもう少し大きく"): rect 15→17.5 in a 24 viewBox rendered 18→20px ≈ 11.25px→14.6px */
+    const _GO_STOP_SVG='<svg viewBox="0 0 24 24" width="20" height="20"><rect x="4.25" y="4.25" width="15.5" height="15.5" rx="3.4" fill="currentColor"/></svg>';   /* (#R150) "四角はほんの少し小さく": rect 17.5→15.5 in a 24 viewBox (rendered ≈14.6px→12.9px) — a gentle trim, still clearly a Stop square */
     /* (#R142) send ⇄ stop: while Atlas is generating a reply, the up-arrow SEND button becomes a red STOP square. */
     function _setGoBusy(busy){ try{ if(!panel) return; const go=panel.querySelector('.atl-go'); if(!go) return;
       if(busy){ go.classList.add('busy'); go.classList.remove('idle'); go.innerHTML=_GO_STOP_SVG; go.onclick=_stopRun; go.title=L('Stop answering','応答を停止','Antwort stoppen','Остановить ответ','Detener respuesta'); go.setAttribute('aria-label',go.title); }
@@ -33278,7 +33436,15 @@ window.addEventListener('DOMContentLoaded', () => {
     /* ---- CRUD ---- */
     async function create(opts){ opts=opts||{}; if(!_loggedIn()){ _promptLogin(); return {ok:false,error:'login'}; }
       const area=opts.area||activeArea(); if(!area||!area.geometry) return {ok:false,error:'no_area'};
-      const row={ name:String(opts.name||area.label||ML('Area monitor','エリア監視','Gebietsmonitor','Монитор области','Monitor de área')).slice(0,120),
+      /* (#R150) THE "Could not save the monitor" ROOT CAUSE: area_monitors.user_id is `not null` and the
+         insert RLS policy is `with check (user_id = auth.uid())`, but this row previously OMITTED user_id —
+         so every UI insert violated NOT NULL / RLS and failed. The feature was only ever verified server-side
+         (service_role sets user_id explicitly), never through the logged-in client. Set it here exactly like
+         every other user-owned insert (feedback / bug_reports / donations). A belt-and-suspenders DB
+         `default auth.uid()` is added in migration 20260721140000 too. */
+      const _uid=(typeof currentUser!=='undefined'&&currentUser&&currentUser.id)||null;
+      if(!_uid){ _promptLogin(); return {ok:false,error:'login'}; }
+      const row={ user_id:_uid, name:String(opts.name||area.label||ML('Area monitor','エリア監視','Gebietsmonitor','Монитор области','Monitor de área')).slice(0,120),
         geometry:area.geometry, geometry_kind:area.geometry_kind||'polygon',
         center_lng:(area.center_lng!=null?area.center_lng:null), center_lat:(area.center_lat!=null?area.center_lat:null), radius_km:(area.radius_km!=null?area.radius_km:null),
         bbox:area.bbox||_bboxOf(area.geometry)||null, area_label:area.label||null,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test",
     "test:security": "node --test tests/security-logic.mjs",
     "test:monitor": "node --test tests/monitor-logic.test.mjs",
-    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs tests/r149-checks.test.mjs && playwright test",
+    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs tests/r149-checks.test.mjs tests/r150-checks.test.mjs && playwright test",
     "report": "playwright show-report"
   },
   "devDependencies": {

--- a/supabase/functions/ai-proxy/index.ts
+++ b/supabase/functions/ai-proxy/index.ts
@@ -17,8 +17,8 @@
 //  Deploy:   supabase functions deploy ai-proxy --project-ref vpekfwdpurzejrrmacac
 //            (verify_jwt can stay ON; we also verify the user explicitly.)
 //  Secrets:  supabase secrets set AI_PROVIDER=openai                  (openai | anthropic | gemini)
-//            supabase secrets set AI_MODEL=gpt-5.6-luna              (#R148 Terra→Luna; Terra 403 no-access on this project; model fixed here — users never pick it)
-//            supabase secrets set OPENAI_API_KEY=sk-...               (CURRENT provider — Luna via /v1/responses)
+//            supabase secrets set AI_MODEL=gpt-5.6-terra             (#R150 Terra re-verified reachable on this project; model fixed here — users never pick it. Luna is the FALLBACK_MODEL.)
+//            supabase secrets set OPENAI_API_KEY=sk-...               (CURRENT provider — Terra via /v1/responses)
 //            # other providers stay wired but dormant:
 //            supabase secrets set GEMINI_API_KEY=AIza...              (if AI_PROVIDER=gemini)
 //            supabase secrets set GEMINI_SEARCH_ENABLED=false         (#R113 Gemini grounding, default OFF)
@@ -90,13 +90,13 @@ const json = (body: unknown, status = 200) =>
 const PLAN_LIMITS: Record<string, number> = { free: 10, plus: 50, pro: 200, unlimited: 1_000_000 };   /* (#R101) free 10→30/day; (#R147) 30→10/day */
 const DEFAULT_LIMIT = PLAN_LIMITS.free;
 
-// (#R148) OpenAI model. GPT-5.6 Terra was set in R147 but this OpenAI PROJECT has NO access to it
-// (api.openai.com → 403 model_not_found "Project ... does not have access to model gpt-5.6-terra"),
-// which took Atlas AI down entirely ("The AI service is temporarily unavailable"). GPT-5.6 Luna IS
-// accessible on the project (verified 200 on /v1/responses) so it is the working default + the
-// fallback. FALLBACK_MODEL is retried once when the configured AI_MODEL is rejected as
-// not-found / no-access, so a bad AI_MODEL secret can never again blanket-kill the AI.
-const OPENAI_DEFAULT_MODEL = "gpt-5.6-luna";
+// (#R150) OpenAI model = GPT-5.6 TERRA. In R148 this project had NO access to gpt-5.6-terra (403
+// model_not_found), so we ran Luna. Re-verified on 2026-07-21 via the refresh-news proxy (same key +
+// AI_MODEL secret, NO model fallback): AI_MODEL=gpt-5.6-terra geocoded 61/63 EN + 104/116 JP articles →
+// Terra is now reachable on the project. Per the user's standing request, Terra is now the model
+// (AI_MODEL secret = gpt-5.6-terra). Luna stays the FALLBACK_MODEL: if Terra ever loses access again, a
+// 403/404 model_not_found retries once with Luna so a model outage can never blanket-kill Atlas.
+const OPENAI_DEFAULT_MODEL = "gpt-5.6-terra";
 const FALLBACK_MODEL = "gpt-5.6-luna";
 
 const MAX_PROMPT = 24_000;     // hard caps so a single call can't be abused

--- a/supabase/migrations/20260721140000_area_monitors_user_default.sql
+++ b/supabase/migrations/20260721140000_area_monitors_user_default.sql
@@ -1,0 +1,31 @@
+-- ============================================================================
+--  IntMap — AREA MONITORS: user_id default (#R150)
+-- ----------------------------------------------------------------------------
+--  WHY
+--    area_monitors.user_id is `not null` and the INSERT RLS policy is
+--    `with check (user_id = auth.uid())`, but the logged-in client insert path
+--    omitted user_id entirely — so every "Create monitor" from the UI violated
+--    the NOT NULL constraint / RLS and returned "Could not save the monitor".
+--    (The feature had only ever been exercised via the service_role runner,
+--    which sets user_id explicitly; the client path was never actually run.)
+--
+--    The client fix (index.html) now sets user_id from the session like every
+--    other user-owned insert. THIS migration adds a DB-side default of
+--    auth.uid() as belt-and-suspenders: any authenticated insert that omits
+--    user_id is populated with the caller's id, which also satisfies the RLS
+--    WITH CHECK. The service_role runner passes user_id explicitly, so an
+--    explicit value always overrides the default — no behavior change there.
+--
+--  IDEMPOTENT & NON-DESTRUCTIVE
+--    Only ALTER COLUMN ... SET DEFAULT. No data change, no DROP, safe to re-run.
+-- ============================================================================
+
+begin;
+
+alter table public.area_monitors
+  alter column user_id set default auth.uid();
+
+comment on column public.area_monitors.user_id is
+  '(#R150) Owner. Defaults to auth.uid() so an authenticated client insert that omits it is still populated correctly (and satisfies the insert RLS WITH CHECK). service_role sets it explicitly.';
+
+commit;

--- a/tests/r147-checks.test.mjs
+++ b/tests/r147-checks.test.mjs
@@ -18,14 +18,13 @@ test('R147 #13 free AI quota is 10/day on the client and server', () => {
   assert.ok(!/1日30回/.test(html), 'no stale JP "1日30回"');
 });
 
-test('R148 #12 Atlas model reverted to GPT-5.6 Luna (Terra had no project access); Gemini Flash-Lite unused', () => {
-  // (#R148) R147 set Terra, but this OpenAI project returns 403 model_not_found for Terra → Atlas died.
-  // Luna IS accessible (verified 200 on /v1/responses) so it is the working default; Terra must NOT
-  // be the default any more.
+test('R150 #9 Atlas model = GPT-5.6 Terra (re-verified reachable); Luna is the fallback; Gemini Flash-Lite unused', () => {
+  // (#R150) R148 ran Luna because this project 403'd Terra. Re-verified 2026-07-21 via the refresh-news proxy
+  // (same key + AI_MODEL, no model fallback): AI_MODEL=gpt-5.6-terra geocoded 61/63 EN + 104/116 JP → Terra is
+  // now reachable, so it is the default per the user's standing request. Luna stays the resilient FALLBACK_MODEL.
   assert.match(aiproxy, /provider === "openai" \? OPENAI_DEFAULT_MODEL/, 'openai default = OPENAI_DEFAULT_MODEL');
-  assert.match(aiproxy, /const OPENAI_DEFAULT_MODEL = "gpt-5\.6-luna"/, 'default model = Luna');
-  assert.match(aiproxy, /const FALLBACK_MODEL = "gpt-5\.6-luna"/, 'fallback model = Luna');
-  assert.ok(!/provider === "openai" \? "gpt-5\.6-terra"/.test(aiproxy), 'Terra is no longer the default');
+  assert.match(aiproxy, /const OPENAI_DEFAULT_MODEL = "gpt-5\.6-terra"/, 'default model = Terra');
+  assert.match(aiproxy, /const FALLBACK_MODEL = "gpt-5\.6-luna"/, 'fallback model = Luna (resilience)');
   assert.match(aiproxy, /Flash-Lite is never used/, 'documents that Gemini Flash-Lite is never used');
   const aiproxyNoNote = aiproxy.replace(/Gemini 3\.1 Flash-Lite is never used\./g, '');
   assert.ok(!/flash-lite/i.test(aiproxyNoNote), 'flash-lite appears only in the "never used" note');

--- a/tests/r149-checks.test.mjs
+++ b/tests/r149-checks.test.mjs
@@ -34,9 +34,12 @@ test('R149 #7 monitor create dialog shows guaranteed INLINE failure feedback', (
   assert.ok((html.match(/showErr\(/g) || []).length >= 2, 'showErr used for no-area AND create failure');
 });
 
-test('R149 #3 Köppen legend compacted so 30 zones fit and can stretch to the last class', () => {
-  assert.match(html, /max-height:calc\(100dvh - 84px\)/, 'CSS ceiling reduced 92→84');
-  assert.match(html, /const cap=Math\.round\(window\.innerHeight - 84\)/, 'JS fit cap matches 84');
+test('R149/R150 #3 Köppen legend stretches to the screen bottom (viewport-based ceiling)', () => {
+  assert.match(html, /max-height:calc\(100dvh - 84px\)/, 'CSS ceiling near full viewport');
+  // (#R150) fit is now VIEWPORT-based (down to ~12px above the screen bottom), NOT clamped to content — so the
+  // resize grip can be dragged all the way down; the old content-height cap made "一番下まで伸ばせない".
+  assert.match(html, /const renderedMax=Math\.round\(window\.innerHeight - top - 12\)/, 'JS fit is viewport-based (R150)');
+  assert.ok(!/const cap=Math\.round\(window\.innerHeight - 84\)/.test(html), 'old content-clamp cap removed');
   assert.match(html, /\.kl-item\{ display:flex; align-items:center; gap:6px; padding:1px 4px;/, 'compact rows (1px)');
   assert.match(html, /\.kl-sw\{ width:11px; height:11px;/, 'smaller swatch');
 });
@@ -46,7 +49,7 @@ test('R149 #4 Atlas typography: em-based heading hierarchy in mdMini', () => {
   assert.match(html, /font-size:1\.55em;letter-spacing:\.01em/, 'h1 ~1.55em');
   assert.match(html, /font-size:1\.32em;line-height:1\.3;letter-spacing:\.005em/, 'h2 ~1.32em');
   assert.match(html, /font-size:1\.14em;line-height:1\.32/, 'h3 ~1.14em');
-  assert.match(html, /'<div style="height:\.7em"><\/div>'/, 'paragraph gap ~0.7em');
+  assert.match(html, /'<div style="height:\.72em"><\/div>'/, 'paragraph gap ~0.72em (R150)');
   // prompts mandate the structure
   assert.match(html, /FORMAT FOR READABILITY — REQUIRED for any answer longer than/, 'answer prompt mandates structure');
 });
@@ -54,7 +57,7 @@ test('R149 #4 Atlas typography: em-based heading hierarchy in mdMini', () => {
 test('R149 #5/#6 send button arrow solid black when idle; bigger stop square', () => {
   assert.match(html, /\.atl-go\.idle\{background:#fff;box-shadow:0 1px 4px rgba\(0,0,0,0\.12\);color:#111;\}/, 'idle icon is #111 (not muted rgba)');
   assert.ok(!/\.atl-go\.idle\{[^}]*rgba\(120,120,128,0\.75\)/.test(html), 'old faded idle colour removed');
-  assert.match(html, /_GO_STOP_SVG='<svg viewBox="0 0 24 24" width="20" height="20"><rect x="3\.25" y="3\.25" width="17\.5" height="17\.5"/, 'stop square enlarged');
+  assert.match(html, /_GO_STOP_SVG='<svg viewBox="0 0 24 24" width="20" height="20"><rect x="4\.25" y="4\.25" width="15\.5" height="15\.5"/, 'stop square slightly smaller (R150 17.5→15.5)');
 });
 
 test('R149 #8 choice free-input send button = white bg + SVG (no plain-text →)', () => {
@@ -80,8 +83,9 @@ test('R149 #9 image paste/vision wired on the client (transport + proxy already 
 
 test('R149 #10 mapping-quality commission: reply places get pinned + honest self-audit', () => {
   assert.match(html, /async function _pinReplyPlaces\(places, ctx\)/, 'reply-place pinning helper');
-  assert.match(html, /_tryMapResearch\(ctx\.place\|\|''/, 'reuses the geocode+pin ladder');
-  assert.match(html, /Not placed \(couldn/, 'honest not-placed note');
+  // (#R150) the orchestrator now audits via the pure verdict (mapped/unplaced/ambiguous) + merges pins; see r150-checks.
+  assert.match(html, /_atlMappingNoteHtml\(_atlMappingVerdict\(spots\)/, 'reply mapping folds into the pure verdict');
+  assert.match(html, /but not placed \(couldn/, 'honest not-placed note (R150 wording)');
   // analyze parses a PLACES: trailer (no extra AI call), answer carries a places array
   assert.match(html, /PLACES\\s\*\[:：\]/, 'analyze strips a PLACES: trailer');
   assert.match(html, /"type":"answer","text":str,"places"\?:\[\{"n":str,"c":str,"k":str\}\]/, 'answer action schema has places');

--- a/tests/r149.spec.js
+++ b/tests/r149.spec.js
@@ -35,31 +35,32 @@ test('#5/#6 Atlas send button ↑ is solid black when idle; stop square is enlar
   expect(r.bg).toBe('rgb(255, 255, 255)');     // white button
 });
 
-test('#3 Köppen legend: all 30 zones fit the viewport and the last class is reachable after fit', async () => {
-  await page.setViewportSize({ width: 1280, height: 720 });
+test('#3 Köppen legend ceiling is viewport-based — it stretches to the screen bottom (R150), last class reachable', async () => {
+  // (#R150) the fit no longer clamps to content height (that made "一番下まで伸ばせない"); it clamps to the viewport,
+  // so the resize grip can be dragged to ~12px above the screen bottom. When content exceeds the box, the inner
+  // .kl-scroll is the safety net — every class stays reachable by scrolling.
+  await page.setViewportSize({ width: 1280, height: 800 });
   const r = await page.evaluate(() => {
     const lg = document.getElementById('koppen-legend');
     if (!lg || typeof window._fitKoppenLegend !== 'function') return { err: 'no legend/fit' };
     let items = '';
     for (let i = 0; i < 30; i++) items += '<div class="kl-item" data-c="X' + i + '"><span class="kl-sw"></span>Cfa · 温暖湿潤気候</div>';
     lg.innerHTML = '<span class="kl-drag">⋮⋮</span><button class="layer-popup-x">✕</button><h4>ケッペン気候区分</h4>'
-      + '<div class="kl-period"><label>期間</label><select><option>1991–2020</option></select></div>'
       + '<div class="kl-scroll">' + items + '</div>'
       + '<div class="kl-hint">クリックでその気候だけ強調 / 右クリックで定義</div>';
-    lg.style.display = 'flex'; lg.style.height = ''; lg.style.maxHeight = 'none';
-    const natural = lg.getBoundingClientRect().height;
-    lg.style.maxHeight = '';
+    lg.style.display = 'flex'; lg.style.top = '74px'; lg.style.height = ''; lg.style.maxHeight = '';
     window._fitKoppenLegend(lg);
-    const sc = lg.querySelector('.kl-scroll');
+    lg.style.height = '4000px';   // simulate dragging the resize grip all the way down
+    const rect = lg.getBoundingClientRect();
+    const sc = lg.querySelector('.kl-scroll'); sc.scrollTop = sc.scrollHeight;   // scroll the inner area to the end
     const last = [...lg.querySelectorAll('.kl-item')].pop();
     const lr = last.getBoundingClientRect(), sr = sc.getBoundingClientRect();
-    return { natural: Math.round(natural), cap: window.innerHeight - 84,
-      innerHidden: sc.scrollHeight - sc.clientHeight, lastVisible: lr.bottom <= sr.bottom + 1.5 };
+    return { bottomGap: Math.round(window.innerHeight - rect.bottom), lastReachable: lr.bottom <= sr.bottom + 2 };
   });
   expect(r.err).toBeUndefined();
-  expect(r.natural).toBeLessThanOrEqual(r.cap);   // the whole 30-zone legend fits the viewport budget
-  expect(r.innerHidden).toBeLessThanOrEqual(1);   // nothing hidden behind an inner scroll
-  expect(r.lastVisible).toBe(true);               // the last climate class is fully visible (stretch-to-end)
+  expect(r.bottomGap).toBeGreaterThanOrEqual(0);
+  expect(r.bottomGap).toBeLessThanOrEqual(26);   // reaches the screen bottom (was clamped ~200px short of it)
+  expect(r.lastReachable).toBe(true);            // the last climate class is reachable via the inner scroll
 });
 
 test('#9 dropping an image into Atlas shows a thumbnail and enables Send', async () => {

--- a/tests/r150-checks.test.mjs
+++ b/tests/r150-checks.test.mjs
@@ -1,0 +1,109 @@
+// R150 source-level regression checks (deterministic, no browser).
+// Guards the batch:
+//   #1  Companies icon slot pixel-matches the Countries flag slot
+//   #2  Atlas Street-View OFF reply also offers the on/off toggle
+//   #3  Köppen legend ceiling is VIEWPORT-based (drag to the screen bottom)  [also in r149-checks]
+//   #4  Atlas typography: _atlStanza groups a flat wall + a sentence-end newline becomes a soft gap
+//   #5  Stop-answering square slightly smaller (17.5 → 15.5)                 [also in r149-checks]
+//   #6  Monitor "Could not save" ROOT CAUSE — client sets user_id + DB default auth.uid()
+//   #7  Geo-target unification — ONE ambiguity gate; confirmation never co-displays with a painted result
+//   #8  Satellite: flight-sim prefetch ahead of the aircraft + sat-labels host round-robin
+//   #9  Atlas model = GPT-5.6 Terra (default), Luna fallback                 [also in r147-checks]
+//   #10 Research-mapping code-side verification (pure audit + merge-not-wipe orchestrator + no empty catch)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+
+const root = new URL('../', import.meta.url);
+const html = readFileSync(new URL('index.html', root), 'utf8');
+const aiproxy = readFileSync(new URL('supabase/functions/ai-proxy/index.ts', root), 'utf8');
+const migDir = new URL('supabase/migrations/', root);
+const migs = readdirSync(migDir).map(f => readFileSync(new URL(f, migDir), 'utf8')).join('\n');
+
+test('R150 #6 monitor save root cause — client sets user_id AND the DB defaults it to auth.uid()', () => {
+  // area_monitors.user_id is `not null` + insert RLS `with check (user_id = auth.uid())`; the client row
+  // previously OMITTED user_id, so every UI insert failed → "Could not save the monitor."
+  assert.match(html, /const _uid=\(typeof currentUser!=='undefined'&&currentUser&&currentUser\.id\)\|\|null;/, 'create() derives the session user id');
+  assert.match(html, /const row=\{ user_id:_uid, name:/, 'insert row now carries user_id (like feedback/bug_reports/donations)');
+  // belt-and-suspenders DB default
+  assert.match(migs, /alter column user_id set default auth\.uid\(\)/, 'migration adds a DB default of auth.uid()');
+});
+
+test('R150 #3 Köppen legend ceiling is viewport-based so the grip reaches the screen bottom', () => {
+  assert.match(html, /const renderedMax=Math\.round\(window\.innerHeight - top - 12\)/, 'ceiling = viewport bottom, not content height');
+  assert.ok(!/const cap=Math\.round\(window\.innerHeight - 84\)/.test(html), 'old content-clamp removed');
+  assert.match(html, /一番下まで伸ばせない/, 'comment records the exact re-report it fixes');
+});
+
+test('R150 #5 stop-answering square trimmed 17.5 → 15.5', () => {
+  assert.match(html, /_GO_STOP_SVG='<svg viewBox="0 0 24 24" width="20" height="20"><rect x="4\.25" y="4\.25" width="15\.5" height="15\.5"/, 'rect is 15.5 in a 24 viewBox');
+  assert.ok(!/width="17\.5" height="17\.5" rx="3\.5"/.test(html), 'the R149 17.5 square is gone');
+});
+
+test('R150 #4 typography: flat prose gets code-side rhythm (stanza + sentence-end gap)', () => {
+  assert.match(html, /function _atlStanza\(raw\)\{/, 'stanza grouping helper exists');
+  assert.match(html, /if\(\(raw\.match\(\/\\n\/g\)\|\|\[\]\)\.length>1\) return raw;/, 'respects the model\'s own line breaks');
+  assert.match(html, /esc\(_dedupText\(_atlStanza\(String\(s\|\|''\)\)\)\)/, 'mdMini runs the stanza pass first');
+  assert.match(html, /\.replace\(\/\(\[\.!\?。！？…”"』）\)\]\)\\n\(\?=\\S\)\/g,'\$1<div style="height:\.5em"><\/div>'\)/, 'a sentence-end + single newline becomes a soft paragraph gap');
+});
+
+test('R150 #10 research-mapping: PURE audit helpers exist and are exposed for tests', () => {
+  for (const fn of ['_atlNorm', '_atlNameOk', '_atlExtractPlaces', '_atlRegDomain', '_atlAuditSources', '_atlMappingVerdict', '_atlMappingNoteHtml', '_atlGeocodeStrict']) {
+    assert.ok(new RegExp('function ' + fn + '\\b').test(html) || new RegExp('const ' + fn + '\\b').test(html), fn + ' is defined');
+  }
+  // exposed on IntMapAtlasDebug for the runtime spec
+  assert.match(html, /extractPlaces:function\(t\)\{/, 'extractPlaces exposed on IntMapAtlasDebug');
+  assert.match(html, /auditSources:function\(c\)\{/, 'auditSources exposed');
+  assert.match(html, /mappingVerdict:function\(s\)\{/, 'mappingVerdict exposed');
+});
+
+test('R150 #10 orchestrator: MERGES with existing pins (no skip-on-pins) and NEVER an empty catch', () => {
+  // the old `!(_pois&&_pois.length)` skip guard is gone from BOTH call sites
+  assert.ok(!/&&!\(_pois&&_pois\.length\)\)\{ try\{ html\+=await _pinReplyPlaces/.test(html), 'analyze no longer skips when pins exist');
+  assert.ok(!/a\.places\.length&&!\(_pois&&_pois\.length\)/.test(html), 'answer no longer skips when pins exist');
+  // the analyze call passes the final text + citations
+  assert.match(html, /_pinReplyPlaces\(replyPlaces,\{text:String\(txt\)\.trim\(\),citations:_aCites\}\)/, 'analyze passes text + citations');
+  // no empty catch — it logs the cause and returns an honest note
+  assert.match(html, /console\.warn\('reply-mapping audit failed',e\)/, 'orchestrator records the failure cause');
+  assert.match(html, /Could not run the map self-check for this answer\./, 'honest fallback note (not silent)');
+  // merge, not wipe: existing pins are read into `pre` and concatenated
+  assert.match(html, /const merged=pre\.concat\(newPins\.map/, 'merges existing pins with the new ones');
+});
+
+test('R150 #10 source-concentration audit is real (normalized domains + official detection)', () => {
+  assert.match(html, /function _atlIsOfficial\(dom\)\{/, 'official/primary detection by institutional TLD (no per-site hardcoding)');
+  assert.match(html, /concentrated = total>=2 && \(domains\.length===1/, 'single-domain concentration detected');
+  assert.match(html, /Sources here concentrate on one site/, 'honest one-domain caveat');
+});
+
+test('R150 #7 geo-target: ONE ambiguity gate; confirmation never co-displays with a painted result', () => {
+  assert.match(html, /const _hlAmbigConfirm=\(ambigArr, clearNames\)=>\{/, 'single shared confirmation builder');
+  // BOTH paths gate on ambiguity BEFORE painting and return a stop
+  assert.match(html, /if\(gAmbig\.length\)\{ if\(_hlMyGen!==_hlGen\) return R\(true,''\); return R\(false, _hlAmbigConfirm\(gAmbig/, 'multi-region path gates before paint');
+  assert.match(html, /if\(ambig\.length\)\{ if\(_hlMyGen!==_hlGen\) return R\(true,''\); const clear=/, 'single-colour path gates before paint');
+  // the old co-display (ambiguous shown as a warning alongside the painted success) is GONE
+  assert.ok(!/if\(gAmbig\.length\) hh\+=warn/.test(html), 'multi-region no longer appends an ambiguous warning to a painted reply');
+  assert.ok(!/if\(ambig\.length\) hh\+=warn/.test(html), 'single-colour no longer appends an ambiguous warning to a painted reply');
+  // the confirmation suppresses the planner say via meta.partial so "highlighted X" can't precede "which X?"
+  assert.match(html, /_hlAmbigConfirm\(ambig, clear\)\+cwarn, \{meta:\{partial:true\}\}/, 'confirmation flags partial to suppress the planner say');
+});
+
+test('R150 #8 satellite: flight-sim prefetches ahead of the aircraft + sat-labels host round-robin', () => {
+  assert.match(html, /window\._imPredictivePrefetch=predictivePrefetch/, 'directional prefetch exposed for the flight loop');
+  assert.match(html, /if\(now-\(st\._pfT\|\|0\)>380\)\{ st\._pfT=now; try\{ window\._imPredictivePrefetch/, 'flight loop warms tiles ~2.6x/s (moveend never fires mid-flight)');
+  // sat-labels reference source now round-robins BOTH Esri hosts (was one)
+  assert.match(html, /'sat-labels':\{type:'raster',tiles:\['https:\/\/server\.arcgisonline\.com[^']*','https:\/\/services\.arcgisonline\.com/, 'sat-labels uses two hosts');
+});
+
+test('R150 #1 Companies icon slot pixel-matches the Countries flag slot (30x30)', () => {
+  assert.match(html, /\.co-logo-box\{ display:inline-flex; align-items:center; justify-content:center; width:30px; height:30px;/, 'logo box is 30x30 like .stat-flag');
+});
+
+test('R150 #2 Atlas Street-View OFF reply offers the on/off toggle', () => {
+  assert.match(html, /Street View off','ストリートビューをオフ'[\s\S]{0,120}\)\)\+_featTogHtml\('streetview'\)\)/, 'the OFF reply carries the toggle to flip it back on');
+});
+
+test('R150 #9 Atlas model comment in index.html reflects Terra (not the reverted-Luna note)', () => {
+  assert.match(html, /gpt-5\.6-terra; #R150 Terra re-verified reachable/, 'legal/provider comment names Terra');
+  assert.ok(!/#R148 reverted from Terra/.test(html), 'the stale R148 revert note is gone');
+});

--- a/tests/r150.spec.js
+++ b/tests/r150.spec.js
@@ -1,0 +1,120 @@
+// R150 runtime regression tests — the work-order (#10) explicitly requires tests that VERIFY behavior,
+// not just string existence. These exercise the code-side research-mapping audit + typography + Köppen
+// stretch through the real page (IntMapAtlasDebug pure surface), fully hermetic (no network).
+//   #10 model omits the list → text extraction; partial placement + text↔pins mismatch → verdict buckets;
+//       same-name → ambiguous; one-domain sources → concentration; honest note rendering.
+//   #4  flat run-on prose is grouped into stanzas; structured text is left untouched.
+//   #3  Köppen legend can be dragged to the screen bottom (viewport-based ceiling).
+import { test, expect } from '@playwright/test';
+import { installHermeticRouting, collectPageDiagnostics } from './helpers/network.js';
+
+const CRITICAL = ['IntMapConsole', 'IntMapAtlasDebug'];
+test.describe.configure({ mode: 'serial' });
+
+let page, diag;
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext();
+  await installHermeticRouting(context);
+  page = await context.newPage();
+  diag = collectPageDiagnostics(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 45_000 });
+  await page.waitForFunction((g) => g.every((k) => typeof window[k] !== 'undefined'), CRITICAL, { timeout: 45_000 });
+  await page.waitForTimeout(600);
+});
+test.afterAll(async () => { await page?.context()?.close(); });
+
+test('#10 model OMITS the structured list — the major spots are still extracted from the answer text', async () => {
+  const r = await page.evaluate(() => {
+    const D = window.IntMapAtlasDebug;
+    const text = "Kyoto's Fushimi Inari Taisha, Kinkaku-ji and the Arashiyama Bamboo Grove are its icons. Nearby, Nijo Castle and Gion draw visitors.";
+    return { places: D.extractPlaces(text) };
+  });
+  // no PLACES list was provided; extraction is the safety net so nothing completes with 0 candidates
+  expect(r.places.length).toBeGreaterThanOrEqual(3);
+  expect(r.places.join(' | ')).toMatch(/Fushimi Inari|Kinkaku|Arashiyama|Nijo|Gion/);
+});
+
+test('#10 partial placement + text↔pins mismatch → mapped / unplaced / ambiguous, no false alarms', async () => {
+  const r = await page.evaluate(() => window.IntMapAtlasDebug.mappingVerdict([
+    { name: 'Rome', src: 'structured', verdict: 'mapped' },
+    { name: 'Colosseum', src: 'text', verdict: 'mapped' },
+    { name: 'Atlantis', src: 'structured', verdict: 'unplaced' },   // model claimed it → surfaced honestly
+    { name: 'Springfield', src: 'structured', verdict: 'ambiguous' }, // same-name → ambiguous, never guessed
+    { name: 'However', src: 'text', verdict: 'unplaced' },           // lone capitalized word → NOT surfaced
+  ]));
+  expect(r.mapped).toEqual(['Rome', 'Colosseum']);
+  expect(r.ambiguous).toEqual(['Springfield']);
+  expect(r.unplaced).toContain('Atlantis');
+  expect(r.unplaced).not.toContain('However');
+});
+
+test('#10 source concentration on ONE domain is detected; a diverse/official set is not', async () => {
+  const r = await page.evaluate(() => {
+    const D = window.IntMapAtlasDebug;
+    return {
+      one: D.auditSources([{ url: 'https://blog.example.com/a' }, { url: 'https://blog.example.com/b' }, { url: 'https://blog.example.com/c' }]),
+      mixed: D.auditSources([{ url: 'https://who.int/x' }, { url: 'https://reuters.com/y' }, { url: 'https://bbc.co.uk/z' }]),
+      dom: [D.regDomain('https://www.bbc.co.uk/n'), D.regDomain('https://mod.go.jp/e'), D.regDomain('https://cnn.com/a')],
+    };
+  });
+  expect(r.one.concentrated).toBe(true);      // one unofficial site → flag it
+  expect(r.one.official.length).toBe(0);
+  expect(r.mixed.concentrated).toBe(false);   // 3 independent domains → fine
+  expect(r.mixed.official).toContain('who.int');
+  expect(r.dom).toEqual(['bbc.co.uk', 'mod.go.jp', 'cnn.com']);
+});
+
+test('#10 the self-audit NOTE honestly lists mapped, ambiguous and unplaced spots + a one-domain caveat', async () => {
+  const r = await page.evaluate(() => {
+    const D = window.IntMapAtlasDebug;
+    return {
+      full: D.mappingNote({ mapped: ['Rome'], unplaced: ['Xanadu'], ambiguous: ['Springfield'] }, { concentrated: false, official: [], dominant: '' }, {}),
+      concentrated: D.mappingNote({ mapped: ['Rome'], unplaced: [], ambiguous: [] }, { concentrated: true, official: [], dominant: 'blog.example.com' }, {}),
+    };
+  });
+  expect(r.full).toMatch(/mapped|地図/i);
+  expect(r.full).toMatch(/Springfield/);   // ambiguous surfaced
+  expect(r.full).toMatch(/Xanadu/);        // unplaced surfaced (never guessed onto the map)
+  expect(r.concentrated).toMatch(/blog\.example\.com/);   // one-domain honesty
+});
+
+test('#4 typography: a flat run-on wall is grouped into stanzas; structured text is left untouched', async () => {
+  const r = await page.evaluate(() => {
+    const D = window.IntMapAtlasDebug;
+    const wall = 'Rome sits on the Tiber and has ruled empires for millennia. Its ancient core packs the Forum and the Palatine. The baroque city layered churches and fountains over that base. Modern Rome is a capital of nearly three million. Tourism and the Holy See anchor its economy. It rewards slow, unhurried wandering.';
+    const structured = '## Overview\nRome is old.\n\n- Forum\n- Palatine';
+    return {
+      wallParas: D.stanza(wall).split('\n\n').length,
+      structuredUnchanged: D.stanza(structured) === structured,
+      mdHasGap: D.mdMini(wall).includes('height:'),
+    };
+  });
+  expect(r.wallParas).toBeGreaterThanOrEqual(2);   // the monotone wall gets breathing room
+  expect(r.structuredUnchanged).toBe(true);        // never fights the model's own structure
+  expect(r.mdHasGap).toBe(true);                    // rendered HTML has paragraph gaps
+});
+
+test('#3 Köppen legend can be dragged to the screen bottom (viewport-based ceiling)', async () => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const r = await page.evaluate(() => {
+    let lg = document.getElementById('koppen-legend');
+    if (!lg) { lg = document.createElement('div'); lg.id = 'koppen-legend'; lg.className = 'koppen-legend'; document.body.appendChild(lg); }
+    lg.innerHTML = '<h4>K</h4><div class="kl-scroll"></div><div class="kl-hint">h</div>';
+    lg.style.display = 'flex'; lg.style.top = '74px'; lg.style.height = ''; lg.style.maxHeight = '';
+    const sc = lg.querySelector('.kl-scroll');
+    for (let i = 0; i < 30; i++) { const d = document.createElement('div'); d.className = 'kl-item'; d.innerHTML = '<span class="kl-sw"></span>Zone ' + i; sc.appendChild(d); }
+    window._fitKoppenLegend(lg);
+    lg.style.height = '4000px';   // simulate dragging the resize grip all the way down
+    const rect = lg.getBoundingClientRect();
+    const bottomGap = window.innerHeight - rect.bottom;
+    lg.remove();
+    return { bottomGap: Math.round(bottomGap) };
+  });
+  // the box now stops ~12px above the screen bottom — it reaches the bottom instead of clamping short (~595px content)
+  expect(r.bottomGap).toBeGreaterThanOrEqual(0);
+  expect(r.bottomGap).toBeLessThanOrEqual(26);
+});
+
+test('no uncaught page errors during R150 interactions', () => {
+  expect(diag.pageErrors, 'pageErrors: ' + JSON.stringify(diag.pageErrors)).toEqual([]);
+});


### PR DESCRIPTION
10 user-reported items fixed from root cause (several 3rd/4th-time re-reports whose prior fixes missed the real cause). All additive/in-place; single-file no-build preserved.

## Root causes
- **#6 Monitor "Could not save the monitor."** — `IntMapMonitors.create()` insert row **omitted `user_id`**, but the column is `not null` and the insert RLS is `with check (user_id = auth.uid())` → every UI insert failed. The feature had only ever been exercised via the service_role runner. Fix: set `row.user_id = currentUser.id` (like every other user-owned insert) + migration `20260721140000` adds a belt-and-suspenders DB `default auth.uid()` (applied to prod).
- **#3 Köppen legend "一番下まで伸ばせない"** — `_fitKoppenLegend` clamped `maxHeight` to **content height**, so `resize:vertical` could never reach the screen bottom. Now viewport-based (`innerHeight − top − 12`); the inner `.kl-scroll` is the safety net. Verified: on a 900px screen the box now stops at 888px (was ~200px short).
- **#7 Geo-target unification** — candidate-confirmation was appended as a warning **alongside** the painted success + not-found failures (both highlight paths). A shared `_hlAmbigConfirm` now **gates before painting** in both paths: any ambiguous target STOPS with one coherent confirmation (`meta.partial` suppresses the planner "highlighted X" say). No per-place hardcoding — driven by `resolveHlTarget`'s ambiguous verdict.
- **#10 Research-mapping code-side verification** — pure, testable helpers (`_atlExtractPlaces`, `_atlAuditSources`/`_atlRegDomain`/`_atlIsOfficial`, `_atlMappingVerdict`, `_atlGeocodeStrict`) exposed on `IntMapAtlasDebug`. The orchestrator now **merges** with existing pins (no skip-on-pins), extracts places from the final text as a safety net when the model omits the list, records failures (no empty catch), audits source-domain concentration, and **never guesses a coordinate**.
- **#9 Atlas model = GPT-5.6 Terra** — re-verified reachable via the `refresh-news` proxy (same key + `AI_MODEL`, no model fallback: `ai` 61/63 EN + 104/116 JP). `AI_MODEL=terra`, ai-proxy default terra + Luna fallback (deployed).
- **#8 Satellite (3D/flight)** — `predictivePrefetch` only fired on `moveend`, which never fires while the camera moves continuously in flight → imagery couldn't keep up. The flight loop now warms tiles ahead ~2.6×/s; `sat-labels` round-robins both Esri hosts.
- **#4 Typography** — `_atlStanza` groups a flat run-on wall into stanzas; a sentence-end + single newline becomes a soft paragraph gap (code-side, not prompt-only). **#5** stop square 17.5→15.5. **#1** `.co-logo-box` 32→30px (pixel-match the Countries flag slot — already isomorphic otherwise). **#2** Street-View OFF reply offers the toggle.

## Tests
- `tests/r150-checks.test.mjs` (node, 12) — source-level guarantees for all 10 items.
- `tests/r150.spec.js` (Playwright, 7) — **runtime** verification of the work-order cases: model omits list, partial placement, same-name ambiguity, one-domain sources, text↔pins mismatch, honest self-audit note, typography stanza, Köppen stretch.
- Updated `r147-checks` (Luna→Terra) and `r149-checks`/`r149.spec.js` (strings/behavior that R150 changed).
- Full suite green: static + node 68 + Playwright 74, 0 page errors.

## Deploy
- ai-proxy + refresh-news deployed; `AI_MODEL=gpt-5.6-terra` secret set; migration applied to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)