### PR TITLE
R151: UX/feature batch (11) — Köppen stop-at-content + stable rows, Measure/Share consolidation, SV coverage auto-show, monitor-delete highlight fix, Companies spark/history, Atlas SNS-source filter

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -5,7 +5,7 @@
 > 時系列の経緯・根本原因の記録は `DEV-NOTES.md`、標準指示（やってはいけないこと等）は `CONSTITUTION.md` を参照。
 > 実装を変えたら、この仕様書も更新すること。
 >
-> Last reviewed: 2026-07-21 (R149 — 画像ペースト入力（ビジョン）／調査回答の地点マッピング＋自己監査／モニタートースト真因／ケッペン凡例圧縮／Atlasタイポ・ボタン。DEV-NOTES R149 参照)
+> Last reviewed: 2026-07-21 (R151 — Companies空比較ヒント＋株価バッチ化(spark)＋全史キャッシュ／Atlasトグル拡充(globe・compare)／**ケッペンは全区分表示で停止＋行幅固定(scrollbar-gutter)**／通常モードMeasure・Share集約／Atlasタイポ(独立太字→見出し)／**モニター削除でハイライト消去**／衛星3D飛行プリフェッチ強化＋3D手動move先読み／**SVオンでcoverage自動**／**Atlas出典からSNS/短縮/動画除去**／Terra本番検証(analyzed_by=ai 354)。DEV-NOTES R151 参照)
 >
 > **R41 の要点**：`whenStyleReady()` が永久ハングし得た問題を修正（idle/loadのみ待機→ポーリング＋ハード解決）＋自己修復をハートビート化（「チェックしても出ない／消したのに残る・再読込で治る」の真因）。相関/散布図の残差マップを再実装（先にモーダルを閉じる＋RdBu連続配色＋指標33→51）。ウェブカムを**実装**（検証済みの24時間ライブYouTube配信25件をポップアップ内に埋め込み再生。検索リンクのハリボテを廃止）。**タイムゾーンレイヤー**新設（Natural Earth境界＋各ゾーンの現在時刻を毎分更新）。GIBSラスターに色スケール凡例。鉄道線を濃色＋白枕木で視認性向上。水域/地形ラベルを別チェック（`cb-geolabels`）化＋河川ラベルを `waterway` 由来に修正（位置ズレ解消）。天気ポップアップの華氏完全対応＋移動可能化。ウィジェット36→41。i18n：RUのレイヤーグループ見出し欠落＋国詳細(Stats)のES欠落を修正、非AIニュース地点辞書を多言語強化。
 
@@ -990,6 +990,21 @@ supabase/
 - **歴史Wiki拡充**: `_ERA_WIKI` に HRV(独立国1941-45)・SGP/BLZ/GUY/SUR/ZMB/MWI/BWA/LSO/SWZ/UGA の植民地期実記事（全て新規キー・ポップアップが存在プローブ）。実測: 1943 Zagreb→`Independent_State_of_Croatia`。
 
 ---
+
+## #R151 補足（UX/機能バッチ11件：ケッペン全区分停止＋行幅固定／Measure・Share集約／SV coverage自動／モニター削除でハイライト消去／Companies株価バッチ＋全史キャッシュ／Atlas出典SNS除去／Atlasトグル拡充／Terra本番検証）
+
+- **ケッペン凡例（#3・R150を上書き）**: `_fitKoppenLegend` を **`min(自然内容高, ビューポート上限)`** に（内容高は inline `height`/`max-height` を一時中和して `getBoundingClientRect` で実測→復元）。**内容<画面＝最終区分で停止**（空白ゼロ＝「すべて表示されたら止まる」）、**内容>画面＝画面下端で停止＋内側 `.kl-scroll`**。行幅固定＝`.kl-scroll{ scrollbar-gutter:stable }`（スクロールバー出没で~15px 揺れ→行 reflow が真因）。R150 の「ビューポート基準で必ず下端」は空白を生む＝要求転換で上書き。r149/r150 の #3 テストを二挙動（短vp下端／高vp内容停止）へ更新。
+- **通常モード Measure/Share 集約（#4）**: Radius を `#measure-dropdown` 内へ（Distance/area・Draw・Radius）。Screenshot＋リンクを新 `.share-menu-container`（🔗 Share ▾＝Screenshot・共有/リンク・`right:0`）へ。**ID温存**（`btn-tool-radius`/`btn-screenshot`/`btn-share`）で既存ハンドラ・モバイル `data-proxy` 不変。`shareMenuBtn`/`shareLinkBtn`/`coCompareEmpty` を5言語追加。
+- **SV coverage 自動（#8）**: `IntMapStreetView.open()` が coverage OFF 時に `coverage(true)`＋`_covAuto`（手動状態温存）、`close()`（✕も集約）で自動分のみ OFF。パノラマを開くと水色の実カバレッジ線が即表示。
+- **モニター削除でハイライト消去（#6）**: `showOnMap(area,points,monId)` に `_shownMonId` 記録（全呼出元に id）、`remove()` 成功時 `_shownMonId===id`（or 未追跡）で `clearMap()`。UI/Atlas 両経路が同一 `remove` を通る。
+- **Companies 深い歴史＋低遅延（#10）**: `_spark(syms,range,interval)` で Yahoo `v8/finance/spark` を~40銘柄バッチ（旧＝1銘柄1req）→ `loadPrices` 即着色＋未解決のみ従来チャートfallback。`_histAll()` が `spark range=max 1mo` を一度取得し `{tk:{year:年末終値}}` キャッシュ→ `setYear` 年スクラブをネット無し即時（未網羅のみ per-year fallback）・`priceSeries` も同キャッシュ。両response shape対応。
+- **Atlas出典の信頼性（#11）**: `_atlBadSourceHost`（`_SNS_RE`＝X/Twitter/FB/IG/Threads/TikTok/Reddit/YouTube/t.me/bit.ly…）で全出典カード経路（`linkCards`＝analyze/answer/mapReport）から SNS/UGC/短縮/動画を除外。`_analysisSystemPrompt` に「SNS等は出典にしない・各URLは主張を直接支持する具体ページのみ」明記。`IntMapAtlasDebug.badSourceHost/linkCards` 公開。
+- **Atlasトグル拡充（#2）**: 既存(layer/base/grid/3D/国情報/SV/borders/labels/roads/ticker)に **globe（地球儀 on/off）・compare** を `_FEAT_TOG` 追加＋projection/compare dispatch に `_featTogHtml`。
+- **タイポ（#5）**: mdMini で**行全体が `**太字**` の行を実見出し**へ（モデルは `##` より太字を多用＝モデル非依存の階層）＋段落余白 .72→.85em。answer/analysis プロンプトの FORMAT指示は既存。
+- **衛星（#7）**: `predictivePrefetch(aggressive)`＝飛行で RING 3→7・斜め角先読み・傾斜時は横一段浅も warm、飛行ループ 380→300ms＋aggressive。**3D手動 pan/rotate（pitch>25）でも `move` ごとにスロットル先読み**（従来 moveend のみ＝連続移動で先読み皆無）。既存最適化(2/5ホスト分散・native-max DEM z15・fade0・8192キャッシュ・pixelRatio上限)温存。
+- **Companies 空比較ヒント（#1）**: Countries同型は既存＋**空状態ヒント**「Tap company rows to select and compare.」（`coCompareEmpty` 5言語・`renderCoCompareFixed` が `scf-empty`）。
+- **Terra（#9）**: `AI_MODEL` secret＋`OPENAI_DEFAULT_MODEL=gpt-5.6-terra`（コメント整合・再deploy）・Luna は model_not_found のみ。**本番検証＝`current_news.analyzed_by='ai'` が 354 件**（refresh-news cron は fallback無でTerra直呼び＝ai>0 が到達の実証）。
+- テスト: `tests/r151-checks.test.mjs`(node 11) ＋ `tests/r151.spec.js`(Playwright 6)。r149/r150 のケッペン#3を R151 仕様へ、r149/r150-checks の exact-string を .85em/prefetch cadence へ更新。`npm test` 緑（node 79・Playwright 80・pageerror 0）。
 
 ## #R150 補足（UX/機能バッチ10件：モニター保存の真因user_id欠落／ケッペン下端伸縮／Atlas曖昧性ゲート統一／調査回答マッピングのコード側検証／Terra採用／衛星飛行プリフェッチ）
 

--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -5,6 +5,38 @@
 
 ---
 
+## R151 — UX/機能バッチ11件：Companies空比較ヒント／Atlasトグル拡充(globe/compare)／**ケッペンは全区分表示で停止＋行幅固定**／通常モードのMeasure/Share集約／Atlasタイポ(独立太字行→見出し)／**モニター削除でハイライト消去**／衛星3D飛行プリフェッチ強化／**SVオンでcoverage自動表示**／Terra本番検証(analyzed_by=ai 354)／**Companies株価バッチ化(spark)＋全史キャッシュ**／**Atlas出典からSNS/短縮/動画を除去** (tag `#R151`)
+
+ユーザー指摘**11件**を根本原因から修正。`index.html`＋Edge Function `ai-proxy`（コメントのみ→再deploy）＋新規テスト2本。`npm test` 緑（static＋node **79**＝security/monitor/r147/r149/r150/**新r151-checks 11**＋Playwright **80**＝新 `r151.spec.js` 6・r149/r150のケッペン#3をR151仕様へ更新、pageerror 0）。ローカル(Browserペイン 4188)で全区分停止・行幅固定・SV coverage自動・トグル・出典フィルタを実測。**Terra本番検証＝`current_news.analyzed_by='ai'` が 354 件**（cron refresh-newsはfallback無でTerra直呼び→ai>0＝Terra到達可を実証）。
+
+### ⑧ SVオン→coverage自動表示（新）
+`IntMapStreetView.open()` が coverage OFF 時に `coverage(true)`＋`_covAuto=true`（手動状態は温存）、`close()`（✕もここへ集約）で `_covAuto` 時のみ OFF に戻す。パノラマを開くと周辺の実カバレッジ（水色線）が即表示。
+
+### ⑥ モニター削除でハイライト残存（新バグ）
+真因＝`remove(id)` は DB delete のみで `im-mon-area` ソースを消していなかった。修正＝`showOnMap(area,points,monId)` に `_shownMonId` を記録（全呼出元に id 付与）、`remove()` 成功時 `_shownMonId===id`（or 未追跡）なら `clearMap()`。作成→削除で確実に消える。UI/Atlas 両経路が同一 `remove` を通る。
+
+### ③ ケッペン「全区分表示で停止」＋「行幅が動かない」（再報告・仕様転換）
+R150は**ビューポート基準**（内容が短くても画面下端まで伸びて空白）→今回ユーザーは「**すべて表示されたら止まる**」を要求＝R150を上書き。`_fitKoppenLegend` を **`min(自然内容高, ビューポート上限)`** に（内容高は inline height/max-height を一時中和して実測）。内容<画面＝最終区分で停止（空白ゼロ）、内容>画面＝画面下端で停止＋内側スクロール。**行幅固定**＝`.kl-scroll` に `scrollbar-gutter:stable`（スクロールバー出没で~15px 揺れて行が reflow していた）。r149/r150 の #3 テストは旧「必ず下端」仕様→**短vp=下端到達＋内側スクロール / 高vp=内容で停止**の二挙動へ更新。
+
+### ④ 通常モード Measure/Share 集約（新）
+Radius を Measure ドロップダウン内へ（Distance/area・Draw・Radius）。Screenshot＋リンクを新 `share-menu-container`（🔗 Share ▾ ＝ Screenshot・共有/リンク）へ。ID温存（`btn-tool-radius`/`btn-screenshot`/`btn-share`）で既存ハンドラ・モバイルproxy不変。CSS は measure ルールに share を相乗り（share は右寄せ `right:0`）。`shareMenuBtn`/`shareLinkBtn`/`coCompareEmpty` を5言語追加。
+
+### ⑩ Companies「もっと昔」＋「高精度・低遅延」（拡張）
+**低遅延**＝`_spark(syms,range,interval)` で Yahoo `v8/finance/spark` を~40銘柄バッチ（旧＝1銘柄1リクエスト）→ `loadPrices` は1バッチで即着色、未解決のみ従来チャートへフォールバック。**深い歴史**＝`_histAll()` が `spark range=max interval=1mo` を一度だけ取得し `{tk:{year:年末終値}}` にキャッシュ→ `setYear` は年スクラブを**ネット無しで即時**（未網羅のみ従来 per-year フォールバック）・`priceSeries` も同キャッシュ。両shape（`spark.result[].response[]`／旧 flat）に対応。全域 YMIN=1900 は既存。
+
+### ⑪ Atlas出典の信頼性（再報告）
+真因＝`linkCards` は Google News アグリゲータのみ除去で、SNS/UGC/短縮/動画は素通り。修正＝`_atlBadSourceHost`（X/Twitter/FB/IG/Threads/TikTok/Reddit/YouTube/t.me/bit.ly 等の `_SNS_RE`）で全出典カード経路（analyze/answer/mapReport）から除外。`_analysisSystemPrompt` に「SNS/フォーラム/短縮/動画は出典にしない・各URLは主張を直接支持する具体ページのみ」を明記。`IntMapAtlasDebug.badSourceHost/linkCards` 公開でhermetic検証。
+
+### ①②⑤⑦⑨ その他
+①Companies＝Countries同型は既存、**空状態ヒント**「Tap company rows to select and compare.」（`coCompareEmpty` 5言語・`renderCoCompareFixed` が `scf-empty` 表示）を追加。②Atlasトグルは layer/base/grid/3D/国情報/SV/borders/labels/roads/ticker に加え **globe（地球儀 on/off）・compare** を追加（projection/compare dispatch に `_featTogHtml`）。⑤タイポ＝mdMini で**行全体が `**太字**` の行を実見出し**へ（モデルは `##` より太字を多用＝モデル非依存の階層）＋段落余白 .72→.85em。⑦衛星＝`predictivePrefetch(aggressive)`（RING 3→7・斜め角先読み・傾斜時は横一段浅も warm）、飛行ループ 380→300ms＋aggressive、**3D手動 pan/rotate（pitch>25）でも `move` ごとにスロットル先読み**（従来 moveend のみ＝連続移動で先読み皆無）。⑨Terraは AI_MODEL secret＋`OPENAI_DEFAULT_MODEL=gpt-5.6-terra`（コメント整合）・Luna は model_not_found 時のみ。
+
+### 罠・教訓
+- **仕様が転換したら旧テストは更新する**＝ケッペンは R150「必ず下端」→ R151「全区分で停止」。テストは新仕様の二挙動（高vp/短vp）を両方assert。
+- **行幅の揺れ＝スクロールバー出没**＝`scrollbar-gutter:stable` で常時gutter予約。
+- **Terra本番検証は `current_news.analyzed_by='ai'` の実数**（refresh-news cron は fallback無＝ai>0 が Terra 到達の証拠）。secret値は読めない・REFRESH_SECRET は回さない（cron破壊）。
+- **外部API latencyはバッチ化**（Yahoo spark 多銘柄）＋**全史一括キャッシュ**で年スクラブをネット無し化。両方フォールバック温存。
+- r147/r149/r150-checks の exact-string assert は自変更で壊れる→**更新必須**（.72→.85em、prefetch cadence）。**PORT=4188 npx playwright**（常駐4173/8781回避）。
+
 ## R150 — UX/機能バッチ10件：モニター保存の真因(**client insertがuser_id欠落**)／ケッペン凡例を画面下端まで伸縮／Atlasタイポ(コード側で階層生成)／停止四角を微縮小／**GPT-5.6 Terra再検証→採用**／**Atlas地理対象の曖昧性ゲート統一**／**調査回答マッピングのコード側検証(業務委託)**／衛星3D飛行プリフェッチ／Companiesアイコン枠一致／SVオフにもトグル (tag `#R150`)
 
 ユーザー指摘**10件**を根本原因から修正。`index.html`＋Edge Function `ai-proxy`＋新規migration＋新規テスト2本。`npm test` 緑（static＋node **68**＝security/monitor/r147/r149/**新r150-checks 12**＋Playwright＝**新 r150.spec.js 7**、pageerror 0）。ローカル(Browserペイン 8781)で純関数・ケッペン下端伸縮・監査挙動を実測。Edge Fn(ai-proxy/refresh-news)本番deploy済み・prod migration適用済み。

--- a/index.html
+++ b/index.html
@@ -452,10 +452,11 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
     .compass-btn{ width:40px; padding:0 6px !important; height:33px; display:flex; align-items:center; justify-content:center; overflow:visible; } .compass-svg{ transition:transform 0.2s; display:block; }
     .layer-menu-container{ position:relative; }
     /* (#R9) Measurement tools collapsed under one "Measure ▾" trigger (Radius stays standalone). */
-    .measure-menu-container{ position:relative; display:inline-block; }
-    .measure-dropdown{ display:none; position:absolute; top:calc(100% + 6px); left:0; z-index:1300; background:var(--popup-bg); border:1px solid rgba(128,128,128,0.18); border-radius:12px; padding:6px; box-shadow:var(--shadow); backdrop-filter:blur(15px); min-width:182px; flex-direction:column; gap:4px; }
-    .measure-menu-container.open .measure-dropdown{ display:flex; }
-    .measure-dropdown .view-btn{ width:100%; text-align:left; justify-content:flex-start; margin:0; }
+    .measure-menu-container, .share-menu-container{ position:relative; display:inline-block; }   /* (#R151) share menu mirrors the measure menu */
+    .measure-dropdown, .share-dropdown{ display:none; position:absolute; top:calc(100% + 6px); left:0; z-index:1300; background:var(--popup-bg); border:1px solid rgba(128,128,128,0.18); border-radius:12px; padding:6px; box-shadow:var(--shadow); backdrop-filter:blur(15px); min-width:182px; flex-direction:column; gap:4px; }
+    .share-dropdown{ left:auto; right:0; }   /* (#R151) share sits near the right edge → anchor the dropdown right so it never overflows the viewport */
+    .measure-menu-container.open .measure-dropdown, .share-menu-container.open .share-dropdown{ display:flex; }
+    .measure-dropdown .view-btn, .share-dropdown .view-btn{ width:100%; text-align:left; justify-content:flex-start; margin:0; }
     .caret-sm{ font-size:9px; opacity:0.7; }
     /* (#R15d) Use the shared glass border so the Layers dropdown matches every other frosted surface. */
     /* (#R34) padding-bottom is 0 so the sticky Active-layers bar sits FLUSH with the dropdown's bottom edge.
@@ -2317,15 +2318,21 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
           <div class="measure-dropdown" id="measure-dropdown">
             <button class="view-btn" id="btn-tool-measure" data-i18n="measureDistBtn" title="Measure distance / area">📏 Distance / area</button>
             <button class="view-btn" id="btn-tool-draw" data-i18n="drawBtn" title="Freehand draw & trace">✏️ Draw</button>
+            <button class="view-btn" id="btn-tool-radius" data-i18n="radiusBtn" title="Radius">⭕ Radius</button><!-- (#R151) Radius folded INTO the Measure menu (Distance/area · Draw · Radius) per request -->
           </div>
         </div>
-        <button class="view-btn" id="btn-tool-radius" data-i18n="radiusBtn" title="Radius">⭕ Radius</button>
         <!-- (#R130) Objects manager moved OFF the bottom-left FAB (which read as "in the sidebar") INTO the top-right
              toolbar, next to Measure/Radius, per request. Shown only when >=1 map object exists (same visibility as
              the old FAB); wired + counted by IntMapObjects.tickFab. On mobile the toolbar is hidden, so the FAB stays. -->
         <button class="view-btn" id="btn-tool-objects" title="Objects" style="display:none;"><span data-i18n="objectsBtn">🗂 Objects</span><span id="tool-objects-n" style="margin-left:5px;font-weight:700;opacity:0.85;"></span></button>
-        <button class="view-btn" id="btn-screenshot" data-i18n-title="screenshotBtn" title="Screenshot">📷</button>
-        <button class="view-btn" id="btn-share" data-i18n-title="shareView" title="Share this view">🔗</button>
+        <!-- (#R151) Screenshot + link folded INTO one Share menu per request -->
+        <div class="share-menu-container">
+          <button class="view-btn" id="btn-share-menu" title="Share"><span aria-hidden="true">🔗</span> <span data-i18n="shareMenuBtn">Share</span> <span class="caret-sm">▾</span></button>
+          <div class="share-dropdown" id="share-dropdown">
+            <button class="view-btn" id="btn-screenshot" data-i18n-title="screenshotBtn" title="Screenshot">📷 <span data-i18n="mScreenshot">Screenshot</span></button>
+            <button class="view-btn" id="btn-share" data-i18n-title="shareView" title="Share this view">🔗 <span data-i18n="shareLinkBtn">Share / copy link</span></button>
+          </div>
+        </div>
         <!-- (#R114) top-bar Atlas launch button removed (requested). Atlas stays reachable via the left-sidebar
              Atlas tab (normal/mobile) and the Window menu (workspace mode); the #btn-atlas wiring below is guarded. -->
         <div class="layer-menu-container">
@@ -2781,12 +2788,12 @@ window.addEventListener('DOMContentLoaded', () => {
       statPop:"Population", statGdp:"GDP (nominal)", statGdpPc:"GDP per capita", statGdpPPP:"GDP (PPP)", statGdpPcPPP:"GDP per capita (PPP)", statArea:"Area", statDensity:"Pop. density", statRegion:"Region", statSub:"Subregion", statCapital:"Capital", statCurrency:"Currency", statLang:"Languages", statHDI:"HDI", statDem:"Democracy Idx", statMil:"Mil. spending", statLife:"Life expectancy", statInet:"Internet users",
       details:"Details ↗", loadingData:"Loading country data...", dataNA:"N/A", noData:"Country data unavailable.", sortGdp:"GDP", sortPop:"Pop", sortArea:"Area", sortName:"A–Z", sortHDI:"HDI", sortMil:"Mil$", elev:"Elev", bearing:"Bearing", presetNone:"— select —", presetLbl:"Range presets", opacity:"Opacity", circumference:"Circumference", lblUnits:"Measurement units", unitBoth:"Metric + Imperial", unitMetric:"Metric only", unitImperial:"Imperial only", msPh:"Search any place on Earth...",
       spRunway:"Runway", spGarrison:"Garrison", spOperator:"Operator", spEstd:"Established", spAircraft:"Aircraft", spType:"Type", spCapacity:"Capacity", spDepth:"Depth", spOutput:"Output", spReserves:"Reserves",
-      flat:"Flat", globe:"Globe", threeD:"⛰️ 3D", gridBtn:"🌐 Grid", gridLayer:"🌐 Grid & labels", widgetsBtn:"Widgets", lblTempUnit:"Temperature", tempBoth:"°C + °F", tempC:"°C only", tempF:"°F only", measureBtn:"📏 Measure", measureMenuBtn:"Measure", measureDistBtn:"📏 Distance / area", areaBtn:"📐 Area", drawBtn:"✏️ Draw", radiusBtn:"⭕ Radius", objectsBtn:"🗂 Objects", mScreenshot:"Screenshot", layersBtn:"Layers ▾",
+      flat:"Flat", globe:"Globe", threeD:"⛰️ 3D", gridBtn:"🌐 Grid", gridLayer:"🌐 Grid & labels", widgetsBtn:"Widgets", lblTempUnit:"Temperature", tempBoth:"°C + °F", tempC:"°C only", tempF:"°F only", measureBtn:"📏 Measure", measureMenuBtn:"Measure", measureDistBtn:"📏 Distance / area", areaBtn:"📐 Area", drawBtn:"✏️ Draw", radiusBtn:"⭕ Radius", objectsBtn:"🗂 Objects", mScreenshot:"Screenshot", shareMenuBtn:"Share", shareLinkBtn:"Share / copy link", layersBtn:"Layers ▾",
       ctxDropPin:"Drop pin here", ctxMeasureFrom:"Start measure from here", ctxPostHere:"Post here (community)", ctxDistFrom:"Distance from previous pin", ctxCopy:"Copy coordinates", ctxClearPins:"Remove all pins", ctxThisPoint:"This point", coords:"Coordinates", depth:"Depth", climate:"Climate", tlToday:"Today", tlTitle:"Time machine", tlMachine:"Time machine", tl10y:"−10y", tl5y:"−5y", tlNow:"Now",
       lblPinMode:"News pin position", pinModeLoc:"Subject location", pinModePub:"Publisher location",
       lyrEEZ:"Maritime EEZ / 12nm", lyrShips:"Live ship traffic", lyrPlanes:"Live aircraft traffic", lyrThermal:"Thermal anomalies (fires)", planesZoomHint:"🔍 Zoom in to load live aircraft", shipsZoomHint:"🔍 Zoom in to load live ships", aisNoKey:"Live ships need a free AISstream.io API key — add it in Settings.", aisKeyLabel:"Live ship traffic (AISstream key)", aisKeyHint:"Get a free key at aisstream.io and paste it here to see live ship traffic. Stored only in this browser.",
       filtCiv:"Civilian", filtMil:"Military", filtAll:"All", trafficFilter:"Filter", lyrTime:"Layer date", thermWin24:"Last 24 h", thermWin48:"Last 48 h", thermWin72:"Last 72 h",
-      tabCommunity:"Community", commAdd:"+ New post", commAddArmed:"Click on map to place pin", commTitle:"Title", commBody:"Share an observation, question, or theory...", commPost:"Post", commCancel:"Cancel", commEmpty:"No posts yet. Click \"+ New post\" to start the discussion.", commComment:"Comment", commLocate:"Show on map", commDelete:"Delete", commReply:"Reply", commWrite:"Write a comment...", commPostNew:"New post", commPlacedAt:"Placed at", commSortHot:"Hot", commSortNew:"New", commSortTop:"Top", commSearchPh:"Search posts…", commInView:"In view", commCat:"Category", commCatAll:"All", commEdit:"Edit", commEdited:"edited", commEditPost:"Edit post", commSaveEdit:"Save changes", commNoMatch:"No posts match your filters.", borders:"Country borders", compare:"Compare", compareEmpty:"Tap country rows to select and compare.", compareView:"Show comparison", compareClear:"Clear", back:"Back", deletePin:"Delete",
+      tabCommunity:"Community", commAdd:"+ New post", commAddArmed:"Click on map to place pin", commTitle:"Title", commBody:"Share an observation, question, or theory...", commPost:"Post", commCancel:"Cancel", commEmpty:"No posts yet. Click \"+ New post\" to start the discussion.", commComment:"Comment", commLocate:"Show on map", commDelete:"Delete", commReply:"Reply", commWrite:"Write a comment...", commPostNew:"New post", commPlacedAt:"Placed at", commSortHot:"Hot", commSortNew:"New", commSortTop:"Top", commSearchPh:"Search posts…", commInView:"In view", commCat:"Category", commCatAll:"All", commEdit:"Edit", commEdited:"edited", commEditPost:"Edit post", commSaveEdit:"Save changes", commNoMatch:"No posts match your filters.", borders:"Country borders", compare:"Compare", compareEmpty:"Tap country rows to select and compare.", coCompareEmpty:"Tap company rows to select and compare.", compareView:"Show comparison", compareClear:"Clear", back:"Back", deletePin:"Delete",
       satCtrlTitle:"Satellite imagery", satProvider:"Provider", satDate:"Capture date", satLatest:"Latest available", satMosaicSuffix:"cloudless mosaic", satLocked:"add API key", satPrevDay:"Previous day", satNextDay:"Next day", satKeysTitle:"Satellite imagery (BYOK)", satKeyHint:"Enter an API key to unlock these providers in the Satellite panel. Keys are stored only in this browser.", satKeyConnected:"Connected", satKeyNone:"No key", satErrAuth:"{provider}: authentication failed — check the API key", satErrTiles:"{provider}: imagery unavailable — switched to fallback",
       aiSecTitle:"AI features", aiSecHint:"Built-in AI — free for logged-in users (up to 10 uses per day). No API key needed.",
       aiProvider:"AI provider", aiModel:"Model", aiApiKey:"API key", aiKeyConnected:"Connected", aiKeyNone:"No key", aiGetKey:"Get a key ↗", aiOnDevice:"Runs on-device in Chrome — no API key needed.",
@@ -2814,12 +2821,12 @@ window.addEventListener('DOMContentLoaded', () => {
       statPop:"人口", statGdp:"GDP(名目)", statGdpPc:"一人当たりGDP", statGdpPPP:"GDP(購買力平価)", statGdpPcPPP:"一人当たりGDP(PPP)", statArea:"面積", statDensity:"人口密度", statRegion:"地域", statSub:"小地域", statCapital:"首都", statCurrency:"通貨", statLang:"言語", statHDI:"HDI", statDem:"民主主義指数", statMil:"軍事費", statLife:"平均寿命", statInet:"ネット利用率",
       details:"詳細 ↗", loadingData:"国データを読み込み中...", dataNA:"データなし", noData:"国データを取得できませんでした。", sortGdp:"GDP", sortPop:"人口", sortArea:"面積", sortName:"50音", sortHDI:"HDI", sortMil:"軍事費", elev:"標高", bearing:"方位角", presetNone:"— 選択 —", presetLbl:"射程プリセット", opacity:"透明度", circumference:"円周", lblUnits:"計測単位", unitBoth:"メートル＋ヤードポンド", unitMetric:"メートルのみ", unitImperial:"ヤードポンドのみ", msPh:"世界中の地名を検索...",
       spRunway:"滑走路長", spGarrison:"駐留兵力", spOperator:"運用", spEstd:"開設", spAircraft:"主要機種", spType:"分類", spCapacity:"容量", spDepth:"水深", spOutput:"出力", spReserves:"埋蔵量",
-      flat:"平面", globe:"地球儀", threeD:"⛰️ 3D", gridBtn:"🌐 グリッド", gridLayer:"🌐 グリッド・地名", widgetsBtn:"ウィジェット", lblTempUnit:"気温の単位", tempBoth:"°C + °F", tempC:"°Cのみ", tempF:"°Fのみ", measureBtn:"📏 計測", measureMenuBtn:"計測", measureDistBtn:"📏 距離・面積", areaBtn:"📐 面積", drawBtn:"✏️ 描画", radiusBtn:"⭕ 半径", objectsBtn:"🗂 オブジェクト", mScreenshot:"スクショ", layersBtn:"レイヤー ▾",
+      flat:"平面", globe:"地球儀", threeD:"⛰️ 3D", gridBtn:"🌐 グリッド", gridLayer:"🌐 グリッド・地名", widgetsBtn:"ウィジェット", lblTempUnit:"気温の単位", tempBoth:"°C + °F", tempC:"°Cのみ", tempF:"°Fのみ", measureBtn:"📏 計測", measureMenuBtn:"計測", measureDistBtn:"📏 距離・面積", areaBtn:"📐 面積", drawBtn:"✏️ 描画", radiusBtn:"⭕ 半径", objectsBtn:"🗂 オブジェクト", mScreenshot:"スクショ", shareMenuBtn:"共有", shareLinkBtn:"共有・リンク", layersBtn:"レイヤー ▾",
       ctxDropPin:"ここにピンを刺す", ctxMeasureFrom:"ここから計測を開始", ctxPostHere:"ここに投稿（コミュニティ）", ctxDistFrom:"直前ピンからの距離", ctxCopy:"座標をコピー", ctxClearPins:"全ピンを削除", ctxThisPoint:"この地点", coords:"座標", depth:"水深", climate:"気候区分", tlToday:"今日", tlTitle:"タイムマシン", tlMachine:"タイムマシン", tl10y:"10年前", tl5y:"5年前", tlNow:"現在",
       lblPinMode:"ニュースピン位置", pinModeLoc:"記事の場所", pinModePub:"発信地(報道機関本社)",
       lyrEEZ:"領海・EEZ", lyrShips:"船舶トラフィック(リアルタイム)", lyrPlanes:"航空トラフィック(リアルタイム)", lyrThermal:"熱異常(火災)", planesZoomHint:"🔍 ズームインで航空機を表示", shipsZoomHint:"🔍 ズームインで船舶を表示", aisNoKey:"船舶のリアルタイム表示には AISstream.io の無料APIキーが必要です。設定から登録してください。", aisKeyLabel:"船舶トラフィック (AISstreamキー)", aisKeyHint:"aisstream.io で無料キーを取得し貼り付けると船舶のリアルタイム表示が有効になります。キーはこのブラウザにのみ保存されます。",
       filtCiv:"民間", filtMil:"軍用", filtAll:"全て", trafficFilter:"絞り込み", lyrTime:"レイヤー日付", thermWin24:"過去24時間", thermWin48:"過去48時間", thermWin72:"過去72時間",
-      tabCommunity:"コミュニティ", commAdd:"+ 新規投稿", commAddArmed:"地図をクリックしてピンを刺してください", commTitle:"タイトル", commBody:"考察・発見・疑問を投稿してください...", commPost:"投稿", commCancel:"キャンセル", commEmpty:"投稿はまだありません。「+ 新規投稿」をタップして議論を始めましょう。", commComment:"コメント", commLocate:"地図で見る", commDelete:"削除", commReply:"返信", commWrite:"コメントを書く...", commPostNew:"新規投稿", commPlacedAt:"投稿位置", commSortHot:"話題", commSortNew:"新着", commSortTop:"人気", commSearchPh:"投稿を検索…", commInView:"表示範囲", commCat:"カテゴリ", commCatAll:"すべて", commEdit:"編集", commEdited:"編集済み", commEditPost:"投稿を編集", commSaveEdit:"変更を保存", commNoMatch:"条件に一致する投稿がありません。", borders:"国境線", compare:"比較", compareEmpty:"行をタップして国を選び比較", compareView:"比較を表示", compareClear:"クリア", back:"戻る", deletePin:"削除",
+      tabCommunity:"コミュニティ", commAdd:"+ 新規投稿", commAddArmed:"地図をクリックしてピンを刺してください", commTitle:"タイトル", commBody:"考察・発見・疑問を投稿してください...", commPost:"投稿", commCancel:"キャンセル", commEmpty:"投稿はまだありません。「+ 新規投稿」をタップして議論を始めましょう。", commComment:"コメント", commLocate:"地図で見る", commDelete:"削除", commReply:"返信", commWrite:"コメントを書く...", commPostNew:"新規投稿", commPlacedAt:"投稿位置", commSortHot:"話題", commSortNew:"新着", commSortTop:"人気", commSearchPh:"投稿を検索…", commInView:"表示範囲", commCat:"カテゴリ", commCatAll:"すべて", commEdit:"編集", commEdited:"編集済み", commEditPost:"投稿を編集", commSaveEdit:"変更を保存", commNoMatch:"条件に一致する投稿がありません。", borders:"国境線", compare:"比較", compareEmpty:"行をタップして国を選び比較", coCompareEmpty:"行をタップして会社を選び比較", compareView:"比較を表示", compareClear:"クリア", back:"戻る", deletePin:"削除",
       satCtrlTitle:"衛星画像", satProvider:"プロバイダ", satDate:"撮影日", satLatest:"最新（自動取得）", satMosaicSuffix:"雲なしモザイク", satLocked:"APIキーを登録", satPrevDay:"前日", satNextDay:"翌日", satKeysTitle:"衛星画像プロバイダ (BYOK)", satKeyHint:"APIキーを入力すると、Satelliteパネルで各プロバイダを選択できます。キーはこのブラウザにのみ保存されます。", satKeyConnected:"接続済み", satKeyNone:"未登録", satErrAuth:"{provider}: 認証に失敗しました — APIキーを確認してください", satErrTiles:"{provider}: 画像を取得できません — フォールバックに切替えました",
       aiSecTitle:"AI機能", aiSecHint:"内蔵AI — ログインすると無料でご利用いただけます（1日10回まで）。APIキーは不要です。",
       aiProvider:"AIプロバイダ", aiModel:"モデル", aiApiKey:"APIキー", aiKeyConnected:"接続済み", aiKeyNone:"未登録", aiGetKey:"キーを取得 ↗", aiOnDevice:"Chrome内で端末内実行されます（APIキー不要）。",
@@ -2855,7 +2862,7 @@ window.addEventListener('DOMContentLoaded', () => {
       aisKeyLabel:"Live-Schiffsverkehr (AISstream-Schlüssel)", aisKeyHint:"Holen Sie sich einen kostenlosen Schlüssel bei aisstream.io und fügen Sie ihn hier ein. Wird nur in diesem Browser gespeichert.",
       aiSecTitle:"KI-Funktionen", aiSecHint:"Integrierte KI — nach der Anmeldung kostenlos nutzbar (bis zu 10×/Tag). Kein API-Schlüssel erforderlich.",
       blueberryBtn:"Unterstützen", borders:"Ländergrenzen", countries:"Länder (Info)", placeNames:"Ortsnamen", geoLabels:"Gewässer- & Geländenamen", adminBounds:"Bundesland-/Provinzgrenzen", roadsLayer:"Straßen", railLayer:"Eisenbahnen", favLayers:"★ Favoriten",
-      measureMenuBtn:"Messen", measureDistBtn:"📏 Distanz / Fläche", drawBtn:"✏️ Zeichnen", radiusBtn:"⭕ Radius", objectsBtn:"🗂 Objekte", mScreenshot:"Screenshot", screenshotBtn:"📷 Screenshot", layersBtn:"Ebenen ▾", uploadGeoJSON:"GeoJSON hochladen",
+      measureMenuBtn:"Messen", measureDistBtn:"📏 Distanz / Fläche", drawBtn:"✏️ Zeichnen", radiusBtn:"⭕ Radius", objectsBtn:"🗂 Objekte", mScreenshot:"Screenshot", shareMenuBtn:"Teilen", shareLinkBtn:"Teilen / Link", screenshotBtn:"📷 Screenshot", layersBtn:"Ebenen ▾", uploadGeoJSON:"GeoJSON hochladen",
       lblDataSources:"Datenquellen", viewDataSources:"Datenquellen ansehen ↗", lblNewsCountries:"Nachrichten-Länder", newsCountriesHint:"Lassen Sie das Feld leer für weltweite Nachrichten.",
       lyrGrpGeo:"Strategische Geografie", lyrGrpStrat:"Strategische Netze", lyrGrpOthers:"Weitere (Beta)",
       filtCiv:"Zivil", filtMil:"Militär", filtAll:"Alle", thermWin24:"Letzte 24 Std", thermWin48:"Letzte 48 Std", thermWin72:"Letzte 72 Std",
@@ -2875,7 +2882,7 @@ window.addEventListener('DOMContentLoaded', () => {
       ctxDropPin:"Pin hier setzen", ctxMeasureFrom:"Messung hier beginnen", ctxPostHere:"Hier posten (Community)", ctxDistFrom:"Entfernung vom vorherigen Pin", ctxCopy:"Koordinaten kopieren", ctxClearPins:"Alle Pins entfernen", ctxThisPoint:"Dieser Punkt", coords:"Koordinaten", depth:"Tiefe", climate:"Klima",
       lyrEEZ:"Meeres-AWZ / 12 sm", lyrShips:"Live-Schiffsverkehr", lyrPlanes:"Live-Flugverkehr", lyrThermal:"Wärmeanomalien (Brände)", planesZoomHint:"🔍 Hineinzoomen, um Live-Flugzeuge zu laden", shipsZoomHint:"🔍 Hineinzoomen, um Live-Schiffe zu laden", aisNoKey:"Live-Schiffe benötigen einen kostenlosen AISstream.io-API-Schlüssel — in den Einstellungen hinzufügen.", trafficFilter:"Filter", lyrTime:"Ebenen-Datum",
       commAdd:"+ Neuer Beitrag", commAddArmed:"Auf die Karte klicken, um einen Pin zu setzen", commTitle:"Titel", commBody:"Teilen Sie eine Beobachtung, Frage oder Theorie...", commPost:"Posten", commCancel:"Abbrechen", commEmpty:"Noch keine Beiträge. Klicken Sie auf \"+ Neuer Beitrag\", um die Diskussion zu starten.", commComment:"Kommentar", commLocate:"Auf Karte zeigen", commDelete:"Löschen", commReply:"Antworten", commWrite:"Kommentar schreiben...", commPostNew:"Neuer Beitrag", commPlacedAt:"Platziert bei", commSortHot:"Angesagt", commSortNew:"Neu", commSortTop:"Top", commSearchPh:"Beiträge suchen…", commInView:"Im Sichtfeld", commCat:"Kategorie", commCatAll:"Alle", commEdit:"Bearbeiten", commEdited:"bearbeitet", commEditPost:"Beitrag bearbeiten", commSaveEdit:"Änderungen speichern", commNoMatch:"Keine Beiträge entsprechen Ihren Filtern.",
-      compare:"Vergleichen", compareEmpty:"Länderzeilen antippen zum Auswählen und Vergleichen.", compareView:"Vergleich anzeigen", compareClear:"Löschen", back:"Zurück", deletePin:"Löschen",
+      compare:"Vergleichen", compareEmpty:"Länderzeilen antippen zum Auswählen und Vergleichen.", coCompareEmpty:"Unternehmenszeilen antippen zum Auswählen und Vergleichen.", compareView:"Vergleich anzeigen", compareClear:"Löschen", back:"Zurück", deletePin:"Löschen",
       satCtrlTitle:"Satellitenbilder", satProvider:"Anbieter", satDate:"Aufnahmedatum", satLatest:"Neueste verfügbar", satMosaicSuffix:"wolkenloses Mosaik", satLocked:"API-Schlüssel hinzufügen", satPrevDay:"Vorheriger Tag", satNextDay:"Nächster Tag", satKeyConnected:"Verbunden", satKeyNone:"Kein Schlüssel", satErrAuth:"{provider}: Authentifizierung fehlgeschlagen — API-Schlüssel prüfen", satErrTiles:"{provider}: Bilder nicht verfügbar — auf Ersatz umgeschaltet",
       aiProvider:"KI-Anbieter", aiModel:"Modell", aiApiKey:"API-Schlüssel", aiKeyConnected:"Verbunden", aiKeyNone:"Kein Schlüssel", aiGetKey:"Schlüssel erhalten ↗", aiOnDevice:"Läuft lokal in Chrome — kein API-Schlüssel nötig.", aiTest:"Verbindung testen", aiTesting:"Test läuft…", aiTestOk:"Verbindung OK ✓", aiNoKey:"Fügen Sie zuerst einen KI-API-Schlüssel unter Einstellungen → KI-Funktionen hinzu.", aiNoVision:"Dieses Modell kann keine Bilder lesen. Wählen Sie GPT-4o, Claude 3.5 Sonnet oder Gemini 1.5 Pro.", aiChromeUnavail:"Die in Chrome integrierte KI ist hier nicht verfügbar. Verwenden Sie Chrome 127+ mit aktivierter On-Device-KI oder einen anderen Anbieter.", aiThinking:"KI analysiert…", aiError:"KI-Anfrage fehlgeschlagen", aiCopy:"Kopieren", aiCopied:"Kopiert ✓", aiClose:"Schließen", aiRetry:"Wiederholen",
       aiGeoBtn:"✨ Alle Nachrichten per KI verorten", aiGeoBtnSub:"✨ Thema per KI verorten", aiGeoBtnPub:"✨ Herausgeber per KI verorten", aiGeoBusy:"Verorten…", aiGeoNone:"Nichts zu verorten.", aiGeoDone:"{n} Meldungen verortet", aiGeoErr:"Geokodierung fehlgeschlagen", aiTransBusy:"Übersetzen…", aiTransDone:"{n} Titel übersetzt", aiTransNone:"Titel bereits in Ihrer Sprache.", aiTranslate:"Übersetzen", aiShowOriginal:"Original", aiTransNoText:"Kein Artikeltext zum Übersetzen — versuchen Sie die Web-Ansicht.",
@@ -2902,7 +2909,7 @@ window.addEventListener('DOMContentLoaded', () => {
       aisKeyLabel:"Морской трафик (ключ AISstream)", aisKeyHint:"Получите бесплатный ключ на aisstream.io и вставьте его сюда. Хранится только в этом браузере.",
       aiSecTitle:"ИИ-функции", aiSecHint:"Встроенный ИИ — бесплатно после входа (до 10 раз в день). Ключ API не нужен.",
       blueberryBtn:"Поддержать", borders:"Границы стран", countries:"Страны (инфо)", placeNames:"Названия мест", geoLabels:"Названия вод и рельефа", adminBounds:"Границы регионов", roadsLayer:"Дороги", railLayer:"Железные дороги", favLayers:"★ Избранное",
-      measureMenuBtn:"Измерить", measureDistBtn:"📏 Расстояние / площадь", drawBtn:"✏️ Рисовать", radiusBtn:"⭕ Радиус", objectsBtn:"🗂 Объекты", mScreenshot:"Снимок", screenshotBtn:"📷 Снимок экрана", layersBtn:"Слои ▾", uploadGeoJSON:"Загрузить GeoJSON",
+      measureMenuBtn:"Измерить", measureDistBtn:"📏 Расстояние / площадь", drawBtn:"✏️ Рисовать", radiusBtn:"⭕ Радиус", objectsBtn:"🗂 Объекты", mScreenshot:"Снимок", shareMenuBtn:"Поделиться", shareLinkBtn:"Поделиться / ссылка", screenshotBtn:"📷 Снимок экрана", layersBtn:"Слои ▾", uploadGeoJSON:"Загрузить GeoJSON",
       lblDataSources:"Источники данных", viewDataSources:"Показать источники данных ↗", lblNewsCountries:"Страны новостей", newsCountriesHint:"Оставьте пустым для новостей со всего мира.",
       lyrGrpGeo:"Стратегическая география", lyrGrpStrat:"Стратегические сети", lyrGrpOthers:"Прочее (бета)",
       filtCiv:"Гражданские", filtMil:"Военные", filtAll:"Все", thermWin24:"Последние 24 ч", thermWin48:"Последние 48 ч", thermWin72:"Последние 72 ч",
@@ -2922,7 +2929,7 @@ window.addEventListener('DOMContentLoaded', () => {
       ctxDropPin:"Поставить метку здесь", ctxMeasureFrom:"Начать измерение отсюда", ctxPostHere:"Опубликовать здесь (сообщество)", ctxDistFrom:"Расстояние от предыдущей метки", ctxCopy:"Скопировать координаты", ctxClearPins:"Удалить все метки", ctxThisPoint:"Эта точка", coords:"Координаты", depth:"Глубина", climate:"Климат",
       lyrEEZ:"Морская ИЭЗ / 12 миль", lyrShips:"Суда в реальном времени", lyrPlanes:"Самолёты в реальном времени", lyrThermal:"Тепловые аномалии (пожары)", planesZoomHint:"🔍 Приблизьте, чтобы загрузить самолёты", shipsZoomHint:"🔍 Приблизьте, чтобы загрузить суда", aisNoKey:"Для судов нужен бесплатный ключ API AISstream.io — добавьте его в Настройках.", trafficFilter:"Фильтр", lyrTime:"Дата слоя",
       commAdd:"+ Новый пост", commAddArmed:"Нажмите на карту, чтобы поставить метку", commTitle:"Заголовок", commBody:"Поделитесь наблюдением, вопросом или теорией...", commPost:"Опубликовать", commCancel:"Отмена", commEmpty:"Пока нет постов. Нажмите \"+ Новый пост\", чтобы начать обсуждение.", commComment:"Комментировать", commLocate:"Показать на карте", commDelete:"Удалить", commReply:"Ответить", commWrite:"Написать комментарий...", commPostNew:"Новый пост", commPlacedAt:"Размещено в", commSortHot:"Популярное", commSortNew:"Новое", commSortTop:"Лучшее", commSearchPh:"Поиск постов…", commInView:"В поле зрения", commCat:"Категория", commCatAll:"Все", commEdit:"Изменить", commEdited:"изменено", commEditPost:"Редактировать пост", commSaveEdit:"Сохранить изменения", commNoMatch:"Нет постов по вашим фильтрам.",
-      compare:"Сравнить", compareEmpty:"Нажимайте на строки стран, чтобы выбрать и сравнить.", compareView:"Показать сравнение", compareClear:"Очистить", back:"Назад", deletePin:"Удалить",
+      compare:"Сравнить", compareEmpty:"Нажимайте на строки стран, чтобы выбрать и сравнить.", coCompareEmpty:"Нажимайте на строки компаний, чтобы выбрать и сравнить.", compareView:"Показать сравнение", compareClear:"Очистить", back:"Назад", deletePin:"Удалить",
       satCtrlTitle:"Спутниковые снимки", satProvider:"Провайдер", satDate:"Дата съёмки", satLatest:"Самые свежие", satMosaicSuffix:"безоблачная мозаика", satLocked:"добавьте ключ API", satPrevDay:"Предыдущий день", satNextDay:"Следующий день", satKeyConnected:"Подключено", satKeyNone:"Нет ключа", satErrAuth:"{provider}: ошибка аутентификации — проверьте ключ API", satErrTiles:"{provider}: снимки недоступны — переключено на резерв",
       aiProvider:"Провайдер ИИ", aiModel:"Модель", aiApiKey:"Ключ API", aiKeyConnected:"Подключено", aiKeyNone:"Нет ключа", aiGetKey:"Получить ключ ↗", aiOnDevice:"Работает локально в Chrome — ключ API не нужен.", aiTest:"Проверить подключение", aiTesting:"Проверка…", aiTestOk:"Подключение в порядке ✓", aiNoKey:"Сначала добавьте ключ API ИИ в Настройки → Функции ИИ.", aiNoVision:"Эта модель не читает изображения. Выберите GPT-4o, Claude 3.5 Sonnet или Gemini 1.5 Pro.", aiChromeUnavail:"Встроенный ИИ Chrome здесь недоступен. Используйте Chrome 127+ с включённым ИИ на устройстве или выберите другого провайдера.", aiThinking:"ИИ анализирует…", aiError:"Сбой запроса к ИИ", aiCopy:"Копировать", aiCopied:"Скопировано ✓", aiClose:"Закрыть", aiRetry:"Повторить",
       aiGeoBtn:"✨ Определить места всех новостей (ИИ)", aiGeoBtnSub:"✨ Определить место события (ИИ)", aiGeoBtnPub:"✨ Определить место издателя (ИИ)", aiGeoBusy:"Определение…", aiGeoNone:"Нечего определять.", aiGeoDone:"Определено новостей: {n}", aiGeoErr:"Ошибка геокодирования", aiTransBusy:"Перевод…", aiTransDone:"Переведено заголовков: {n}", aiTransNone:"Заголовки уже на вашем языке.", aiTranslate:"Перевести", aiShowOriginal:"Оригинал", aiTransNoText:"Нет текста статьи для перевода — попробуйте веб-вид.",
@@ -2950,7 +2957,7 @@ window.addEventListener('DOMContentLoaded', () => {
       aisKeyLabel:"Tráfico marítimo en vivo (clave AISstream)", aisKeyHint:"Obtén una clave gratuita en aisstream.io y pégala aquí. Se guarda solo en este navegador.",
       aiSecTitle:"Funciones de IA", aiSecHint:"IA integrada — gratis al iniciar sesión (hasta 10 usos al día). No se necesita clave API.",
       blueberryBtn:"Apoyar", borders:"Fronteras de países", countries:"Países (info)", placeNames:"Nombres de lugares", geoLabels:"Etiquetas de agua y relieve", adminBounds:"Fronteras de estados/provincias", roadsLayer:"Carreteras", railLayer:"Ferrocarriles", favLayers:"★ Favoritos",
-      measureMenuBtn:"Medir", measureDistBtn:"📏 Distancia / área", drawBtn:"✏️ Dibujar", radiusBtn:"⭕ Radio", objectsBtn:"🗂 Objetos", mScreenshot:"Captura", screenshotBtn:"📷 Captura de pantalla", layersBtn:"Capas ▾", uploadGeoJSON:"Subir GeoJSON",
+      measureMenuBtn:"Medir", measureDistBtn:"📏 Distancia / área", drawBtn:"✏️ Dibujar", radiusBtn:"⭕ Radio", objectsBtn:"🗂 Objetos", mScreenshot:"Captura", shareMenuBtn:"Compartir", shareLinkBtn:"Compartir / enlace", screenshotBtn:"📷 Captura de pantalla", layersBtn:"Capas ▾", uploadGeoJSON:"Subir GeoJSON",
       lblDataSources:"Fuentes de datos", viewDataSources:"Ver fuentes de datos ↗", lblNewsCountries:"Países de noticias", newsCountriesHint:"Déjalo vacío para noticias de todo el mundo.",
       lyrGrpGeo:"Geografía estratégica", lyrGrpStrat:"Redes estratégicas", lyrGrpOthers:"Otras (beta)",
       filtCiv:"Civil", filtMil:"Militar", filtAll:"Todos", thermWin24:"Últimas 24 h", thermWin48:"Últimas 48 h", thermWin72:"Últimas 72 h",
@@ -2969,7 +2976,7 @@ window.addEventListener('DOMContentLoaded', () => {
       ctxDropPin:"Poner marcador aquí", ctxMeasureFrom:"Empezar a medir desde aquí", ctxPostHere:"Publicar aquí (comunidad)", ctxDistFrom:"Distancia desde el marcador anterior", ctxCopy:"Copiar coordenadas", ctxClearPins:"Quitar todos los marcadores", ctxThisPoint:"Este punto", coords:"Coordenadas", depth:"Profundidad", climate:"Clima",
       lyrEEZ:"ZEE marítima / 12 mn", lyrShips:"Tráfico marítimo en vivo", lyrPlanes:"Tráfico aéreo en vivo", lyrThermal:"Anomalías térmicas (incendios)", planesZoomHint:"🔍 Acerca para cargar aviones en vivo", shipsZoomHint:"🔍 Acerca para cargar barcos en vivo", aisNoKey:"Los barcos en vivo necesitan una clave API gratuita de AISstream.io — añádela en Ajustes.", trafficFilter:"Filtro", lyrTime:"Fecha de la capa",
       commAdd:"+ Nueva publicación", commAddArmed:"Haz clic en el mapa para poner un marcador", commTitle:"Título", commBody:"Comparte una observación, pregunta o teoría...", commPost:"Publicar", commCancel:"Cancelar", commEmpty:"Aún no hay publicaciones. Haz clic en \"+ Nueva publicación\" para empezar.", commComment:"Comentar", commLocate:"Mostrar en el mapa", commDelete:"Eliminar", commReply:"Responder", commWrite:"Escribe un comentario...", commPostNew:"Nueva publicación", commPlacedAt:"Colocado en", commSortHot:"Popular", commSortNew:"Nuevo", commSortTop:"Top", commSearchPh:"Buscar publicaciones…", commInView:"En vista", commCat:"Categoría", commCatAll:"Todas", commEdit:"Editar", commEdited:"editado", commEditPost:"Editar publicación", commSaveEdit:"Guardar cambios", commNoMatch:"Ninguna publicación coincide con tus filtros.",
-      compare:"Comparar", compareEmpty:"Toca filas de países para elegir y comparar.", compareView:"Mostrar comparación", compareClear:"Borrar", back:"Atrás", deletePin:"Eliminar",
+      compare:"Comparar", compareEmpty:"Toca filas de países para elegir y comparar.", coCompareEmpty:"Toca filas de empresas para elegir y comparar.", compareView:"Mostrar comparación", compareClear:"Borrar", back:"Atrás", deletePin:"Eliminar",
       satCtrlTitle:"Imágenes de satélite", satProvider:"Proveedor", satDate:"Fecha de captura", satLatest:"Más reciente disponible", satMosaicSuffix:"mosaico sin nubes", satLocked:"añadir clave API", satPrevDay:"Día anterior", satNextDay:"Día siguiente", satKeyConnected:"Conectado", satKeyNone:"Sin clave", satErrAuth:"{provider}: fallo de autenticación — comprueba la clave API", satErrTiles:"{provider}: imágenes no disponibles — se cambió a reserva",
       aiProvider:"Proveedor de IA", aiModel:"Modelo", aiApiKey:"Clave API", aiKeyConnected:"Conectado", aiKeyNone:"Sin clave", aiGetKey:"Obtener una clave ↗", aiOnDevice:"Se ejecuta localmente en Chrome — sin clave API.", aiTest:"Probar conexión", aiTesting:"Probando…", aiTestOk:"Conexión correcta ✓", aiNoKey:"Primero añade una clave API de IA en Ajustes → Funciones de IA.", aiNoVision:"Este modelo no puede leer imágenes. Elige GPT-4o, Claude 3.5 Sonnet o Gemini 1.5 Pro.", aiChromeUnavail:"La IA integrada de Chrome no está disponible aquí. Usa Chrome 127+ con la IA en el dispositivo activada, o elige otro proveedor.", aiThinking:"La IA está analizando…", aiError:"Falló la solicitud de IA", aiCopy:"Copiar", aiCopied:"Copiado ✓", aiClose:"Cerrar", aiRetry:"Reintentar",
       aiGeoBtn:"✨ Localizar todas las noticias (IA)", aiGeoBtnSub:"✨ Localizar el tema (IA)", aiGeoBtnPub:"✨ Localizar el medio (IA)", aiGeoBusy:"Localizando…", aiGeoNone:"Nada que localizar.", aiGeoDone:"{n} noticias localizadas", aiGeoErr:"Falló la geocodificación", aiTransBusy:"Traduciendo…", aiTransDone:"{n} títulos traducidos", aiTransNone:"Los títulos ya están en tu idioma.", aiTranslate:"Traducir", aiShowOriginal:"Original", aiTransNoText:"No hay texto de artículo para traducir — prueba la vista web.",
@@ -4424,7 +4431,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const _lat2y=(lat,z)=>{ const r=lat*Math.PI/180; return Math.floor((1-Math.log(Math.tan(r)+1/Math.cos(r))/Math.PI)/2*Math.pow(2,z)); };
   const _tileUrl=(tpl,z,x,y)=>tpl.replace('{z}',z).replace('{x}',x).replace('{y}',y);
   let _prevCenter=null, _prefetchT=null;
-  function predictivePrefetch(){
+  function predictivePrefetch(aggressive){
     if(!map || currentMapType!=='sat') return;                          /* satellite = the heavy high-res case the user asked about */
     const p=satProviderById(satState.providerId); if(!p) return;
     let tiles; try{ tiles=satBuildTiles(p); }catch(_){ return; }
@@ -4435,21 +4442,34 @@ window.addEventListener('DOMContentLoaded', () => {
     if(x1<x0){[x0,x1]=[x1,x0];} if(y1<y0){[y0,y1]=[y1,y0];}
     let dx=0,dy=0; if(_prevCenter){ dx=Math.sign(c.lng-_prevCenter.lng); dy=Math.sign(_prevCenter.lat-c.lat); } /* moving north → smaller tile y */
     _prevCenter={lng:c.lng,lat:c.lat};
-    const urls=[], RING=3, push=(x,y)=>{ if(x>=0&&y>=0&&x<n&&y<n) urls.push(_tileUrl(tpl,z,x,y)); };
-    if(dx>0) for(let k=1;k<=RING;k++) for(let y=y0;y<=y1;y++) push(x1+k,y);
-    else if(dx<0) for(let k=1;k<=RING;k++) for(let y=y0;y<=y1;y++) push(x0-k,y);
-    if(dy>0) for(let k=1;k<=RING;k++) for(let x=x0;x<=x1;x++) push(x,y1+k);
-    else if(dy<0) for(let k=1;k<=RING;k++) for(let x=x0;x<=x1;x++) push(x,y0-k);
+    /* (#R151) FLIGHT LEAD: in the sim the camera moves continuously and fast, so a 3-tile lead can't keep the imagery
+       ahead of the aircraft ("3D衛星画像の生成が飛行に追い付いていない"). When called aggressively (flight loop), warm a
+       DEEPER ring in the direction of travel AND, if the map is tilted (3D/oblique), one zoom level SHALLOWER too so the
+       far horizon tiles the oblique view pulls in are resident before they scroll into frame. */
+    const RING=aggressive?7:3, push=(x,y)=>{ if(x>=0&&y>=0&&x<n&&y<n) urls.push(_tileUrl(tpl,z,x,y)); };
+    const urls=[];
+    const _side=(k)=>{ if(dx>0) for(let y=y0-1;y<=y1+1;y++) push(x1+k,y); else if(dx<0) for(let y=y0-1;y<=y1+1;y++) push(x0-k,y);
+      if(dy>0) for(let x=x0-1;x<=x1+1;x++) push(x,y1+k); else if(dy<0) for(let x=x0-1;x<=x1+1;x++) push(x,y0-k); };
+    for(let k=1;k<=RING;k++) _side(k);
+    if(aggressive && dx&&dy){ for(let k=1;k<=RING;k++){ push((dx>0?x1:x0)+dx*k,(dy>0?y1:y0)+ (dy>0?1:-1)*k); } }   /* diagonal corner ahead for a banking turn */
     /* (#R8) Anticipate a zoom-IN: warm the center tiles one AND two levels deeper so the next pinch is
        already resident (the user asked for "Unthinkable Speed" satellite). */
     for(let dz=1;dz<=2;dz++){ const z2=z+dz; if(z2>(p.maxzoom||19)) break; const n2=Math.pow(2,z2),cx=_lng2x(c.lng,z2),cy=_lat2y(c.lat,z2),rr=dz===1?1:0; for(let ix=-rr;ix<=rr;ix++) for(let iy=-rr;iy<=rr;iy++){ const x=cx+ix,y=cy+iy; if(x>=0&&y>=0&&x<n2&&y<n2) urls.push(_tileUrl(tpl,z2,x,y)); } }
+    /* (#R151) tilted view → the horizon draws from a shallower zoom; warm a small block one level up in the travel dir. */
+    if(aggressive){ try{ if((map.getPitch()||0)>25){ const zc=Math.max(0,z-1), nc=Math.pow(2,zc), cx=_lng2x(c.lng,zc)+ (dx||0)*2, cy=_lat2y(c.lat,zc)+ ( -(dy||0))*2; for(let ix=-2;ix<=2;ix++) for(let iy=-2;iy<=2;iy++){ const x=cx+ix,y=cy+iy; if(x>=0&&y>=0&&x<nc&&y<nc) urls.push(_tileUrl(tpl,zc,x,y)); } } }catch(_){} }
     if(!urls.length) return;
-    const uniq=[...new Set(urls)].slice(0,(typeof isMobile==='function'&&isMobile())?60:150);   /* (#R21) spend more of the measured idle bandwidth on desktop */
+    const _mob=(typeof isMobile==='function'&&isMobile());
+    const uniq=[...new Set(urls)].slice(0, aggressive?(_mob?110:280):(_mob?60:150));   /* (#R21/#R151) flight spends more of the idle bandwidth to stay ahead */
     if(_tileSW){ try{ _tileSW.postMessage({type:'prefetch',urls:uniq}); return; }catch(_){} }
     uniq.forEach(u=>{ try{ fetch(u,{mode:'cors',cache:'force-cache'}).catch(()=>{}); }catch(_){} });
   }
   registerTileSW();
   if(map) map.on('moveend',()=>{ clearTimeout(_prefetchT); _prefetchT=setTimeout(predictivePrefetch,90); });
+  /* (#R151) 3D is "dramatically heavier the moment you enable it" because a tilted/oblique view pulls in far more
+     tiles AND `moveend` never fires during a continuous drag-rotate/pitch — so satellite imagery streamed in behind
+     the gesture. Warm tiles ahead on every `move` while tilted (pitch>25°) in satellite mode, throttled to ~3×/s. */
+  let _movePfT=0;
+  if(map) map.on('move',()=>{ try{ if(currentMapType!=='sat') return; const now=Date.now(); if((map.getPitch()||0)>25 && now-_movePfT>320){ _movePfT=now; predictivePrefetch(true); } }catch(_){} });
   /* (#R150) expose the directional prefetch so the flight simulator can warm satellite tiles AHEAD of the aircraft
      every few hundred ms — during flight the camera moves CONTINUOUSLY so `moveend` never fires and the imagery
      couldn't keep up ("3D衛星画像の生成が飛行に追い付いていない"). The flight loop throttles the calls. */
@@ -6206,7 +6226,7 @@ window.addEventListener('DOMContentLoaded', () => {
   function _syncToolBtns(){
     ['measure','radius'].forEach(m=>{ const b=document.getElementById('btn-tool-'+m); if(b) b.classList.toggle('tool-on', toolMode===m); });
     const trig=document.getElementById('btn-measure-menu');
-    if(trig) trig.classList.toggle('tool-on', toolMode==='measure'||toolMode==='area'||!!(window.DrawTool&&window.DrawTool.active&&window.DrawTool.active()));
+    if(trig) trig.classList.toggle('tool-on', toolMode==='measure'||toolMode==='area'||toolMode==='radius'||!!(window.DrawTool&&window.DrawTool.active&&window.DrawTool.active()));   /* (#R151) Radius now lives in the Measure menu → its trigger reflects an active radius too */
     try{ window._mAddPointUpdate&&window._mAddPointUpdate(); }catch(_){}   /* show/hide the mobile "+Add point" button with the tool state (#R13) */
   }
   window._syncToolBtns=_syncToolBtns;
@@ -6996,7 +7016,7 @@ window.addEventListener('DOMContentLoaded', () => {
   document.getElementById('btn-tool-grid').onclick=toggleGrid;
   { const _gcb=document.getElementById('cb-grid'); if(_gcb) _gcb.onchange=(e)=>setGrid(e.target.checked); }   /* (#R10/#R38) Grid in Layers — drive state FROM the box (idempotent) so a re-asserted change can't re-enable it */
   document.getElementById('btn-tool-measure').onclick=()=>{ setTool('measure'); if(window._closeMeasureMenu)window._closeMeasureMenu(); };
-  document.getElementById('btn-tool-radius').onclick=()=>setTool('radius');
+  document.getElementById('btn-tool-radius').onclick=()=>{ setTool('radius'); if(window._closeMeasureMenu) window._closeMeasureMenu(); };   /* (#R151) Radius is a Measure-menu item → close the menu after picking it */
   /* (#R9) "Measure ▾" groups Measure + Draw under one trigger; click-away closes it. */
   (function(){
     const c=document.querySelector('.measure-menu-container'), trig=document.getElementById('btn-measure-menu');
@@ -7004,6 +7024,15 @@ window.addEventListener('DOMContentLoaded', () => {
     if(trig){ trig.onclick=(e)=>{ e.stopPropagation(); if(c) c.classList.toggle('open'); }; }
     document.addEventListener('click',(e)=>{ if(c && !c.contains(e.target)) c.classList.remove('open'); });
     const dr=document.getElementById('btn-tool-draw'); if(dr) dr.addEventListener('click',()=>window._closeMeasureMenu&&window._closeMeasureMenu());
+  })();
+  /* (#R151) "Share ▾" groups Screenshot + link/share under one trigger (mirrors the Measure menu); click-away + item-click close it.
+     The item buttons keep their original ids (#btn-screenshot / #btn-share) so their existing handlers are unchanged. */
+  (function(){
+    const c=document.querySelector('.share-menu-container'), trig=document.getElementById('btn-share-menu');
+    window._closeShareMenu=()=>{ if(c) c.classList.remove('open'); };
+    if(trig){ trig.onclick=(e)=>{ e.stopPropagation(); if(c) c.classList.toggle('open'); }; }
+    document.addEventListener('click',(e)=>{ if(c && !c.contains(e.target)) c.classList.remove('open'); });
+    ['btn-screenshot','btn-share'].forEach(id=>{ const b=document.getElementById(id); if(b) b.addEventListener('click',()=>window._closeShareMenu&&window._closeShareMenu()); });
   })();
   function updateCompass(){ const s=document.querySelector('.compass-svg'); if(s&&map)s.style.transform=`rotate(${-map.getBearing()}deg)`; }
   document.getElementById('btn-compass').onclick=()=>map&&map.easeTo({bearing:0,pitch:0,duration:500});
@@ -10518,6 +10547,31 @@ window.addEventListener('DOMContentLoaded', () => {
     const DATA=RAW.map(r=>({tk:r[0],n:r[1],nJp:r[2]||'',cc:r[3],sec:r[4],dom:r[5],fnd:r[6],emp:r[7],rev:r[8],ni:r[9],sh:r[10]||0,mcapSnap:r[11],price:0}));
     const PROX=[x=>x, x=>'https://corsproxy.io/?url='+encodeURIComponent(x), x=>'https://api.allorigins.win/raw?url='+encodeURIComponent(x)];
     async function _fjson(u){ for(const p of PROX){ try{ const r=await fetch(p(u)); if(r&&r.ok) return await r.json(); }catch(_){} } return null; }
+    /* (#R151) BATCHED multi-symbol quote via Yahoo's keyless "spark" endpoint — ONE request for up to ~40 tickers instead
+       of one-per-name, so live prices paint far faster (低遅延) and time-machine year-scrubbing no longer refetches ~150
+       symbols per year. Robust to both spark response shapes (nested spark.result[].response[] and the older flat
+       {TK:{timestamp,close,...}} form). Returns Map<tk,{ts:number[],close:number[],price:number}>. */
+    async function _spark(syms, range, interval){ const out=new Map(); const B=40;
+      for(let i=0;i<syms.length;i+=B){ const batch=syms.slice(i,i+B);
+        const u='https://query1.finance.yahoo.com/v8/finance/spark?symbols='+batch.map(encodeURIComponent).join(',')+'&range='+range+'&interval='+interval;
+        let j=null; try{ j=await _fjson(u); }catch(_){} if(!j) continue;
+        const res=(j.spark&&Array.isArray(j.spark.result))?j.spark.result:null;
+        if(res){ res.forEach(r=>{ try{ const tk=r.symbol, rp=r.response&&r.response[0]; if(!tk||!rp) return;
+              const ts=rp.timestamp||[], cl=(rp.indicators&&rp.indicators.quote&&rp.indicators.quote[0]&&rp.indicators.quote[0].close)||[];
+              out.set(tk,{ts,close:cl,price:(rp.meta&&+rp.meta.regularMarketPrice)||0}); }catch(_){} }); }
+        else { batch.forEach(tk=>{ try{ const r=j[tk]; if(!r) return; out.set(tk,{ts:r.timestamp||[],close:r.close||[],price:+(r.regularMarketPrice||r.chartPreviousClose||r.previousClose||0)||0}); }catch(_){} }); }
+      }
+      return out; }
+    /* (#R151) FULL monthly price history for every live name, fetched ONCE (batched spark, range=max) and cached as
+       {tk:{year:yearEndClose}} — the time-machine then reads any past year from this INSTANTLY (もっと昔も見れる) with no
+       per-year network. Built lazily on the first time-travel / time-series request; guarded so a failure just falls back. */
+    let _HALL=null, _HALLp=null;
+    function _histAll(){ if(_HALL) return Promise.resolve(_HALL); if(_HALLp) return _HALLp;
+      const syms=DATA.filter(c=>c.sh>0).map(c=>c.tk);
+      _HALLp=(async()=>{ const map={}; try{ const sp=await _spark(syms,'max','1mo');
+          sp.forEach((v,tk)=>{ const by={}, ts=v.ts||[], cl=v.close||[]; for(let i=0;i<ts.length;i++){ const cv=+cl[i]; if(cv>0) by[new Date(ts[i]*1000).getUTCFullYear()]=cv; } map[tk]=by; }); }catch(_){}
+        _HALL=map; return _HALL; })();
+      return _HALLp; }
     /* (#R142) _hy = the time-machine year (null = present/live). In a past year market cap = today's shares × the share
        price AT that year (c.hp); a company founded AFTER the year, or a non-live name with no price path, has no cap. */
     let _hy=null, _hSeq=0, _hyLoaded=null;
@@ -10529,17 +10583,24 @@ window.addEventListener('DOMContentLoaded', () => {
        same CORS-proxy ladder the ticker uses), concurrency-limited, cached 5 min. onUpdate fires progressively and
        once at completion so the ranking re-sorts live. Non-US names keep their reported snapshot. Fully guarded —
        if the proxies are down the tab still shows real (reported) figures. */
+    /* SANITY GUARD: a live market cap that deviates by more than ~5× from the reported snapshot means a bad fetch
+       (wrong symbol / stale proxy response / currency mismatch) or an off share count — reject it and keep the honest
+       reported figure rather than corrupt the ranking. Genuine price movement stays live. */
+    function _applyPrice(c,p){ if(!(p>0)) return false; const cand=c.sh*p; if(cand>=c.mcapSnap*0.2 && cand<=c.mcapSnap*5){ c.price=p; return true; } return false; }
     async function loadPrices(onUpdate){
       const now=Date.now(); if(_loading) return; if(_loaded && (now-_loaded)<300000) return;
-      _loading=true; const live=DATA.filter(c=>c.sh>0); let idx=0, upd=0; const CONC=5;
-      async function w(){ for(;;){ const i=idx++; if(i>=live.length) return; const c=live[i];
+      _loading=true; const live=DATA.filter(c=>c.sh>0); const byTk={}; live.forEach(c=>byTk[c.tk]=c);
+      /* (#R151) FAST PATH: one batched spark request per ~40 names → the whole board prices in a few round-trips (低遅延). */
+      let missing=live;
+      try{ const sp=await _spark(live.map(c=>c.tk),'1d','1d'); const done=new Set();
+        sp.forEach((v,tk)=>{ const c=byTk[tk]; if(!c) return; let p=+v.price; if(!(p>0)&&Array.isArray(v.close)){ for(let k=v.close.length-1;k>=0;k--){ if(+v.close[k]>0){ p=+v.close[k]; break; } } } if(_applyPrice(c,p)) done.add(tk); });
+        missing=live.filter(c=>!done.has(c.tk)); if(onUpdate){ try{ onUpdate(); }catch(_){} } }catch(_){}
+      /* FALLBACK: per-symbol chart for any the batch didn't resolve (proxy hiccup / symbol quirk). */
+      let idx=0, upd=0; const CONC=6;
+      async function w(){ for(;;){ const i=idx++; if(i>=missing.length) return; const c=missing[i];
         try{ const j=await _fjson('https://query1.finance.yahoo.com/v8/finance/chart/'+encodeURIComponent(c.tk)+'?range=1d&interval=1d');
           const m=j&&j.chart&&j.chart.result&&j.chart.result[0]&&j.chart.result[0].meta;
-          if(m&&+m.regularMarketPrice>0){ const p=+m.regularMarketPrice, cand=c.sh*p;
-            /* SANITY GUARD: a live market cap that deviates by more than ~5× from the reported snapshot means a bad
-               fetch (wrong symbol / stale proxy response / currency mismatch) or an off share count — reject it and
-               keep the honest reported figure rather than corrupt the ranking. Genuine price movement stays live. */
-            if(cand>=c.mcapSnap*0.2 && cand<=c.mcapSnap*5){ c.price=p; if((++upd%8===0)&&onUpdate){ try{ onUpdate(); }catch(_){} } } } }catch(_){} } }
+          if(m&&_applyPrice(c,+m.regularMarketPrice)){ if((++upd%8===0)&&onUpdate){ try{ onUpdate(); }catch(_){} } } }catch(_){} } }
       try{ await Promise.all(Array.from({length:CONC},()=>w())); }catch(_){}
       _loaded=Date.now(); _loading=false; if(onUpdate){ try{ onUpdate(); }catch(_){} }
     }
@@ -10553,13 +10614,19 @@ window.addEventListener('DOMContentLoaded', () => {
       _hy=year; const my=++_hSeq;
       if(_hyLoaded===year){ if(onUpdate){ try{ onUpdate(); }catch(_){} } return; }
       DATA.forEach(c=>{ c.hp=0; }); if(onUpdate){ try{ onUpdate(); }catch(_){} }   /* show the loading (—) state at once */
-      const p1=Math.floor(Date.UTC(year,0,1)/1000), p2=Math.floor(Date.UTC(year,11,31)/1000);
-      const live=DATA.filter(c=>c.sh>0 && c.fnd<=year); let idx=0, upd=0; const CONC=5;
-      async function w(){ for(;;){ if(my!==_hSeq) return; const i=idx++; if(i>=live.length) return; const c=live[i];
-        try{ const j=await _fjson('https://query1.finance.yahoo.com/v8/finance/chart/'+encodeURIComponent(c.tk)+'?period1='+p1+'&period2='+p2+'&interval=1mo');
-          const rt=j&&j.chart&&j.chart.result&&j.chart.result[0]; const q=rt&&rt.indicators&&rt.indicators.quote&&rt.indicators.quote[0]&&rt.indicators.quote[0].close;
-          if(Array.isArray(q)){ for(let k=q.length-1;k>=0;k--){ if(q[k]>0){ c.hp=+q[k]; break; } } if(c.hp>0 && (++upd%8===0) && onUpdate){ try{ onUpdate(); }catch(_){} } } }catch(_){} } }
-      try{ await Promise.all(Array.from({length:CONC},()=>w())); }catch(_){}
+      const live=DATA.filter(c=>c.sh>0 && c.fnd<=year);
+      /* (#R151) read each name's year-end close from the ONE-TIME full-history cache → instant, and reaches as far back
+         as Yahoo has data. A name whose data starts later simply has no entry for this year (mcap()=NaN, honest —). */
+      let all=null; try{ all=await _histAll(); }catch(_){} if(my!==_hSeq) return;
+      if(all){ live.forEach(c=>{ const by=all[c.tk]; const v=by&&by[year]; if(v>0) c.hp=v; }); if(onUpdate){ try{ onUpdate(); }catch(_){} } }
+      /* FALLBACK: any live name the cache didn't cover (spark failed / gap) → the proven per-year chart fetch. */
+      const miss=live.filter(c=>!(c.hp>0));
+      if(miss.length){ const p1=Math.floor(Date.UTC(year,0,1)/1000), p2=Math.floor(Date.UTC(year,11,31)/1000); let idx=0, upd=0; const CONC=6;
+        async function w(){ for(;;){ if(my!==_hSeq) return; const i=idx++; if(i>=miss.length) return; const c=miss[i];
+          try{ const j=await _fjson('https://query1.finance.yahoo.com/v8/finance/chart/'+encodeURIComponent(c.tk)+'?period1='+p1+'&period2='+p2+'&interval=1mo');
+            const rt=j&&j.chart&&j.chart.result&&j.chart.result[0]; const q=rt&&rt.indicators&&rt.indicators.quote&&rt.indicators.quote[0]&&rt.indicators.quote[0].close;
+            if(Array.isArray(q)){ for(let k=q.length-1;k>=0;k--){ if(q[k]>0){ c.hp=+q[k]; break; } } if(c.hp>0 && (++upd%8===0) && onUpdate){ try{ onUpdate(); }catch(_){} } } }catch(_){} } }
+        try{ await Promise.all(Array.from({length:CONC},()=>w())); }catch(_){} }
       if(my===_hSeq){ _hyLoaded=year; if(onUpdate){ try{ onUpdate(); }catch(_){} } }
     }
     /* (#R145) Share-price HISTORY for the compare Time-series mode — one keyless Yahoo v8 call per name over a year
@@ -10567,6 +10634,8 @@ window.addEventListener('DOMContentLoaded', () => {
        names only; snapshot-only names have no path and return {} (charted honestly as "no history"). */
     const _histCache={};
     async function priceSeries(tk, y0, y1){ const key=tk+'|'+y0+'|'+y1; if(_histCache[key]) return _histCache[key];
+      /* (#R151) serve from the full-history cache when present (no extra network); else the per-symbol chart below. */
+      try{ const all=await _histAll(); if(all&&all[tk]){ const by={}; for(let y=y0;y<=y1;y++){ if(all[tk][y]>0) by[y]=all[tk][y]; } if(Object.keys(by).length){ _histCache[key]=by; return by; } } }catch(_){}
       const p1=Math.floor(Date.UTC(y0,0,1)/1000), p2=Math.floor(Date.UTC(y1,11,31)/1000);
       const byYear={};
       try{ const j=await _fjson('https://query1.finance.yahoo.com/v8/finance/chart/'+encodeURIComponent(tk)+'?period1='+p1+'&period2='+p2+'&interval=1mo');
@@ -10604,8 +10673,11 @@ window.addEventListener('DOMContentLoaded', () => {
   window._coShowCompare=function(){ if(coCompareSet.size<2) return; try{ showCoCompare([...coCompareSet]); }catch(_){} };
   function renderCoCompareFixed(){ const feed=document.getElementById('info-dashboard'); if(!feed) return;
     let tray=document.getElementById('co-compare-fixed');
-    if(!coCompareSet.size || document.getElementById('co-cmp-view')){ if(tray) tray.remove(); return; }
+    if(document.getElementById('co-cmp-view')){ if(tray) tray.remove(); return; }   /* the compare VIEW owns the feed → hide the dock */
     if(!tray){ tray=document.createElement('div'); tray.id='co-compare-fixed'; tray.className='co-compare-fixed'; feed.appendChild(tray); }
+    /* (#R151) Countries-parity empty hint ("Tap company rows to select and compare.") — Countries shows this in its
+       #stats-compare-fixed dock; Companies previously removed the tray entirely when nothing was selected. */
+    if(!coCompareSet.size){ tray.innerHTML=`<div class="scf-empty">${t('coCompareEmpty')}</div>`; return; }
     const items=[...coCompareSet].map(tk=>IntMapCompanies.DATA.find(x=>x.tk===tk)).filter(Boolean);
     const chips=items.map(c=>`<span class="scb-chip">${IntMapSafe.html(_coName(c))}<button data-cx="${IntMapSafe.html(c.tk)}">×</button></span>`).join('');
     tray.innerHTML=`<div class="scf-head"><span class="scf-title">${_coL('Compare','比較','Vergleich','Сравнение','Comparar')} (${coCompareSet.size}/10)</span><div style="display:flex;gap:6px;">`+(coCompareSet.size>=2?`<button class="scf-view" data-cv="1">${t('compareView')}</button>`:'')+`<button data-cc="1">${t('compareClear')}</button></div></div><div class="scf-chips">${chips}</div>`;
@@ -12614,7 +12686,7 @@ window.addEventListener('DOMContentLoaded', () => {
          couldn't be dragged tall enough to reveal all 30 Köppen classes ("長く伸ばせられない") — restore the near-full-viewport
          ceiling so the legend can be stretched long again; height stays auto (fits content) with a comfortable default. */
       .koppen-legend{ display:none; flex-direction:column; position:absolute; top:74px; bottom:auto; left:24px; right:auto; z-index:1100; background:var(--popup-bg); border:1px solid rgba(128,128,128,0.15); border-radius:11px; padding:7px 10px; box-shadow:var(--shadow); backdrop-filter:blur(15px); height:auto; min-height:150px; max-height:calc(100dvh - 84px); overflow:hidden; resize:vertical; width:186px; min-width:186px; max-width:186px; font-size:10.5px; }   /* (#R149) trimmed padding + reserved margin 92→84 so more of the 30 Köppen zones fit; see compacted rows/chrome below — the legend can finally stretch to the last class ("さいごまで伸ばせない") */
-      .koppen-legend .kl-scroll{ overflow-y:auto; flex:1 1 auto; min-height:0; margin-top:1px; }
+      .koppen-legend .kl-scroll{ overflow-y:auto; flex:1 1 auto; min-height:0; margin-top:1px; scrollbar-gutter:stable; }   /* (#R151) reserve the scrollbar gutter ALWAYS so climate-name rows keep a constant width while the legend is resized ("気候名の行幅が勝手に動かないように") — the appearing/disappearing scrollbar was stealing ~15px and reflowing the row text */
       /* (#R15 / #37) Make the vertical-resize grabber VISIBLE so users discover it — the user reported the
          resize "isn't implemented", but it was: the native grabber was just painted transparent. Now it
          shows a small diagonal grip at the bottom-right, matching the resize:vertical affordance. */
@@ -14271,10 +14343,20 @@ window.addEventListener('DOMContentLoaded', () => {
       if(window.innerWidth<=768) return;
       const top=lg.getBoundingClientRect().top;                 /* rendered top edge (top-anchored: stable as it grows) */
       const renderedMax=Math.round(window.innerHeight - top - 12);   /* how tall the border-box may be before it hits the screen bottom */
-      /* max-height on a content-box element sizes the CONTENT box; the rendered border-box is that + padding + border.
-         Subtract the chrome so the RENDERED bottom edge lands ~12px above the screen bottom (not 18px past it). */
-      let mh=renderedMax;
-      if(cs.boxSizing!=='border-box'){ const pb=(parseFloat(cs.paddingTop)||0)+(parseFloat(cs.paddingBottom)||0)+(parseFloat(cs.borderTopWidth)||0)+(parseFloat(cs.borderBottomWidth)||0); mh=Math.max(0, renderedMax-pb); }
+      /* (#R151) STOP WHEN ALL CLASSES ARE SHOWN ("すべての気候区分が表示されたら止まる"). R150 set max-height = the
+         viewport ceiling with NO content clamp, so the resize grabber kept stretching into EMPTY space past the last
+         class. Measure the natural height that shows every class (temporarily neutralise any dragged inline height +
+         max-height so the box shrink-wraps), then cap at min(content, viewport): a short list stops exactly at its
+         last row (no blank space), a list taller than the screen stops at the screen bottom with the inner .kl-scroll
+         revealing the rest. Measured set→read→restore in one synchronous task → no paint, no flicker. */
+      const prevH=lg.style.height, prevMH=lg.style.maxHeight;
+      lg.style.maxHeight='none'; lg.style.height='auto';
+      const naturalBorderBox=lg.getBoundingClientRect().height;   /* full height that shows every climate class */
+      lg.style.height=prevH; lg.style.maxHeight=prevMH;
+      const ceil=Math.min(renderedMax, Math.ceil(naturalBorderBox));   /* border-box: content OR viewport, whichever is smaller */
+      /* max-height on a content-box element sizes the CONTENT box; the rendered border-box is that + padding + border. */
+      let mh=ceil;
+      if(cs.boxSizing!=='border-box'){ const pb=(parseFloat(cs.paddingTop)||0)+(parseFloat(cs.paddingBottom)||0)+(parseFloat(cs.borderTopWidth)||0)+(parseFloat(cs.borderBottomWidth)||0); mh=Math.max(0, ceil-pb); }
       lg.style.maxHeight=Math.max(150, mh)+'px';
     }catch(_){} }
     window._fitKoppenLegend=_fitKoppenLegend;
@@ -25085,7 +25167,7 @@ window.addEventListener('DOMContentLoaded', () => {
         +'<div class="sv-body" style="flex:1 1 auto;position:relative;background:#000;min-height:0;"><iframe class="sv-if" style="width:100%;height:100%;border:0;display:block;" allowfullscreen loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>'
         +'<div class="sv-hint" style="position:absolute;left:0;right:0;bottom:0;font-size:10px;color:#ddd;background:rgba(0,0,0,0.5);padding:3px 8px;pointer-events:none;">'+LL('Drag to look; use ◀ ▶ to turn (the map shows your facing).','ドラッグで見回し／◀ ▶ で向きを変更（地図に向きを表示）。','Ziehen zum Umsehen; ◀ ▶ zum Drehen.','Тяните; ◀ ▶ — поворот (направление на карте).','Arrastra; ◀ ▶ para girar (dirección en el mapa).')+'</div></div>';
       document.body.appendChild(panel); iframe=panel.querySelector('.sv-if');
-      panel.querySelector('.sv-close').onclick=()=>{ panel.style.display='none'; try{ iframe.src='about:blank'; }catch(_){} _clearHere(); };
+      panel.querySelector('.sv-close').onclick=()=>close();   /* (#R151) route through close() so auto-shown coverage is turned off too */
       panel.querySelector('.sv-turn-l').onclick=()=>_rotateHere(-30);
       panel.querySelector('.sv-turn-r').onclick=()=>_rotateHere(30);
       panel.querySelector('.sv-fwd').onclick=()=>_moveHere(1);
@@ -25180,6 +25262,10 @@ window.addEventListener('DOMContentLoaded', () => {
       return true; }
     function open(ll,label){ if(!ll||ll.lng==null||!isFinite(+ll.lng)) return false;
       const lng=+ll.lng, lat=+ll.lat, hdg0=(ll.heading!=null&&isFinite(+ll.heading))?((+ll.heading%360)+360)%360:0;
+      /* (#R151) "ストリートビューをオンにしている際は、coverageも表示するように" — whenever a panorama is opened,
+         auto-show Google's real coverage (the light-blue lines) so the surrounding walkable network is visible.
+         Only auto-enable when it was OFF (preserve a user's manual coverage state); close() turns it back off. */
+      if(!_cov){ try{ coverage(true); _covAuto=true; }catch(_){} }
       if(ll.noSnap){ return _openAt(lng,lat,label,hdg0); }        /* internal raw path (caller already has a coverage point) */
       try{ _setHere(lng,lat,hdg0); }catch(_){}                    /* instant marker feedback while the pano resolves */
       /* covered → snap the marker AND embed onto the REAL nearest pano (+ store walkable links for forward/back);
@@ -25188,13 +25274,14 @@ window.addEventListener('DOMContentLoaded', () => {
       const _fallbackHonest=()=>{ _svLinks=[]; _openAt(lng,lat,label,hdg0); _coverageUnverifiedToast(); };   /* (#R142) never a silent "moved to your click" — say coverage is unverified */
       _snapPano(lng,lat).then(res=>{ if(!_resolve(res)) _fallbackHonest(); }).catch(_fallbackHonest);
       return true; }
-    function close(){ if(panel){ panel.style.display='none'; try{ iframe.src='about:blank'; }catch(_){} } _clearHere(); }
+    function close(){ if(panel){ panel.style.display='none'; try{ iframe.src='about:blank'; }catch(_){} } _clearHere();
+      if(_covAuto){ _covAuto=false; try{ coverage(false); }catch(_){} } }   /* (#R151) turn off auto-shown coverage when SV closes (manual coverage stays) */
     /* (#R84/#R140) COVERAGE MODE ("地図上の水色の線、ポイントから選択できるように") — show Google's REAL Street-View
        coverage and let the user click it. R84–R85 approximated coverage by tinting the BASEMAP's own road lines blue,
        but that is NOT where panoramas actually exist ("Coverageを全く考慮していない"): a road with no SV lit up, and a
        covered alley that the basemap lacked stayed dark. We now overlay Google's genuine keyless SV coverage tiles
        (the svv layer) so the blue lines ARE the real panoramas, and clicks snap to them via _nearestCoverage. */
-    let _cov=false, _covClick=null, _covHint=null, _covStyled=false;
+    let _cov=false, _covClick=null, _covHint=null, _covStyled=false, _covAuto=false;   /* (#R151) _covAuto = coverage was auto-enabled by opening SV (restored on close) */
     const _COV_SRC='sv-cov-src', _COV_LYR='sv-cov-lyr';
     const _covTileUrl=(sd)=>'https://mts'+sd+'.google.com/vt?hl=en&src=api&x={x}&y={y}&z={z}&lyrs=svv&style=40,18';
     function addCoverageTiles(){ try{
@@ -26732,7 +26819,7 @@ window.addEventListener('DOMContentLoaded', () => {
       /* (#R150) warm satellite tiles AHEAD of the aircraft (~2.6×/s). `moveend` never fires while the camera moves
          continuously in flight, so without this the imagery streamed in BEHIND the aircraft; predictivePrefetch
          self-gates to satellite mode + uses the center delta (flight direction) to prefetch the tiles just ahead. */
-      if(now-(st._pfT||0)>380){ st._pfT=now; try{ window._imPredictivePrefetch&&window._imPredictivePrefetch(); }catch(_){} }
+      if(now-(st._pfT||0)>300){ st._pfT=now; try{ window._imPredictivePrefetch&&window._imPredictivePrefetch(true); }catch(_){} }   /* (#R151) aggressive lead + slightly faster cadence (~3.3×/s) so 3D imagery stays ahead of the aircraft */
       raf=requestAnimationFrame(loop); }
     /* switch aircraft mid-flight — keep position/attitude, reset speed to the new type's cruise + clear rates */
     function selectAircraft(k){ if(!AIRCRAFT[k]) return; acKey=k; if(st){ st.V=AIRCRAFT[k].Vcruise; st.om=[0,0,0]; st.elev=0; st.ail=0; st.rud=0; st.flaps=0; st.gear=0; computeTrim(); } try{ syncHUDChrome(); }catch(_){} }
@@ -27717,6 +27804,10 @@ window.addEventListener('DOMContentLoaded', () => {
       .replace(/^#{3,6}\s*(.+)$/gm,'<div style="font-weight:700;color:var(--primary-color);margin:1em 0 .3em;font-size:1.14em;line-height:1.32;">$1</div>')
       .replace(/^##\s*(.+)$/gm,'<div style="font-weight:700;color:var(--primary-color);margin:1.2em 0 .4em;font-size:1.32em;line-height:1.3;letter-spacing:.005em;">$1</div>')
       .replace(/^#\s*(.+)$/gm,'<div style="font-weight:800;color:var(--primary-color);margin:1.15em 0 .45em;font-size:1.55em;letter-spacing:.01em;line-height:1.26;">$1</div>')
+      /* (#R151) MODEL-INDEPENDENT hierarchy — a line that is ENTIRELY a **bold run** is a section lead the model DID emit
+         (models reach for standalone bold far more readily than "## "); render it at real heading size + spacing so the
+         reply stops reading as one flat block even when no "## " markers appear. Inline bold stays <b> (below). */
+      .replace(/^\*\*([^*\n]{2,90})\*\*[ \t]*:?[ \t]*$/gm,'<div style="font-weight:700;color:var(--primary-color);margin:1.05em 0 .32em;font-size:1.18em;line-height:1.3;">$1</div>')
       .replace(/\*\*([^*]+)\*\*/g,'<b>$1</b>')
       /* (#R74) markdown links render as real (safe) anchors — "記事のリンク等をChatGPT風UIで" */
       .replace(/\[([^\]\n]{1,120})\]\((https?:[^)\s]{4,300})\)/g,(m,t,u)=>'<a href="'+u+'" target="_blank" rel="noopener" style="color:var(--primary-color);text-decoration:none;border-bottom:1px solid currentColor;">'+t+'</a>')
@@ -27724,8 +27815,8 @@ window.addEventListener('DOMContentLoaded', () => {
          — the leading-char guard skips urls already inside an href="…" attribute of the anchors made just above. */
       .replace(/(^|[^"'=>\/])(https?:\/\/[^\s<)"']+)/g,(m,pre,u)=>pre+'<a href="'+u+'" target="_blank" rel="noopener" style="color:var(--primary-color);text-decoration:none;border-bottom:1px solid currentColor;word-break:break-all;">'+u+'</a>')
       .replace(/^[-・*]\s+(.+)$/gm,'<div style="padding-left:1.15em;text-indent:-0.9em;margin:.24em 0;">• $1</div>')
-      .replace(/\n{2,}/g,'<div style="height:.72em"></div>')                                       /* explicit paragraph → generous gap */
-      .replace(/([.!?。！？…”"』）)])\n(?=\S)/g,'$1<div style="height:.5em"></div>')                  /* (#R150) sentence-end + single newline = soft paragraph gap ("まとまりの間に余白") */
+      .replace(/\n{2,}/g,'<div style="height:.85em"></div>')                                       /* (#R151) explicit paragraph → generous gap (more "余白" between groups) */
+      .replace(/([.!?。！？…”"』）)])\n(?=\S)/g,'$1<div style="height:.6em"></div>')                  /* (#R150/#R151) sentence-end + single newline = soft paragraph gap ("まとまりの間に余白") */
       .replace(/\n/g,'<br>'); }
     /* (#R74) ChatGPT-style SOURCE LINK CARDS ("Atlasの返答に、必要であれば記事のリンク等をChatGPT風UIで表示"):
        compact rounded cards with the site's favicon, the article title and its domain — used by analyze,
@@ -27741,6 +27832,12 @@ window.addEventListener('DOMContentLoaded', () => {
       const um=bin.match(/https?:\/\/[A-Za-z0-9._~:\/?#\[\]@!$&'()*+,;=%-]{6,}/); if(!um) return null;
       let real=um[0].replace(/[\x00-\x1f].*$/,''); try{ const h=new URL(real).hostname; if(!h||/news\.google\.com/i.test(h)||h.indexOf('.')<0) return null; }catch(_){ return null; }
       return real; }catch(_){ return null; } }
+    /* (#R151) SOURCE RELIABILITY — the user reported Atlas citing "まったく関係ないリンクや、SNSのリンク" (unrelated / social
+       links). Social & UGC platforms, URL shorteners and video hosts are NOT reliable primary sources for factual claims,
+       so DROP them from the source cards (kept end-to-end for every reply that shows sources). Reputable news, official
+       (.gov/.mil/.int/.edu/.go.jp…) and encyclopedic domains pass through unchanged. */
+    const _SNS_RE=/(^|\.)(twitter\.com|x\.com|t\.co|facebook\.com|fb\.com|fb\.watch|m\.facebook\.com|instagram\.com|threads\.net|tiktok\.com|reddit\.com|redd\.it|pinterest\.[a-z.]+|tumblr\.com|mastodon\.[a-z.]+|bsky\.app|weibo\.com|vk\.com|ok\.ru|linkedin\.com|lnkd\.in|quora\.com|snapchat\.com|discord\.(?:com|gg)|t\.me|telegram\.me|youtube\.com|youtu\.be|m\.youtube\.com|bit\.ly|tinyurl\.com|goo\.gl|ift\.tt|buff\.ly|dlvr\.it|ow\.ly)$/i;
+    function _atlBadSourceHost(h){ try{ return _SNS_RE.test(String(h||'').toLowerCase().replace(/^www\./,'')); }catch(_){ return false; } }
     function linkCards(list){ try{
       const seen=new Set(); const cards=[];
       /* (#R107) show ONLY links that point at the ACTUAL article ("記事へのリンクではなく情報源の一般的なリンクに
@@ -27752,6 +27849,7 @@ window.addEventListener('DOMContentLoaded', () => {
         if(_isAggUrl(u)){ const dec=_decGNewsUrl(u); if(dec) u=dec; else return; }   /* un-decodable aggregator → drop */
         let host=''; try{ host=new URL(u).hostname.replace(/^www\./,''); }catch(_){ return; }
         if(/(^|\.)news\.google\.com$/i.test(host)||/^news\.google$/i.test(host)) return;   /* still an aggregator → drop */
+        if(_atlBadSourceHost(host)) return;   /* (#R151) drop SNS / UGC / shorteners / video hosts — not reliable factual sources */
         const k=u.replace(/[#?].*$/,''); if(seen.has(k)) return; seen.add(k);
         const title=String(it.title||it.src||host).slice(0,90);
         cards.push('<a class="atl-lc" href="'+esc(u)+'" target="_blank" rel="noopener">'
@@ -28751,7 +28849,7 @@ window.addEventListener('DOMContentLoaded', () => {
       /* ---- (#R147) scope: analyse sensitive-but-legitimate questions instead of over-refusing ---- */
       s+='SCOPE: analyse sensitive but legitimate questions (defence, disasters, disease, hazards, crime statistics, cyber, critical infrastructure) from PUBLIC information at an appropriate level of generality — judge by purpose, target, precision and output, never by a sensitive-sounding word. State the uncertainty and cite public sources; decline ONLY genuinely operational harm (real-time targeting, a precise strike or kill plan, or weapon/agent synthesis instructions) and, even then, still give the safe public-information analysis you can. ';
       /* ---- length + sources ---- */
-      s+='Answer in '+lang+'.'+(String(lang).indexOf('Japanese')>=0?' When answering in Japanese, use polite form (です・ます／敬語) unless the user is clearly casual or explicitly requests plain/casual speech.':'')+' FORMAT FOR READABILITY (the user complained Atlas answers are a monotonous wall of same-size text with no headings or spacing): structure a multi-part answer with a short **bold** lead sentence, "## " sub-headings that name each distinct section, "- " bullets for lists, and a blank line between sections — these render with real, larger heading sizes and clear spacing. Keep a short, single-idea answer as plain sentences (do NOT over-structure a one-paragraph reply). Aim for concision (~230 words is a good target for an open-ended question) BUT never drop the user\'s required sections or a required verdict to hit a word count — their requested structure wins. SOURCE QUALITY: prefer the single most authoritative PRIMARY source per claim (official body, government, the institution itself, primary reporting) over merely-highly-ranked pages; do NOT lean the whole answer on one site or domain — corroborate across independent source types. Then, after the answer, on its own line, output "SOURCES: <url1> | <url2> | …" with up to 4 REAL article/page URLs (from the NEWS EVIDENCE urls or from your web search this turn) that support your key claims; omit the line entirely if you have none; fabricating a URL is forbidden. MAP VALUE (IntMap is a MAP product, not a chatbot — every location-rich answer must put its spots ON the map): if the answer names specific, real, mappable places (cities, towns, districts, landmarks, buildings, stations, airports, ports, parks, gardens, museums, squares/plazas, stadiums, named facilities, or named natural features such as rivers/mountains/islands/straits), then on the VERY LAST line — AFTER any SOURCES line — output "PLACES: " followed by a ONE-LINE compact JSON array naming EVERY such place: [{"n":"exact place name","c":"the modern country it lies in","k":"kind"}]. IntMap resolves the coordinates from n+c and pins them — NEVER output latitude/longitude, never invent a place, exclude whole countries and vague/relative terms ("the region","the coast","downtown"), and list a place only if you actually named it in the answer. The places you name in the prose and the places in PLACES must MATCH. Omit the PLACES line only when the answer truly names no mappable place.';
+      s+='Answer in '+lang+'.'+(String(lang).indexOf('Japanese')>=0?' When answering in Japanese, use polite form (です・ます／敬語) unless the user is clearly casual or explicitly requests plain/casual speech.':'')+' FORMAT FOR READABILITY (the user complained Atlas answers are a monotonous wall of same-size text with no headings or spacing): structure a multi-part answer with a short **bold** lead sentence, "## " sub-headings that name each distinct section, "- " bullets for lists, and a blank line between sections — these render with real, larger heading sizes and clear spacing. Keep a short, single-idea answer as plain sentences (do NOT over-structure a one-paragraph reply). Aim for concision (~230 words is a good target for an open-ended question) BUT never drop the user\'s required sections or a required verdict to hit a word count — their requested structure wins. SOURCE QUALITY: prefer the single most authoritative PRIMARY source per claim (official body, government, the institution itself, primary reporting) over merely-highly-ranked pages; do NOT lean the whole answer on one site or domain — corroborate across independent source types. NEVER cite social media, user-generated forums, link shorteners or video platforms (X/Twitter, Facebook, Instagram, Reddit, YouTube, TikTok, Telegram, etc.) as a source — they are not reliable factual sources and will be discarded. Then, after the answer, on its own line, output "SOURCES: <url1> | <url2> | …" with up to 4 REAL article/page URLs (from the NEWS EVIDENCE urls or from your web search this turn); EACH url must be a specific page that DIRECTLY supports a claim you made — never a generic homepage, a search page, or an unrelated link. Omit the line entirely if you have none; fabricating a URL is forbidden. MAP VALUE (IntMap is a MAP product, not a chatbot — every location-rich answer must put its spots ON the map): if the answer names specific, real, mappable places (cities, towns, districts, landmarks, buildings, stations, airports, ports, parks, gardens, museums, squares/plazas, stadiums, named facilities, or named natural features such as rivers/mountains/islands/straits), then on the VERY LAST line — AFTER any SOURCES line — output "PLACES: " followed by a ONE-LINE compact JSON array naming EVERY such place: [{"n":"exact place name","c":"the modern country it lies in","k":"kind"}]. IntMap resolves the coordinates from n+c and pins them — NEVER output latitude/longitude, never invent a place, exclude whole countries and vague/relative terms ("the region","the coast","downtown"), and list a place only if you actually named it in the answer. The places you name in the prose and the places in PLACES must MATCH. Omit the PLACES line only when the answer truly names no mappable place.';
       return s; }
     /* (#R131) The TIME CONTEXT + REQUESTED COVERAGE header of the analyze DATA block. Shared by the live path and
        the regression harness so the two can never drift. */
@@ -28876,6 +28974,8 @@ window.addEventListener('DOMContentLoaded', () => {
       nameOk:function(a,b){ try{ return _atlNameOk(a,b); }catch(_){ return false; } },
       extractPlaces:function(t){ try{ return _atlExtractPlaces(t); }catch(_){ return []; } },
       regDomain:function(u){ try{ return _atlRegDomain(u); }catch(_){ return ''; } },
+      badSourceHost:function(h){ try{ return _atlBadSourceHost(h); }catch(_){ return false; } },
+      linkCards:function(l){ try{ return linkCards(l); }catch(_){ return ''; } },
       auditSources:function(c){ try{ return _atlAuditSources(c); }catch(_){ return null; } },
       mappingVerdict:function(s){ try{ return _atlMappingVerdict(s); }catch(_){ return null; } },
       mappingNote:function(v,s,m){ try{ return _atlMappingNoteHtml(v,s,m); }catch(_){ return ''; } },
@@ -29703,9 +29803,9 @@ window.addEventListener('DOMContentLoaded', () => {
             ctl+='</div>'; } }catch(_){}
           return R(true, note('✓ '+esc(r.label)+' — '+onTxt+(r.already?(' ('+L('already','既に','bereits','уже','ya')+')'):''))+verifyNote+ctl, unverified?{meta:{unverified:true}}:undefined); }
         case 'opacity': { const r=resolveLayer(a.name); if(!r) return R(false, warn('⚠ '+L('Layer not found','レイヤーが見つかりません','Ebene nicht gefunden','Слой не найден','Capa no encontrada')+': '+esc(a.name||''))); const sl=layerOpacityControl(r.cb); let v=(a.value!=null?+a.value:(a.percent!=null?+a.percent:null)); if(v!=null&&v>1) v=v/100; if(v==null&&a.delta!=null&&sl){ let d=+a.delta; if(!isNaN(d)){ if(Math.abs(d)>1) d/=100; v=Math.max(0,Math.min(1,(parseFloat(sl.value)||0)+d)); } } if(sl&&v!=null&&!isNaN(v)){ if(!r.cb.checked){ r.cb.checked=true; r.cb.dispatchEvent(new Event('change',{bubbles:true})); } sl.value=v; sl.dispatchEvent(new Event('input',{bubbles:true})); sl.dispatchEvent(new Event('change',{bubbles:true})); return R(true, note('🎚 '+esc(r.label)+' '+Math.round(v*100)+'%')); } return R(false, warn('⚠ '+L('No opacity control: ','透明度調整なし: ','Keine Deckkraft: ','Нет прозрачности: ','Sin opacidad: ')+esc(r.label))); }
-        case 'projection': { const flat=(a.mode==='flat'); const ok=kexec(flat?'view.proj.flat':'view.proj.globe', flat?'btn-view-flat':'btn-view-globe'); return R(ok, ok?note('✓ '+esc(flat?L('Flat map','平面地図','Flache Karte','Плоская карта','Mapa plano'):L('Globe','地球儀','Globus','Глобус','Globo'))):warn('⚠')); }
+        case 'projection': { const flat=(a.mode==='flat'); const ok=kexec(flat?'view.proj.flat':'view.proj.globe', flat?'btn-view-flat':'btn-view-globe'); return R(ok, ok?note('✓ '+esc(flat?L('Flat map','平面地図','Flache Karte','Плоская карта','Mapa plano'):L('Globe','地球儀','Globus','Глобус','Globo')))+_featTogHtml('globe'):warn('⚠')); }   /* (#R151) offer the 3D-globe on/off switch */
         case 'base': { const sat=(a.mode==='satellite'||a.mode==='sat'); const ok=kexec(sat?'view.base.sat':'view.base.map', sat?'btn-view-sat':'btn-view-map'); return R(ok, ok?note('✓ '+esc(sat?L('Satellite','衛星','Satellit','Спутник','Satélite'):L('Map','地図','Karte','Карта','Mapa')))+_featTogHtml('satellite'):warn('⚠')); }   /* (#R147) offer the Satellite on/off button */
-        case 'compare': { try{ if(a.on===false){ const x=document.querySelector('#compare-window .cmp-close'); if(x){ x.click(); return R(true, note('✓ '+L('Compare off','比較オフ','Vergleich aus','Сравнение выкл','Comparar: off'))); } } else if(window.IntMapCompare&&window.IntMapCompare.open){ window.IntMapCompare.open(); return R(true, note('✓ '+L('Compare','比較','Vergleich','Сравнение','Comparar'))); } }catch(_){} return R(clickId('btn-compare'), note('✓ '+L('Compare','比較','Vergleich','Сравнение','Comparar'))); }
+        case 'compare': { try{ if(a.on===false){ const x=document.querySelector('#compare-window .cmp-close'); if(x){ x.click(); return R(true, note('✓ '+L('Compare off','比較オフ','Vergleich aus','Сравнение выкл','Comparar: off'))+_featTogHtml('compare')); } } else if(window.IntMapCompare&&window.IntMapCompare.open){ window.IntMapCompare.open(); return R(true, note('✓ '+L('Compare','比較','Vergleich','Сравнение','Comparar'))+_featTogHtml('compare')); } }catch(_){} return R(clickId('btn-compare'), note('✓ '+L('Compare','比較','Vergleich','Сравнение','Comparar'))+_featTogHtml('compare')); }   /* (#R151) offer the Compare on/off switch */
         case 'flyTo': { const exZ=(a.zoom!=null)?+a.zoom:null; const placeStr=String(a.place||'').trim();
           /* "the whole world / earth / globe" → zoom OUT to the planet, NEVER geocode (was → "World Bank building"). */
           if(WORLD_RE.test(placeStr) || /^(world|globe|earth)$/i.test(String(a.scale||''))){ try{ map.flyTo({center:[map.getCenter().lng,20],zoom:(exZ!=null?exZ:1.4),duration:1100}); }catch(_){ try{ map.zoomTo(1.4); }catch(__){} } return R(true, note('🌍 '+L('Whole world','全世界','Ganze Welt','Весь мир','El mundo entero'))); }
@@ -31823,7 +31923,10 @@ window.addEventListener('DOMContentLoaded', () => {
       borders:{ lbl:()=>L('Borders','国境','Grenzen','Границы','Fronteras'), on:()=>{ const cb=document.getElementById('cb-borders'); return !!(cb&&cb.checked); }, set:v=>{ const cb=document.getElementById('cb-borders'); if(cb&&cb.checked!==v){ cb.checked=v; cb.dispatchEvent(new Event('change',{bubbles:true})); } } },
       labels:{ lbl:()=>L('Place labels','地名ラベル','Beschriftungen','Подписи','Etiquetas'), on:()=>{ const cb=document.getElementById('cb-geolabels')||document.getElementById('cb-names'); return !!(cb&&cb.checked); }, set:v=>{ const cb=document.getElementById('cb-geolabels')||document.getElementById('cb-names'); if(cb&&cb.checked!==v){ cb.checked=v; cb.dispatchEvent(new Event('change',{bubbles:true})); } } },
       roads:{ lbl:()=>L('Roads','道路','Straßen','Дороги','Carreteras'), on:()=>{ const cb=document.getElementById('cb-roads'); return !!(cb&&cb.checked); }, set:v=>{ const cb=document.getElementById('cb-roads'); if(cb&&cb.checked!==v){ cb.checked=v; cb.dispatchEvent(new Event('change',{bubbles:true})); } } },
-      ticker:{ lbl:()=>L('Bottom ticker','下部ティッカー','Ticker','Бегущая строка','Cinta inferior'), on:()=>{ try{ return String(window.imTicker||'')!=='off'; }catch(_){ return true; } }, set:v=>{ try{ if(window.IntMapTicker){ window.imTicker=v?'on':'off'; window.IntMapTicker.apply(); if(typeof saveSettings==='function') saveSettings(); } }catch(_){} } }   /* (#R149) more on/off features get an inline toggle */
+      ticker:{ lbl:()=>L('Bottom ticker','下部ティッカー','Ticker','Бегущая строка','Cinta inferior'), on:()=>{ try{ return String(window.imTicker||'')!=='off'; }catch(_){ return true; } }, set:v=>{ try{ if(window.IntMapTicker){ window.imTicker=v?'on':'off'; window.IntMapTicker.apply(); if(typeof saveSettings==='function') saveSettings(); } }catch(_){} } },   /* (#R149) more on/off features get an inline toggle */
+      /* (#R151) even more on/off surfaces get a switch ("オンオフ要素のある時はなるべくトグルボタンを設置") */
+      globe:{ lbl:()=>L('3D globe','地球儀','Globus','Глобус','Globo'), on:()=>{ const b=document.getElementById('btn-view-globe'); return !!(b&&(b.classList.contains('active')||b.classList.contains('view-on')||b.classList.contains('on')||b.getAttribute('aria-pressed')==='true')); }, set:v=>{ clickId(v?'btn-view-globe':'btn-view-flat'); } },
+      compare:{ lbl:()=>L('Compare panel','比較パネル','Vergleich','Панель сравнения','Comparar'), on:()=>{ try{ return document.body.classList.contains('cmp-open'); }catch(_){ return false; } }, set:v=>{ try{ if(v){ if(window.IntMapCompare&&window.IntMapCompare.open) window.IntMapCompare.open(); else clickId('btn-compare'); } else { const x=document.querySelector('#compare-window .cmp-close'); if(x) x.click(); } }catch(_){} } }
     };
     function _featTogHtml(kind){ const f=_FEAT_TOG[kind]; if(!f) return ''; let on=false; try{ on=!!f.on(); }catch(_){}
       /* (#R148) removed R147's bespoke .atl-featbtn ("独自ボタン") — restore the standard iOS toggle switch that shipped before R147. */
@@ -33414,13 +33517,16 @@ window.addEventListener('DOMContentLoaded', () => {
       if(!map.getSource('im-mon-pts')){ map.addSource('im-mon-pts',{type:'geojson',data:{type:'FeatureCollection',features:[]}});
         map.addLayer({id:'im-mon-pts-c',type:'circle',source:'im-mon-pts',paint:{'circle-radius':7,'circle-color':'#ff375f','circle-stroke-color':'#fff','circle-stroke-width':2,'circle-opacity':0.9}}); }
       return true; }catch(_){ return false; } }
-    function showOnMap(area,points){ try{ if(!_ensureLayers()) return; const af=[]; if(area&&area.geometry) af.push({type:'Feature',geometry:area.geometry,properties:{}});
+    /* (#R151) track WHICH monitor's area is currently painted so deleting it can clear the highlight
+       ("モニターで監視を作成した際のハイライトが、モニター削除後も残ってしまった"). */
+    let _shownMonId=null;
+    function showOnMap(area,points,monId){ try{ if(!_ensureLayers()) return; _shownMonId=(monId!=null?monId:null); const af=[]; if(area&&area.geometry) af.push({type:'Feature',geometry:area.geometry,properties:{}});
       map.getSource('im-mon-area').setData({type:'FeatureCollection',features:af});
       const pf=(points||[]).filter(p=>isFinite(p.lng)&&isFinite(p.lat)).map(p=>({type:'Feature',geometry:{type:'Point',coordinates:[p.lng,p.lat]},properties:{label:p.label||''}}));
       map.getSource('im-mon-pts').setData({type:'FeatureCollection',features:pf});
       if(area&&area.bbox){ try{ map.fitBounds([[area.bbox[0],area.bbox[1]],[area.bbox[2],area.bbox[3]]],{padding:80,maxZoom:9,duration:800}); }catch(_){} }
     }catch(_){} }
-    function clearMap(){ try{ if(map.getSource('im-mon-area')) map.getSource('im-mon-area').setData({type:'FeatureCollection',features:[]}); if(map.getSource('im-mon-pts')) map.getSource('im-mon-pts').setData({type:'FeatureCollection',features:[]}); }catch(_){} }
+    function clearMap(){ _shownMonId=null; try{ if(map.getSource('im-mon-area')) map.getSource('im-mon-area').setData({type:'FeatureCollection',features:[]}); if(map.getSource('im-mon-pts')) map.getSource('im-mon-pts').setData({type:'FeatureCollection',features:[]}); }catch(_){} }
 
     /* ---- data access (RLS scopes to the owner) ---- */
     async function _list(){ const {data,error}=await DB.from('area_monitors').select('*').order('created_at',{ascending:false}); if(error) throw error; return data||[]; }
@@ -33454,7 +33560,9 @@ window.addEventListener('DOMContentLoaded', () => {
       try{ const {data,error}=await DB.from('area_monitors').insert(row).select('*').single(); if(error) return {ok:false,error:_errMsg(error),raw:error}; return {ok:true,monitor:data}; }
       catch(e){ return {ok:false,error:_errMsg(e),raw:e}; } }
     async function setEnabled(id,on){ try{ const {error}=await DB.from('area_monitors').update({enabled:!!on}).eq('id',id); return !error; }catch(_){ return false; } }
-    async function remove(id){ try{ const {error}=await DB.from('area_monitors').delete().eq('id',id); return !error; }catch(_){ return false; } }
+    async function remove(id){ try{ const {error}=await DB.from('area_monitors').delete().eq('id',id);
+      if(!error && (_shownMonId===id || _shownMonId==null)) clearMap();   /* (#R151) delete must remove the leftover area highlight for the monitor being shown */
+      return !error; }catch(_){ return false; } }
     async function pause(id){ const ok=await setEnabled(id,false); if(ok) render(); return ok; }
     async function resume(id){ const ok=await setEnabled(id,true); if(ok) render(); return ok; }
     /* Honest, localized reasons for why a manual run couldn't start. The server
@@ -33519,7 +33627,7 @@ window.addEventListener('DOMContentLoaded', () => {
         row.querySelectorAll('.mon-ic').forEach(b=>{ b.onclick=async(e)=>{ e.stopPropagation(); const act=b.getAttribute('data-act');
           if(act==='pause'){ await pause(id); }
           else if(act==='resume'){ await resume(id); }
-          else if(act==='map'){ const m=byId[id]||await _get(id); if(m){ let pts=[]; try{ if(m.last_report_id){ const rep=await _report(m.last_report_id); if(rep&&rep.change_points) pts=rep.change_points; } }catch(_){} showOnMap({geometry:m.geometry,bbox:m.bbox},pts); _closeSheetIfMobile(); } }
+          else if(act==='map'){ const m=byId[id]||await _get(id); if(m){ let pts=[]; try{ if(m.last_report_id){ const rep=await _report(m.last_report_id); if(rep&&rep.change_points) pts=rep.change_points; } }catch(_){} showOnMap({geometry:m.geometry,bbox:m.bbox},pts,m.id); _closeSheetIfMobile(); } }
           else if(act==='run'){ b.disabled=true; b.textContent='…'; const r=await runNow(id); b.disabled=false; b.textContent='▶';
             if(r.ok){ _toast(ML('Monitor ran: ','実行しました: ','Ausgeführt: ','Запущено: ','Ejecutado: ')+statusLabel(r.status)); render(); }
             else if(r.error==='login'){ _promptLogin(); }
@@ -33567,7 +33675,7 @@ window.addEventListener('DOMContentLoaded', () => {
         const sensV=ov.querySelector('#mon-sens').value; const sensMap={low:{min_score:0.45,min_new:3},medium:{min_score:0.3,min_new:1},high:{min_score:0.18,min_new:1}};
         const res=await create({ name:ov.querySelector('#mon-name').value, area, sources, comparison:{mode:cmp,window_days:30}, intervalMin:intv, sensitivity:sensMap[sensV]||{} });
         if(res.ok){ ov.remove(); _toast(ML('Monitor created.','監視を作成しました。','Monitor erstellt.','Монитор создан.','Monitor creado.')); render();
-          try{ if(map){ showOnMap({geometry:res.monitor.geometry,bbox:res.monitor.bbox},[]); } }catch(_){} }
+          try{ if(map){ showOnMap({geometry:res.monitor.geometry,bbox:res.monitor.bbox},[],res.monitor.id); } }catch(_){} }
         else if(res.error==='login'){ _promptLogin(); }
         else { btn.disabled=false; btn.textContent=ML('Create monitor','監視を作成','Monitor erstellen','Создать','Crear monitor'); showErr(String(res.error||ML('Could not create the monitor.','監視を作成できませんでした。','Monitor konnte nicht erstellt werden.','Не удалось создать монитор.','No se pudo crear el monitor.'))); } };
     }
@@ -33599,7 +33707,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const ov=_overlay(inner,'mon-ov-detail');
       ov.querySelectorAll('.mon-detail-acts .mon-btn').forEach(b=>{ b.onclick=async()=>{ const d=b.getAttribute('data-d');
         if(d==='run'){ b.disabled=true; b.textContent='…'; const r=await runNow(id); if(r.ok){ _toast(ML('Ran: ','実行: ','Lauf: ','Запуск: ','Ejec.: ')+statusLabel(r.status)); ov.remove(); render(); setTimeout(()=>openDetail(id),400); } else if(r.error==='login'){ _promptLogin(); } else { b.disabled=false; _toast(r.message||_runReasonMsg(r.error)); } }
-        else if(d==='map'){ let pts=[]; try{ if(m.last_report_id){ const rep=await _report(m.last_report_id); if(rep&&rep.change_points) pts=rep.change_points; } }catch(_){} showOnMap({geometry:m.geometry,bbox:m.bbox},pts); ov.remove(); _closeSheetIfMobile(); }
+        else if(d==='map'){ let pts=[]; try{ if(m.last_report_id){ const rep=await _report(m.last_report_id); if(rep&&rep.change_points) pts=rep.change_points; } }catch(_){} showOnMap({geometry:m.geometry,bbox:m.bbox},pts,m.id); ov.remove(); _closeSheetIfMobile(); }
         else if(d==='pause'){ await pause(id); ov.remove(); }
         else if(d==='resume'){ await resume(id); ov.remove(); }
         else if(d==='del'){ if(confirm(ML('Delete this monitor and its history?','この監視と履歴を削除しますか？','Diesen Monitor löschen?','Удалить этот монитор?','¿Eliminar este monitor?'))){ await remove(id); ov.remove(); render(); } }
@@ -33637,9 +33745,9 @@ window.addEventListener('DOMContentLoaded', () => {
         +'<div class="mon-repfoot">'+S(ML('Generated','生成','Erstellt','Создано','Generado'))+': '+S(_fmtWhen(rep.created_at))+(rep.ai_model?' · '+S(rep.ai_model):'')+'</div>';
       const ov=_overlay(inner,'mon-ov-report');
       ov.querySelectorAll('.mon-evchip').forEach(ch=>{ ch.onclick=()=>{ const k=ch.getAttribute('data-ev'); const t=ov.querySelector('#mon-ev-'+CSS.escape(k)); if(t){ t.scrollIntoView({behavior:'smooth',block:'center'}); t.classList.add('mon-ev-hl'); setTimeout(()=>t.classList.remove('mon-ev-hl'),1500); } }; });
-      const rm=ov.querySelector('#mon-rep-map'); if(rm) rm.onclick=async()=>{ let area=null; try{ const m=await _get(rep.monitor_id); if(m) area={geometry:m.geometry,bbox:m.bbox}; }catch(_){} showOnMap(area,rep.change_points||[]); ov.remove(); _closeSheetIfMobile(); }; }
+      const rm=ov.querySelector('#mon-rep-map'); if(rm) rm.onclick=async()=>{ let area=null; try{ const m=await _get(rep.monitor_id); if(m) area={geometry:m.geometry,bbox:m.bbox}; }catch(_){} showOnMap(area,rep.change_points||[],rep.monitor_id); ov.remove(); _closeSheetIfMobile(); }; }
 
-    async function flyTo(id){ try{ const m=(typeof id==='object')?id:await _get(id); if(!m) return false; let pts=[]; try{ if(m.last_report_id){ const rep=await _report(m.last_report_id); if(rep&&rep.change_points) pts=rep.change_points; } }catch(_){} showOnMap({geometry:m.geometry,bbox:m.bbox},pts); return true; }catch(_){ return false; } }
+    async function flyTo(id){ try{ const m=(typeof id==='object')?id:await _get(id); if(!m) return false; let pts=[]; try{ if(m.last_report_id){ const rep=await _report(m.last_report_id); if(rep&&rep.change_points) pts=rep.change_points; } }catch(_){} showOnMap({geometry:m.geometry,bbox:m.bbox},pts,m.id); return true; }catch(_){ return false; } }
 
     /* (#R149) ROOT-CAUSE of "監視を作成を押しても何も起こらない": imToast/aiToast are closure-scoped functions
        (the app is NOT an ES module, so top-level fns are NOT on window). This guarded on `window.imToast` /

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test",
     "test:security": "node --test tests/security-logic.mjs",
     "test:monitor": "node --test tests/monitor-logic.test.mjs",
-    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs tests/r149-checks.test.mjs tests/r150-checks.test.mjs && playwright test",
+    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs tests/r149-checks.test.mjs tests/r150-checks.test.mjs tests/r151-checks.test.mjs && playwright test",
     "report": "playwright show-report"
   },
   "devDependencies": {

--- a/supabase/functions/ai-proxy/index.ts
+++ b/supabase/functions/ai-proxy/index.ts
@@ -596,7 +596,7 @@ Deno.serve(async (req) => {
     : (wantJson && payload.schema && typeof payload.schema === "object" ? payload.schema : undefined);
   const searchEnabled = (Deno.env.get("GEMINI_SEARCH_ENABLED") || "").toLowerCase() === "true";
   const model = Deno.env.get("AI_MODEL") ||
-    (provider === "openai" ? OPENAI_DEFAULT_MODEL : provider === "gemini" ? "gemini-3.5-flash" : "claude-3-5-haiku-latest");   /* (#R148) OpenAI default = GPT-5.6 Luna (Terra has no project access → 403) */
+    (provider === "openai" ? OPENAI_DEFAULT_MODEL : provider === "gemini" ? "gemini-3.5-flash" : "claude-3-5-haiku-latest");   /* (#R151) OpenAI default = GPT-5.6 Terra (AI_MODEL secret = gpt-5.6-terra; re-verified reachable R150/R151). Luna stays the FALLBACK_MODEL only on 403/404 model_not_found so a model outage can never blanket-kill Atlas. */
 
   try {
     let out: { text: string; finishReason: string; webAttached?: boolean; webUsed?: boolean; webCount?: number; citations?: WebCitation[] };

--- a/tests/r149-checks.test.mjs
+++ b/tests/r149-checks.test.mjs
@@ -49,7 +49,7 @@ test('R149 #4 Atlas typography: em-based heading hierarchy in mdMini', () => {
   assert.match(html, /font-size:1\.55em;letter-spacing:\.01em/, 'h1 ~1.55em');
   assert.match(html, /font-size:1\.32em;line-height:1\.3;letter-spacing:\.005em/, 'h2 ~1.32em');
   assert.match(html, /font-size:1\.14em;line-height:1\.32/, 'h3 ~1.14em');
-  assert.match(html, /'<div style="height:\.72em"><\/div>'/, 'paragraph gap ~0.72em (R150)');
+  assert.match(html, /'<div style="height:\.85em"><\/div>'/, 'paragraph gap ~0.85em (R151, was .72 in R150)');
   // prompts mandate the structure
   assert.match(html, /FORMAT FOR READABILITY — REQUIRED for any answer longer than/, 'answer prompt mandates structure');
 });

--- a/tests/r149.spec.js
+++ b/tests/r149.spec.js
@@ -35,11 +35,11 @@ test('#5/#6 Atlas send button ↑ is solid black when idle; stop square is enlar
   expect(r.bg).toBe('rgb(255, 255, 255)');     // white button
 });
 
-test('#3 Köppen legend ceiling is viewport-based — it stretches to the screen bottom (R150), last class reachable', async () => {
-  // (#R150) the fit no longer clamps to content height (that made "一番下まで伸ばせない"); it clamps to the viewport,
-  // so the resize grip can be dragged to ~12px above the screen bottom. When content exceeds the box, the inner
-  // .kl-scroll is the safety net — every class stays reachable by scrolling.
-  await page.setViewportSize({ width: 1280, height: 800 });
+test('#3 Köppen legend: short viewport clamps to the screen bottom, inner scroll reveals the rest (R151)', async () => {
+  // (#R151) the fit clamps to min(content, viewport). When the classes DON'T fit (short viewport) the box reaches
+  // ~12px above the screen bottom and the inner .kl-scroll is the safety net — every class stays reachable by
+  // scrolling. (The complementary tall-viewport "stop exactly at the content" case is covered in r150.spec.js #3.)
+  await page.setViewportSize({ width: 1280, height: 520 });
   const r = await page.evaluate(() => {
     const lg = document.getElementById('koppen-legend');
     if (!lg || typeof window._fitKoppenLegend !== 'function') return { err: 'no legend/fit' };
@@ -52,15 +52,18 @@ test('#3 Köppen legend ceiling is viewport-based — it stretches to the screen
     window._fitKoppenLegend(lg);
     lg.style.height = '4000px';   // simulate dragging the resize grip all the way down
     const rect = lg.getBoundingClientRect();
-    const sc = lg.querySelector('.kl-scroll'); sc.scrollTop = sc.scrollHeight;   // scroll the inner area to the end
+    const sc = lg.querySelector('.kl-scroll');
+    const innerHidden = sc.scrollHeight - sc.clientHeight;   // > 0 → content exceeds the box, inner scroll is needed
+    sc.scrollTop = sc.scrollHeight;   // scroll the inner area to the end
     const last = [...lg.querySelectorAll('.kl-item')].pop();
     const lr = last.getBoundingClientRect(), sr = sc.getBoundingClientRect();
-    return { bottomGap: Math.round(window.innerHeight - rect.bottom), lastReachable: lr.bottom <= sr.bottom + 2 };
+    return { bottomGap: Math.round(window.innerHeight - rect.bottom), innerHidden, lastReachable: lr.bottom <= sr.bottom + 2 };
   });
   expect(r.err).toBeUndefined();
   expect(r.bottomGap).toBeGreaterThanOrEqual(0);
-  expect(r.bottomGap).toBeLessThanOrEqual(26);   // reaches the screen bottom (was clamped ~200px short of it)
-  expect(r.lastReachable).toBe(true);            // the last climate class is reachable via the inner scroll
+  expect(r.bottomGap).toBeLessThanOrEqual(26);   // content exceeds the short viewport → the box reaches the screen bottom
+  expect(r.innerHidden).toBeGreaterThan(0);      // and the inner scroll is genuinely needed
+  expect(r.lastReachable).toBe(true);            // every climate class is still reachable via the inner scroll
 });
 
 test('#9 dropping an image into Atlas shows a thumbnail and enables Send', async () => {

--- a/tests/r150-checks.test.mjs
+++ b/tests/r150-checks.test.mjs
@@ -44,7 +44,7 @@ test('R150 #4 typography: flat prose gets code-side rhythm (stanza + sentence-en
   assert.match(html, /function _atlStanza\(raw\)\{/, 'stanza grouping helper exists');
   assert.match(html, /if\(\(raw\.match\(\/\\n\/g\)\|\|\[\]\)\.length>1\) return raw;/, 'respects the model\'s own line breaks');
   assert.match(html, /esc\(_dedupText\(_atlStanza\(String\(s\|\|''\)\)\)\)/, 'mdMini runs the stanza pass first');
-  assert.match(html, /\.replace\(\/\(\[\.!\?。！？…”"』）\)\]\)\\n\(\?=\\S\)\/g,'\$1<div style="height:\.5em"><\/div>'\)/, 'a sentence-end + single newline becomes a soft paragraph gap');
+  assert.match(html, /\.replace\(\/\(\[\.!\?。！？…”"』）\)\]\)\\n\(\?=\\S\)\/g,'\$1<div style="height:\.6em"><\/div>'\)/, 'a sentence-end + single newline becomes a soft paragraph gap');
 });
 
 test('R150 #10 research-mapping: PURE audit helpers exist and are exposed for tests', () => {
@@ -90,7 +90,7 @@ test('R150 #7 geo-target: ONE ambiguity gate; confirmation never co-displays wit
 
 test('R150 #8 satellite: flight-sim prefetches ahead of the aircraft + sat-labels host round-robin', () => {
   assert.match(html, /window\._imPredictivePrefetch=predictivePrefetch/, 'directional prefetch exposed for the flight loop');
-  assert.match(html, /if\(now-\(st\._pfT\|\|0\)>380\)\{ st\._pfT=now; try\{ window\._imPredictivePrefetch/, 'flight loop warms tiles ~2.6x/s (moveend never fires mid-flight)');
+  assert.match(html, /if\(now-\(st\._pfT\|\|0\)>300\)\{ st\._pfT=now; try\{ window\._imPredictivePrefetch&&window\._imPredictivePrefetch\(true\)/, 'flight loop warms tiles ~3.3x/s aggressively (moveend never fires mid-flight)');
   // sat-labels reference source now round-robins BOTH Esri hosts (was one)
   assert.match(html, /'sat-labels':\{type:'raster',tiles:\['https:\/\/server\.arcgisonline\.com[^']*','https:\/\/services\.arcgisonline\.com/, 'sat-labels uses two hosts');
 });

--- a/tests/r150.spec.js
+++ b/tests/r150.spec.js
@@ -94,7 +94,10 @@ test('#4 typography: a flat run-on wall is grouped into stanzas; structured text
   expect(r.mdHasGap).toBe(true);                    // rendered HTML has paragraph gaps
 });
 
-test('#3 Köppen legend can be dragged to the screen bottom (viewport-based ceiling)', async () => {
+test('#3 Köppen legend STOPS when all classes are shown (R151: clamp to content, no empty space)', async () => {
+  // (#R151) supersedes R150. The user asked that the legend "stop once every climate class is displayed" — it must
+  // NOT keep stretching into empty space past the last class. On a tall viewport the 30 zones fit, so the box stops at
+  // the content height (all shown, small gap below), rather than being dragged all the way to the screen bottom.
   await page.setViewportSize({ width: 1280, height: 900 });
   const r = await page.evaluate(() => {
     let lg = document.getElementById('koppen-legend');
@@ -104,15 +107,20 @@ test('#3 Köppen legend can be dragged to the screen bottom (viewport-based ceil
     const sc = lg.querySelector('.kl-scroll');
     for (let i = 0; i < 30; i++) { const d = document.createElement('div'); d.className = 'kl-item'; d.innerHTML = '<span class="kl-sw"></span>Zone ' + i; sc.appendChild(d); }
     window._fitKoppenLegend(lg);
-    lg.style.height = '4000px';   // simulate dragging the resize grip all the way down
+    lg.style.height = '4000px';   // try to drag the grip all the way down — it must NOT go past the content
+    // natural content height (every class), measured with the caps neutralised
+    const sh = lg.style.height, smh = lg.style.maxHeight;
+    lg.style.maxHeight = 'none'; lg.style.height = 'auto';
+    const natural = lg.getBoundingClientRect().height;
+    lg.style.height = sh; lg.style.maxHeight = smh;
     const rect = lg.getBoundingClientRect();
-    const bottomGap = window.innerHeight - rect.bottom;
+    const info = { boxH: Math.round(rect.height), natural: Math.round(natural), bottom: Math.round(rect.bottom), vh: window.innerHeight, innerHidden: sc.scrollHeight - sc.clientHeight };
     lg.remove();
-    return { bottomGap: Math.round(bottomGap) };
+    return info;
   });
-  // the box now stops ~12px above the screen bottom — it reaches the bottom instead of clamping short (~595px content)
-  expect(r.bottomGap).toBeGreaterThanOrEqual(0);
-  expect(r.bottomGap).toBeLessThanOrEqual(26);
+  expect(r.innerHidden).toBeLessThanOrEqual(2);                    // all 30 classes visible (nothing hidden by the inner scroll)
+  expect(r.bottom).toBeLessThanOrEqual(r.vh);                      // never past the screen bottom
+  expect(Math.abs(r.boxH - r.natural)).toBeLessThanOrEqual(12);    // box == content height → it stopped exactly at the last class
 });
 
 test('no uncaught page errors during R150 interactions', () => {

--- a/tests/r151-checks.test.mjs
+++ b/tests/r151-checks.test.mjs
@@ -1,0 +1,111 @@
+// R151 source-level regression checks (deterministic, no browser).
+// Guards the batch:
+//   #1  Companies UI parity — "Tap company rows to select and compare." empty hint (Countries parity)
+//   #2  Atlas toggle buttons — globe + compare join the on/off switch set
+//   #3  Köppen legend — stops when all classes shown (clamp to content) + stable row width (scrollbar-gutter)
+//   #4  Toolbar — Radius folded into the Measure menu; Screenshot + link folded into one Share menu
+//   #5  Atlas typography — a standalone **bold line** renders as a real sub-heading (model-independent hierarchy)
+//   #6  Monitor highlight cleared on delete (tracked _shownMonId)
+//   #7  Satellite — aggressive flight prefetch + tilted-move prefetch (3D keeps up)
+//   #8  Street View ON → coverage auto-shown (and turned back off on close)
+//   #9  Atlas model = GPT-5.6 Terra (ai-proxy default), Luna only as model-not-found fallback
+//   #10 Companies — batched multi-symbol quotes (spark) + full-history cache (deep history, low latency)
+//   #11 Atlas sources — SNS / UGC / shortener / video hosts dropped from source cards
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../', import.meta.url);
+const html = readFileSync(new URL('index.html', root), 'utf8');
+const aiproxy = readFileSync(new URL('supabase/functions/ai-proxy/index.ts', root), 'utf8');
+
+test('R151 #1 Companies compare shows the Countries-parity empty hint', () => {
+  // i18n key present in all five languages of the single i18n object
+  for (const v of ['Tap company rows to select and compare.', '行をタップして会社を選び比較',
+    'Unternehmenszeilen antippen zum Auswählen und Vergleichen.',
+    'Нажимайте на строки компаний, чтобы выбрать и сравнить.', 'Toca filas de empresas para elegir y comparar.']) {
+    assert.ok(html.includes(v), 'coCompareEmpty translation present: ' + v.slice(0, 24));
+  }
+  assert.match(html, /coCompareEmpty:/, 'coCompareEmpty key defined');
+  // renderCoCompareFixed now renders the empty hint instead of removing the tray
+  assert.match(html, /if\(!coCompareSet\.size\)\{ tray\.innerHTML=`<div class="scf-empty">\$\{t\('coCompareEmpty'\)\}<\/div>`; return; \}/, 'empty hint rendered');
+});
+
+test('R151 #2 Atlas on/off toggles gain globe + compare switches', () => {
+  assert.match(html, /globe:\{ lbl:\(\)=>L\('3D globe'/, 'globe feature toggle added');
+  assert.match(html, /compare:\{ lbl:\(\)=>L\('Compare panel'/, 'compare feature toggle added');
+  // projection + compare dispatch cases now append the toggle
+  assert.match(html, /L\('Globe','地球儀','Globus','Глобус','Globo'\)\)\)\+_featTogHtml\('globe'\)/, 'projection case offers the globe toggle');
+  assert.match(html, /_featTogHtml\('compare'\)/, 'compare case offers the compare toggle');
+});
+
+test('R151 #3 Köppen legend clamps to content (stops when all shown) + stable row width', () => {
+  // ceiling = min(viewport, natural content height) — no more stretching into empty space past the last class
+  assert.match(html, /const ceil=Math\.min\(renderedMax, Math\.ceil\(naturalBorderBox\)\);/, 'clamp to content OR viewport');
+  assert.match(html, /lg\.style\.maxHeight='none'; lg\.style\.height='auto';/, 'measures natural height with a temporary auto');
+  // scrollbar gutter reserved so the row text width is constant while resizing
+  assert.match(html, /\.koppen-legend \.kl-scroll\{[^}]*scrollbar-gutter:stable;/, 'scrollbar-gutter:stable on the inner scroll');
+});
+
+test('R151 #4 toolbar: Radius under Measure menu, Screenshot + link under one Share menu', () => {
+  // Radius button now lives INSIDE the measure dropdown
+  assert.match(html, /<div class="measure-dropdown" id="measure-dropdown">[\s\S]*?id="btn-tool-radius"[\s\S]*?<\/div>\s*<\/div>/, 'radius inside measure dropdown');
+  // a share menu container wraps the screenshot + share buttons
+  assert.match(html, /<div class="share-menu-container">/, 'share menu container exists');
+  assert.match(html, /id="btn-share-menu"/, 'share menu trigger exists');
+  assert.match(html, /<div class="share-dropdown" id="share-dropdown">[\s\S]*?id="btn-screenshot"[\s\S]*?id="btn-share"[\s\S]*?<\/div>/, 'screenshot + share inside the share dropdown');
+  // share menu wiring + i18n
+  assert.match(html, /window\._closeShareMenu=/, 'share menu close helper wired');
+  assert.match(html, /shareMenuBtn:"Share"/, 'Share menu label (EN)');
+  // the measure-menu trigger now reflects an active Radius too
+  assert.match(html, /toolMode==='radius'\|\|!!\(window\.DrawTool/, 'measure trigger reflects active radius');
+});
+
+test('R151 #5 Atlas typography: a standalone bold line becomes a real sub-heading', () => {
+  assert.match(html, /\.replace\(\/\^\\\*\\\*\(\[\^\*\\n\]\{2,90\}\)\\\*\\\*\[ \\t\]\*:\?\[ \\t\]\*\$\/gm/, 'standalone **bold line** → heading rule');
+  assert.match(html, /<div style="height:\.85em"><\/div>/, 'generous explicit-paragraph gap');
+});
+
+test('R151 #6 monitor highlight is cleared when the monitor is deleted', () => {
+  assert.match(html, /let _shownMonId=null;/, 'tracks which monitor area is painted');
+  assert.match(html, /function showOnMap\(area,points,monId\)\{ try\{ if\(!_ensureLayers\(\)\) return; _shownMonId=\(monId!=null\?monId:null\);/, 'showOnMap records the monitor id');
+  assert.match(html, /if\(!error && \(_shownMonId===id \|\| _shownMonId==null\)\) clearMap\(\);/, 'remove() clears the leftover highlight');
+});
+
+test('R151 #7 satellite: flight + tilted-move prefetch keeps 3D imagery ahead', () => {
+  assert.match(html, /function predictivePrefetch\(aggressive\)\{/, 'prefetch takes an aggressive flag');
+  assert.match(html, /const RING=aggressive\?7:3/, 'flight uses a deeper directional ring');
+  assert.match(html, /window\._imPredictivePrefetch\(true\)/, 'flight loop calls it aggressively');
+  assert.match(html, /if\(currentMapType!=='sat'\) return; const now=Date\.now\(\); if\(\(map\.getPitch\(\)\|\|0\)>25 && now-_movePfT>320\)\{ _movePfT=now; predictivePrefetch\(true\); \}/, 'tilted 3D drag warms tiles mid-move');
+});
+
+test('R151 #8 Street View ON auto-shows coverage (restored on close)', () => {
+  assert.match(html, /_covAuto=false/, 'auto-coverage flag declared');
+  assert.match(html, /if\(!_cov\)\{ try\{ coverage\(true\); _covAuto=true; \}catch\(_\)\{\} \}/, 'open() enables coverage when it was off');
+  assert.match(html, /if\(_covAuto\)\{ _covAuto=false; try\{ coverage\(false\); \}catch\(_\)\{\} \}/, 'close() restores coverage state');
+});
+
+test('R151 #9 Atlas model = GPT-5.6 Terra (Luna only as model-not-found fallback)', () => {
+  assert.match(aiproxy, /const OPENAI_DEFAULT_MODEL = "gpt-5\.6-terra";/, 'ai-proxy default = Terra');
+  assert.match(aiproxy, /const FALLBACK_MODEL = "gpt-5\.6-luna";/, 'Luna is the fallback');
+  assert.match(aiproxy, /model_not_found\|does not have access to model/, 'fallback only on model-not-found');
+});
+
+test('R151 #10 Companies: batched spark quotes + full-history cache', () => {
+  assert.match(html, /async function _spark\(syms, range, interval\)\{/, 'batched multi-symbol spark helper');
+  assert.match(html, /finance\/spark\?symbols='/, 'uses the keyless spark endpoint');
+  assert.match(html, /function _histAll\(\)\{/, 'full-history cache builder');
+  assert.match(html, /const sp=await _spark\(live\.map\(c=>c\.tk\),'1d','1d'\)/, 'loadPrices fast path uses one batched request');
+  assert.match(html, /let all=null; try\{ all=await _histAll\(\); \}catch\(_\)\{\} if\(my!==_hSeq\) return;/, 'setYear reads the year from the cache');
+});
+
+test('R151 #11 Atlas source cards drop SNS / UGC / shorteners / video hosts', () => {
+  assert.match(html, /function _atlBadSourceHost\(h\)\{/, 'bad-source-host predicate exists');
+  assert.match(html, /twitter\\\.com\|x\\\.com/, 'X/Twitter in the drop list');
+  assert.match(html, /youtube\\\.com\|youtu\\\.be/, 'YouTube in the drop list');
+  assert.match(html, /if\(_atlBadSourceHost\(host\)\) return;/, 'linkCards drops bad hosts');
+  // prompt reinforcement
+  assert.match(html, /NEVER cite social media, user-generated forums, link shorteners or video platforms/, 'analysis prompt forbids SNS sources');
+  // exposed for hermetic tests
+  assert.match(html, /badSourceHost:function\(h\)\{/, 'exposed on IntMapAtlasDebug');
+});

--- a/tests/r151.spec.js
+++ b/tests/r151.spec.js
@@ -1,0 +1,118 @@
+// R151 runtime regression tests — verify behavior through the real page (hermetic, no network).
+//   #3  Köppen row width stays constant while the legend is resized (scrollbar-gutter reserved)
+//   #4  toolbar consolidation: Radius lives in the Measure menu; Screenshot + link in one Share menu
+//   #8  Street View open() auto-shows coverage; close() restores it
+//   #10 Companies batched spark helper + full-history cache exist on the module surface
+//   #11 Atlas source cards drop SNS / UGC / shortener / video hosts (IntMapAtlasDebug.linkCards)
+import { test, expect } from '@playwright/test';
+import { installHermeticRouting, collectPageDiagnostics } from './helpers/network.js';
+
+const CRITICAL = ['IntMapConsole', 'IntMapAtlasDebug', 'IntMapStreetView'];
+test.describe.configure({ mode: 'serial' });
+
+let page, diag;
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext();
+  await installHermeticRouting(context);
+  page = await context.newPage();
+  diag = collectPageDiagnostics(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 45_000 });
+  await page.waitForFunction((g) => g.every((k) => typeof window[k] !== 'undefined'), CRITICAL, { timeout: 45_000 });
+  await page.waitForTimeout(600);
+});
+test.afterAll(async () => { await page?.context()?.close(); });
+
+test('#3 Köppen climate-name row width is constant across a resize (scrollbar gutter reserved)', async () => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const r = await page.evaluate(() => {
+    let lg = document.getElementById('koppen-legend');
+    if (!lg) { lg = document.createElement('div'); lg.id = 'koppen-legend'; lg.className = 'koppen-legend'; document.body.appendChild(lg); }
+    lg.innerHTML = '<h4>K</h4><div class="kl-scroll"></div><div class="kl-hint">h</div>';
+    lg.style.display = 'flex'; lg.style.top = '74px'; lg.style.height = ''; lg.style.maxHeight = '';
+    const sc = lg.querySelector('.kl-scroll');
+    const mk = (n) => { sc.innerHTML = ''; for (let i = 0; i < n; i++) { const d = document.createElement('div'); d.className = 'kl-item'; d.innerHTML = '<span class="kl-sw"></span>Zone ' + i; sc.appendChild(d); } };
+    // few rows: no inner scrollbar needed
+    mk(3); window._fitKoppenLegend(lg);
+    const rowFew = sc.querySelector('.kl-item').getBoundingClientRect().width;
+    // many rows: inner scroll active — with scrollbar-gutter:stable the row content width must NOT shift
+    mk(40); lg.style.height = '300px'; window._fitKoppenLegend(lg);
+    const rowMany = sc.querySelector('.kl-item').getBoundingClientRect().width;
+    const gutter = getComputedStyle(sc).scrollbarGutter;
+    lg.remove();
+    return { rowFew: Math.round(rowFew), rowMany: Math.round(rowMany), gutter };
+  });
+  expect(r.gutter).toContain('stable');
+  expect(Math.abs(r.rowFew - r.rowMany)).toBeLessThanOrEqual(1);   // row width unchanged whether or not the scrollbar shows
+});
+
+test('#4 toolbar: Radius is inside the Measure menu; Screenshot + link are inside the Share menu', async () => {
+  const r = await page.evaluate(() => {
+    const inMeasure = !!document.querySelector('#measure-dropdown #btn-tool-radius');
+    const shareMenu = !!document.getElementById('btn-share-menu');
+    const shotInShare = !!document.querySelector('#share-dropdown #btn-screenshot');
+    const linkInShare = !!document.querySelector('#share-dropdown #btn-share');
+    return { inMeasure, shareMenu, shotInShare, linkInShare };
+  });
+  expect(r.inMeasure).toBe(true);
+  expect(r.shareMenu).toBe(true);
+  expect(r.shotInShare).toBe(true);
+  expect(r.linkInShare).toBe(true);
+});
+
+test('#8 opening Street View auto-shows coverage; closing restores it', async () => {
+  const r = await page.evaluate(async () => {
+    const SV = window.IntMapStreetView;
+    if (!SV || !SV.coverage || !SV.open || !SV.coverageOn) return { module: false };
+    SV.coverage(false);                       // start OFF
+    const before = SV.coverageOn();
+    SV.open({ lng: -73.9857, lat: 40.7580 }); // opening a panorama should turn coverage ON
+    const during = SV.coverageOn();
+    SV.close();                               // closing restores (it was auto-enabled → back OFF)
+    const after = SV.coverageOn();
+    return { module: true, before, during, after };
+  });
+  expect(r.module).toBe(true);
+  expect(r.before).toBe(false);
+  expect(r.during).toBe(true);    // coverage auto-shown while SV is open
+  expect(r.after).toBe(false);    // auto-coverage removed on close (manual state preserved)
+});
+
+test('#10 Companies module exposes batched history/price plumbing', async () => {
+  const r = await page.evaluate(() => {
+    const C = window.IntMapCompanies;
+    if (!C) return { module: false };
+    return { module: true, hasLoadPrices: typeof C.loadPrices === 'function', hasSetYear: typeof C.setYear === 'function', hasSeries: typeof C.priceSeries === 'function', dataLen: (C.DATA || []).length };
+  });
+  expect(r.module).toBe(true);
+  expect(r.hasLoadPrices).toBe(true);
+  expect(r.hasSetYear).toBe(true);
+  expect(r.hasSeries).toBe(true);
+  expect(r.dataLen).toBeGreaterThan(100);
+});
+
+test('#11 Atlas source cards drop SNS / video / shortener hosts but keep reputable ones', async () => {
+  const r = await page.evaluate(() => {
+    const D = window.IntMapAtlasDebug;
+    if (!D || !D.linkCards || !D.badSourceHost) return { api: false };
+    const bad = ['twitter.com', 'x.com', 'www.facebook.com', 'youtube.com', 'youtu.be', 'reddit.com', 't.me', 'bit.ly'].map(h => D.badSourceHost(h));
+    const good = ['reuters.com', 'www.bbc.com', 'nasa.gov', 'un.org', 'en.wikipedia.org'].map(h => D.badSourceHost(h));
+    const html = D.linkCards([
+      { url: 'https://twitter.com/someone/status/1', title: 'a tweet' },
+      { url: 'https://www.youtube.com/watch?v=x', title: 'a video' },
+      { url: 'https://www.reuters.com/world/article', title: 'real report' },
+      { url: 'https://www.bbc.com/news/article', title: 'bbc report' },
+    ]);
+    return { api: true, bad, good, html };
+  });
+  expect(r.api).toBe(true);
+  expect(r.bad.every(Boolean)).toBe(true);       // every SNS/video/shortener host flagged
+  expect(r.good.some(Boolean)).toBe(false);      // no reputable/official host flagged
+  expect(r.html).toContain('reuters.com');
+  expect(r.html).toContain('bbc.com');
+  expect(r.html).not.toContain('twitter.com');
+  expect(r.html).not.toContain('youtube.com');
+});
+
+test('no uncaught page errors during R151 interactions', () => {
+  expect(diag.pageErrors, 'pageerror list should be empty: ' + JSON.stringify(diag.pageErrors)).toHaveLength(0);
+});


### PR DESCRIPTION
User-reported batch of **11 items**, fixed from root cause. Single `index.html` (build-less) + `ai-proxy` comment (redeployed) + 2 new test files.

## Items
1. **Companies parity** — Countries-style empty compare hint "Tap company rows to select and compare." (`coCompareEmpty`, 5 langs; rows already tap-to-compare).
2. **Atlas toggles** — add **globe** (3D-globe on/off) + **compare** switches to the on/off toggle set (projection/compare dispatch now offer `_featTogHtml`).
3. **Köppen legend** — **stop when all classes are shown**: clamp to `min(content, viewport)` (measures natural height with a temporary auto) so it no longer stretches into empty space past the last class; `.kl-scroll { scrollbar-gutter: stable }` keeps the climate-name **row width constant** while resizing (scrollbar appear/disappear was reflowing rows). *Supersedes R150's viewport-based ceiling; r149/r150 Köppen #3 tests updated to the new two-behavior contract (short vp → reach bottom + inner scroll; tall vp → stop at content).*
4. **Toolbar consolidation** (normal mode) — Radius folded into the **Measure** menu (Distance/area · Draw · Radius); Screenshot + link folded into one **Share** menu. Button ids preserved → existing handlers + mobile proxies unchanged.
5. **Atlas typography** — mdMini renders a **standalone `**bold line**` as a real sub-heading** (models reach for bold far more than `##` → model-independent hierarchy) + more paragraph spacing. Answer/analysis prompts already mandate `##`/bold/bullets structure.
6. **Monitor highlight** — deleting a monitor now **clears its leftover area highlight** (tracks `_shownMonId`; `remove()` clears the map).
7. **Satellite 2D/3D speed** — flight prefetch is now **aggressive** (directional ring 3→7, oblique-horizon warming, ~3.3×/s) and manual **3D pan/rotate warms tiles on every `move` while tilted** (moveend never fires mid-drag). Existing multi-host / big-cache / fade-0 / native-max-zoom optimizations kept.
8. **Street View** — opening a panorama **auto-shows Google's real coverage** (the light-blue lines); closing restores prior state (`_covAuto`).
9. **Atlas model = GPT-5.6 Terra** — confirmed live in prod: `AI_MODEL` secret + `OPENAI_DEFAULT_MODEL="gpt-5.6-terra"`, Luna only on `model_not_found`. Verified end-to-end via `current_news.analyzed_by='ai' = 354` (refresh-news cron calls Terra directly with **no fallback** → ai>0 proves reachability).
10. **Companies history + prices** — **batched Yahoo `spark`** quotes (~40 symbols/request → low latency) with per-symbol fallback; **one-time full-history cache** (`spark range=max 1mo` → `{tk:{year:close}}`) so the time machine reads any past year instantly with per-year fallback. Deep history back to Yahoo's earliest.
11. **Atlas sources** — `_atlBadSourceHost` drops **SNS / UGC / URL-shorteners / video hosts** (X, Facebook, Reddit, YouTube, t.me, bit.ly…) from every source-card path (`linkCards`); `_analysisSystemPrompt` reinforced to never cite social/forums/shorteners/video and require each URL to directly support a claim.

## Tests
`npm test` green: static checks + **node 79** (security/monitor/r147/r149/r150 + new **r151-checks 11**) + **Playwright 80** (new **r151.spec 6**; r149/r150 Köppen #3 rewritten to the R151 contract; exact-string asserts updated for `.85em`/prefetch cadence), **pageerror 0**. Local runtime measured on the Browser pane (port 4188): stop-at-content, stable row width, SV coverage auto-show, toggles, source filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)