### PR TITLE
R160: sidebar no-move (overlay) + width 300 + settings-reopen fix + MapLibre reduction (Phase 2)

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -172,10 +172,13 @@ IntMap は、世界のニュース・気候・人口・経済・地政学デー�
     蓄積禁止）。全世界の全湖沼・全山岳が対象。診断: `window._imLabelStats()`。
     ③**ティッカーは真のインフロー帯** — `position:fixed`廃止→`.operation-room`直後の**通常フロー要素**（不透明
     `--bg-color`、30px）。表示倍率やdvh差異でも地図に重なり得ない。
-    ④**右レイヤーサイドバー＝左と同じ展開式** — fixedオーバーレイ廃止→`.operation-room`の**フレックス子**
-    （`margin-right`トランジション＝左サイドバーの鏡像、`--lsr-w`）。開くと**地図が縮む**。検索・プレビュー・
-    Active layers維持。（バグ修正: `.lsr-thumb`スパンが名前抽出querySelectorに先に一致し、右モードでActive layers
-    チップ名が全て空になっていた → 全抽出箇所に `:not(.lsr-thumb)`）
+    ④**右レイヤーサイドバー** — 検索・プレビュー・Active layers維持。（バグ修正: `.lsr-thumb`スパンが名前抽出
+    querySelectorに先に一致し、右モードでActive layersチップ名が全て空になっていた → 全抽出箇所に `:not(.lsr-thumb)`）
+    **※#R160 更新**: かつては `margin-right` で地図を縮めていた（「開くと地図が縮む」）が、**開閉で地図が動く**問題の
+    構造的根治として、左右どちらのサイドバーも**固定フル幅の地図に重なるオーバーレイ**へ変更（`@media(min-width:769px)
+    { body:not(.ws-mode) .map-container{position:absolute;inset:0;width:100%} + .sidebar{position:absolute} }`）。
+    地図コンテナは開閉で一切リサイズ・移動しない＝再センタリングが構造的に起きない。右アンカーHUDは `body.lsr-open`
+    時に `right:calc(var(--lsr-w)+…)` でパネル幅ぶん左へ退避。既定幅 `--lsr-w` は 340→**300**（#R160）。
     ⑤**Active layersは最上部** — sticky **top** の先頭要素（クラシック/右サイドバー/モバイルシート共通）。チップは
     **固定高1行の横スクロール**で、R32の「1pxも動かない」保証は高さ不変で維持（空でも"(0)"で常時表示）。5言語化。
     ⑥**POI全域網羅＋根拠明示** — 地名が実OSM行政リレーションに解決されたら **Overpassエリアクエリ**
@@ -1043,16 +1046,16 @@ supabase/
 
 ## #R152 補足（UX/機能バッチ13件＋**地図エンジン抽象層 第1段階**）
 
-### §7.1 `IntMapGeoEngine` — レンダラー抽象層（業務委託・第1段階）
+### §7.1 `IntMapGeoEngine` — レンダラー抽象層（業務委託・第1段階＝#R152 / 第2段階＝#R160）
 `window.__imap=map` の直後（`map.on('load')` 内）に定義する**薄い facade**。目的＝将来 Google-Earth 級 Earth Mode を差し込めるよう MapLibre 依存を隔離すること。**純粋 additive・挙動/性能/モバイル完全同一**。
 
 - **構造**: `IntMapGeoEngine`（facade）→ `_adapter`（現状 `MapLibreAdapter` のみ）。`MapLibreAdapter` は全メソッドが現行 `map` への 1:1 委譲。`use(adapter)` で将来別レンダラーに差替。`capabilities()`／`contracts()`／`can(feat)`。`raw()`＝MapLibre 実体を返すエスケープハッチ（未一般化コード用）。
-- **抽象済み（安全に共通化した処理のみ）**: `camera`（flyTo/easeTo/jumpTo/fitBounds/setPadding/get/setProjection）・`coords`（project/unproject/terrainElevation/queryRenderedFeatures）・`layers`（addSource/setSourceData/removeSource/add/remove/setVisible/isVisible/setPaint/setLayout/**setOpacity**＝レイヤ型からopacity paint名を解決）・`events`（on/off/once）。
+- **抽象済み（安全に共通化した処理のみ）**: `camera`（flyTo/easeTo/jumpTo/fitBounds/setPadding/get/setProjection＋**#R160**: getZoom/getCenter/getBearing/getPitch/getBounds/zoomTo/zoomIn/zoomOut/stop）・`coords`（project/unproject/terrainElevation/queryRenderedFeatures）・`layers`（addSource/setSourceData/removeSource/add/remove/setVisible/isVisible/setPaint/setLayout/**setOpacity**＝レイヤ型からopacity paint名を解決＋**#R160**: setFeatureState/removeFeatureState）・**`render`（#R160: resize/triggerRepaint/canvas）**・`events`（on/off/once）。
 - **Cesium**: `CESIUM_CONTRACT`＝capabilities 宣言のみ（`implemented:false`）。**SDK・API キーは未導入**。将来は Cesium 版 Adapter を実装し `use()` するだけ。
-- **Atlas 配線**: アクション形式は不変。実行部のみ抽象層経由の実証として **`pitch`/`bearing` の `easeTo` を `IntMapGeoEngine.camera.easeTo` へ**通す。
-- **未対応（次段階の移行対象）**: `addSource`≈343・`addLayer`≈426・`setPaint/LayoutProperty`≈120 の**大量呼出は段階移行**（一括書換えは禁止）。`queryTerrainElevation`／`setSky`／`setTerrain`／`setMaxPitch`／3D地形など **MapLibre 固有機能は当面 `raw()` 経由**（無理に一般化しない）。副次地図（gmap/cmap/minimap）も現状は直接。
-- **次にやること**: ①新規の共通機能は必ず `IntMapGeoEngine` 経由にする（`map` 直呼び禁止の徐々な徹底）、②pin/marker と GeoJSON ヘルパ（addChoro/addRaster）を engine へ、③別レンダラーの capabilities で分岐する UI（Earth Mode トグル）、④Cesium Adapter の骨子。
-- **検証**: 契約テスト＝`tests/r152-checks.test.mjs`（facade/adapter/contract/camera 配線の存在）＋既存スモーク（`smoke.spec` の 7 critical globals＋#map で全体ブートを担保）。
+- **Atlas 配線**: アクション形式は不変。実行部のみ抽象層経由の実証として **Atlas カメラ制御 3ケース（`zoom`/`bearing`/`pitch`）を `const GE=IntMapGeoEngine.camera` で読み取りも駆動もエンジン経由へ**（#R152 で `pitch`/`bearing` の easeTo、#R160 で getter＋`zoom` ケースを追加）。複雑な `flyTo` ケースは誤移行リスクのため据え置き（将来段階）。
+- **未対応（次段階の移行対象）**: `addSource`≈343・`addLayer`≈426・`setPaint/LayoutProperty`≈120・`flyTo`/`fitBounds` の**大量呼出は段階移行**（一括書換えは禁止）。`queryTerrainElevation`／`setSky`／`setTerrain`／`setMaxPitch`／3D地形など **MapLibre 固有機能は当面 `raw()` 経由**（無理に一般化しない）。副次地図（gmap/cmap/minimap）も現状は直接。
+- **次にやること**: ①新規の共通機能は必ず `IntMapGeoEngine` 経由にする（`map` 直呼び禁止の徐々な徹底）、②pin/marker と GeoJSON ヘルパ（addChoro/addRaster）を engine へ、③`flyTo`/`fitBounds` 系ディスパッチの移行、④別レンダラーの capabilities で分岐する UI（Earth Mode トグル）、⑤Cesium Adapter の骨子。
+- **検証**: 契約テスト＝`tests/r152-checks.test.mjs`＋`tests/r160-checks.test.mjs`（facade/adapter/contract/拡幅契約/camera 配線の存在）＋既存スモーク（`smoke.spec` の critical globals＋#map で全体ブートを担保）。
 
 ### その他12件（要点）
 ①ケッペン**行折返し撲滅で単一行化**（真因は自然高777px・14行折返し／`_fitKoppenLegend`無変更）。②Companies を静的下端オーバーレイ ドックで**Countries完全同一化**。③Atlasタイポ＝フラット文の先頭文をリード太字へ昇格＋見出し拡大。④出典＝ブロックリスト拡張＋`_atlRelevantCards` 関連度ゲート＋未引用を「関連記事」表記。⑤トグル＝全画面＋汎用control。⑥衛星＝**実測(curl)で Esri z19 が keyless 上限**（z20は東京すら灰色2521B）→画質のコード変更なし。⑦SV線細く（glow paint撤去）。⑨Measure/Share 不透過（card-bg）。⑩方位磁針 右クリック数値入力。⑪フライトシム 海面フロア(countryGeo判別)＋水面 fill。⑫等高線 密度スライダー（凡例内）。⑧Companies 月次高精度＋歴史floor 1962。

--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -5,6 +5,33 @@
 
 ---
 
+## R160 — サイドバー無移動の構造的修正＋幅縮小＋設定バグ／MapLibre依存軽減の続き：**左右どちらのサイドバーを開閉しても地図は絶対に動かない（両サイドバーを固定フル幅の地図に「かぶせる」オーバーレイへ再設計・R158/R159の毎フレームresize＋エッジアンカー機構は全削除）／右サイドバー既定幅をさらに縮小（340→300）／設定変更で右サイドバーが勝手に開く不具合の修正／IntMapGeoEngine（レンダラ抽象）Phase 2＝カメラgetter・ズーム操作・renderサーフェス・feature-stateを契約へ追加しAtlasカメラ制御（zoom/bearing/pitch）をエンジン経由へ移行** (tag `#R160`)
+
+**背景（業務委託・4件＋継続1件）**: (1) 右サイドバー既定幅をもう少し小さく、(2) **左サイドバーを開閉すると地図が勝手に動く**（「余計な事をするな」）、(3) **右サイドバーの開閉で地図領域の位置が動く**（同）、(4) **設定を変更すると勝手に右サイドバーが出てくる**、(5) 以前のMapLibre依存軽減作業の続き。※(2)(3)はR158/R159で二度修正を試みたが未解決の再々報告＝設計から見直す。
+
+### ① 真因＝「横並び（beside）」レイアウトが地図コンテナをリサイズする限り、MapLibreは必ず再センタリングする（`#sidebar`／`applySidebarStyle`／`_sbBeginAnim`）
+デスクトップ**クラシックモード**（ws-mode off・既定スタイル`opaque`＝solid）では、左`#sidebar`は**フレックスの実兄弟**（`flex-shrink:0`）で、折りたたむと`#map-container`（`flex:1`）が伸縮→`map.resize()`が地図中心をコンテナ中央へ再配置＝**地図が横に飛ぶ**。右サイドバーも`body.lsr-open .map-container{margin-right:var(--lsr-w)}`で地図を押し縮め→同様に再センタリング。R158（transitionendで1回resize）もR159（毎フレームrAF resize＋静止エッジを`panBy`で再ピンする`_sbCaptureAnchor`/`_sbReanchor`）も、この「リサイズ→再センタリング」を**補正で打ち消そうとする**アプローチで、GLバッファ再確保と`panBy`が毎フレーム競合して「きもい」動き＝**まさに『余計な事』**。**リサイズしなければ再センタリングも起きない**＝構造的に解決するには地図コンテナを固定するしかない。
+
+### ② 構造修正＝両サイドバーを固定フル幅の地図に「かぶせる」オーバーレイへ（`@media(min-width:769px){ body:not(.ws-mode) … }`）
+- **左サイドバー**: フロスト（`sidebar-glass`）モードが既に採用済みだったオーバーレイ（`.map-container{position:absolute;inset:0;width:100%}`＋`.sidebar{position:absolute;left:0;…}`）を、**glass限定を外して全クラシックデスクトップ（solid含む）へ一般化**。地図は常にフル幅の背景、サイドバーは`transform`スライドで上に乗るだけ＝**折りたたみは覆っていた帯を『あらわにする』のみで、既存の地図表示は一切動かない**。
+- **右サイドバー**: `margin-right`押し出し（desktop）を**撤去**（モバイルは元からオーバーレイ）＝`open()`/`close()`/リサイザの`mc.style.marginRight`書込みも撤去。既に`position:absolute`＋`transform`スライドなので、地図はフル幅のまま。
+- **HUDの追随**: フル幅化で右アンカーHUD（`.map-controls-top`/`#tool-panel`/`#sat-controller`/`.news-timeline`）がパネル裏に隠れるため、`body.lsr-open`時に`right:calc(var(--lsr-w)+…)`で左へスライド（`.38s`トランジション付き）。左アンカーHUD（`coord-readout`/凡例/`country-info`）のズラしは既存のglass限定ルールを`body:not(.ws-mode)`へ一般化。`ms-narrow`検索ピルの左境界も`sidebar-glass`判定から「オーバーレイ中の`.sidebar`（`position:absolute`かつ非collapsed）」判定へ一般化。
+- **カメラ非駆動**: `applySidebarStyle`の`setPadding`/`easeTo`光学中心シフトを**全撤去**（マテリアルクラスのトグルのみ残す・古いbuild由来の残留paddingを1度だけ0へ戻す安全網付き）。トグルハンドラは`collapsed`反転＋`applySidebarStyle(false)`＋`intmap-sidebar-resize`発火（`ms-narrow`再計算用）だけ＝**カメラもリサイズも一切触らない**。
+- **機構の削除**: `_sbBeginAnim`/`_sbReanchor`/`_sbCaptureAnchor`/`_sbFrame`/`_sbFinishAnim`/`_sbStopLoop`と関連stateを全削除。`_sbBeginAnim`だけは後方互換シム（コールバック発火＋genuine resizeのcoalesce）として残置。`coalescedResize`は本物のウィンドウ／コンテナリサイズ専用（`_rsRAF`）へ。ニュース記事リーダーからの左サイドバー強制オープンもアンカー廃止で単純化。
+- **検証（実Chromium）**: 左右いずれのトグルでも`#map-container`の矩形は`[0,winW]`のまま**不変**（幅・左端の変化<2px）、固定geo点のスクリーン位置ドリフト<6px＝**地図はピクセル単位で不動**。既定ビューは`center:[10,20],zoom:1.7`（全球）なのでフル幅化による初期フレーミング差は無視できる。
+
+### ③ 右サイドバー既定幅 340→300（`--lsr-w`）
+CSS `:root{--lsr-w:min(300px,92vw)}`＋`open()`の既定キャップ`Math.min(300,…)`（floor 280・ドラッグ幅`intmap_lsr_w`永続は無改変）。オーバーレイ化で「地図の可視幅≥320px」計算の左サイドバー幅減算が`position!=='absolute'`ガードで無効化されていた点も修正（左サイドバーは常にabsoluteになったので、開いていれば常に幅を減算＝両オーバーレイ間で可視地図≥320px維持）。
+
+### ④ 設定変更で右サイドバーが勝手に開く不具合（設定Apply・`IntMapLayerSidebar.apply()`）
+**真因**: 設定保存（`btn-close-settings`）が**毎回無条件に**`IntMapLayerSidebar.apply()`を呼び、`apply()`は`imLayerPanel==='right'`なら`if(!isMob()) open()`で**常に右サイドバーを開く**＝テーマや単位など無関係な設定を変えるたび、ユーザーが閉じた右サイドバーが再オープン。**修正**: Apply時に旧`imLayerPanel`を退避し、**モードが実際に変わったときだけ**`apply()`を呼ぶ（`right`→`classic`／`classic`→`right`の正当な切替は従来どおり反映・無変更なら開閉状態をユーザーのまま維持）。
+
+### ⑤ MapLibre依存軽減の続き（IntMapGeoEngine Phase 2・委託#5）
+R152で骨格（facade＋`MapLibreAdapter`）は作ったが実採用は2箇所のみだった。**Phase 2＝契約の拡幅＋自己完結サブシステムの移行**: (a) アダプタ/facadeへ**カメラgetter**（`getZoom/getCenter/getBearing/getPitch/getBounds`）・**ズーム操作**（`zoomTo/zoomIn/zoomOut/stop`）・**renderサーフェス**（`resize/triggerRepaint/canvas`）・**feature-state**（`set/removeFeatureState`）を追加（各1:1パススルー＝挙動バイト同一・将来のCesium/Earthアダプタはこれらを実装するだけ）。(b) Atlasディスパッチの**カメラ制御3ケース**（`zoom`/`bearing`/`pitch`）を`const GE=IntMapGeoEngine.camera`で**読み取りも駆動もエンジン経由**へ移行（`bearing/pitch`のeaseToはR152で移行済み＝getterも移行して完結、`zoom`は新規）。`flyTo`ケースは分岐が複雑で誤移行リスクが高いため今回は据え置き（将来Phase）。
+
+### テスト/CI/デプロイ
+`index.html`＋テストのみ変更（**Edge Function 変更なし＝デプロイ不要**／GitHub Pagesはmerge時に自動反映）。新規 `tests/r160-checks.test.mjs`（source 10：幅300・両オーバーレイ・機構削除・トグル最小化・applySidebarStyle非カメラ化・右push撤去＋HUDズラし・左HUD一般化＋ms-narrow・設定ガード・エンジン契約拡幅・カメラディスパッチ移行）＋ `tests/r160.spec.js`（Playwright 3：右サイドバー無移動・右HUDスライド・設定で再オープンしない）。既存 `tests/r159.spec.js #4` を「オーバーレイでコンテナ不変＋geo点ピクセル固定」へ書き換え、自変更で壊れた **r152 #13・r154 #9・r158 #10・r159 #3/#4** の exact-string assert を新挙動へ更新。`npm test` 緑：static＋node **162**＋Playwright **100**（CI条件 workers=2/retries=2）。**罠（R152/R154/R158/R159 と同一）**: (a) 文字列変更で旧 exact-string assert が壊れる→全掃引して現挙動へ更新。(b) **ヘッドレスBrowserペインは`document.hidden`でCSSトランジションが凍結**＝右HUDの`right`が遷移開始値（10px）のまま読める→`transition:none`注入で確定値を、動作の真偽は実Chromium（Playwright）で検証。(c) デスクトップ既定は本来ws-modeだが、ペインでのws-mode初期化は非同期でタイミング依存＝ペインの中間状態は環境要因（実ブラウザのsmokeは0 pageerrorでブート確認済）。両オーバーレイ規則は`body:not(.ws-mode)`＋`@media(min-width:769px)`スコープでws-mode（`!important`上書き）とモバイル（別`@media`）を構造的に除外。
+
 ## R159 — UX/Atlasバッチ（6件）：**Atlas返答から太字と区切り横線を撤去／「その他の収集記事」欄の削除（never-zeroフォールバックは保持）／右サイドバー既定幅を縮小（380→340）／サイドバー開閉を滑らかに＋左サイドバーで地図を動かさない（エッジアンカー）／ニュースピン帯のホバーでポップアップ表示時に帯を隠す／Atlas複合調査回答の統合（修復は追記でなく置換・目的単位で最良の1回答だけを確定表示・地図失敗と分析失敗の分離・内部処理名/コード/repair回数を非露出）** (tag `#R159`)
 
 **背景（6件）**: (1) Atlas返答テキストの太字と区切りの横線が不要、(2) Atlasの「その他の収集記事」欄が完全に不要、(3) 右サイドバー既定幅をもう少し小さく、(4) 左右サイドバー開閉の動きが「きもい」＋左サイドバーで地図位置を勝手に変えない、(6) ニュースピンの帯をホバーしてポップアップが出るとき帯が消えない、(7) Atlas複合調査回答で「最初の分析」と「修復後の分析」が同一メッセージへ連続追加され互いに矛盾した結果が同時表示される。※(5) MapLibre依存軽減・(8) Atlas無劣化高速化は別バッチ。

--- a/index.html
+++ b/index.html
@@ -1890,14 +1890,17 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
 
     /* ---- Sidebar material (matches the floating surfaces above) ---- */
     .sidebar{ background-color:var(--glass-fill); backdrop-filter:saturate(var(--glass-sat)) blur(var(--glass-blur)); -webkit-backdrop-filter:saturate(var(--glass-sat)) blur(var(--glass-blur)); }
-    /* Desktop: SOLID keeps the sidebar in normal flex flow (map centerd beside it, no shift).
-       A FROSTED mode overlays the sidebar on the map so the glass actually has the map behind it
-       to blur (#23); the map keeps its optical center via JS padding (applySidebarStyle). */
+    /* (#R160) Desktop classic mode ALWAYS overlays the sidebar on a FULL-WIDTH map — in BOTH the solid and
+       frosted styles — so opening/closing the sidebar can NEVER resize or recentre the map. The map is a fixed
+       full-bleed backdrop; the sidebar simply slides over it (opaque hides the strip it covers, frosted blurs
+       the map behind it #23). Collapsing REVEALS the covered strip rather than shifting the whole view, so the
+       existing map content never moves ("左サイドバーを開閉すると地図が勝手に動いてしまう" の根絶). There is NO
+       per-frame resize / camera reanchor / optical-padding on toggle anymore — that machinery is deleted.
+       ws-mode (each panel is its own window) keeps its own !important layout and is excluded. */
     @media(min-width:769px){
-      .sidebar{ position:relative; }
-      body.sidebar-glass .map-container{ position:absolute; inset:0; width:100%; }
-      body.sidebar-glass .sidebar{ position:absolute; left:0; top:0; bottom:0; height:100%; z-index:1000; box-shadow:8px 0 32px rgba(0,0,0,0.10); }
-      body.sidebar-glass .sidebar.collapsed{ margin-left:calc(-1 * var(--sidebar-w)); }
+      body:not(.ws-mode) .map-container{ position:absolute; inset:0; width:100%; }
+      body:not(.ws-mode) .sidebar{ position:absolute; left:0; top:0; bottom:0; height:100%; z-index:1000; box-shadow:8px 0 32px rgba(0,0,0,0.10); }
+      body:not(.ws-mode) .sidebar.collapsed{ margin-left:calc(-1 * var(--sidebar-w)); }
     }
 
     /* --- Timebar (news-timeline) redesign + glass, aligned with Summarize button (#9,#22,#24) --- */
@@ -1927,14 +1930,29 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
        sidebar when the sidebar overlays the map (frosted mode) so it is never hidden behind it. --- */
     .coord-readout{ background:rgba(18,18,20,0.64) !important; -webkit-backdrop-filter:saturate(160%) blur(14px) !important; backdrop-filter:saturate(160%) blur(14px) !important; border:1px solid rgba(255,255,255,0.14) !important; color:#fff !important; z-index:1200; }
     .coord-readout span, .coord-readout .cr-elev, .coord-readout .cr-sat{ color:#fff !important; font-weight:600; }
-    body.sidebar-glass .coord-readout{ left:calc(var(--sidebar-w) + 16px); }
-    body.sidebar-glass .sidebar.collapsed ~ .map-container .coord-readout{ left:16px; }
-    /* (#R13c) Desktop legends now sit on the LEFT of the map. In frosted-overlay mode the sidebar floats
-       over the map, so push the legends past it (clear of the sidebar); collapsed sidebar → flush left. */
+    /* (#R13c/#R160) Desktop classic mode now ALWAYS overlays the sidebar (solid + frosted), so the left-anchored
+       HUD (coord readout, data/Köppen legends) must clear the open sidebar; a collapsed sidebar → flush left.
+       Desktop-only (mobile's --sidebar-w is 100vw, which would fling these off-screen) and not ws-mode. */
     @media(min-width:769px){
-      body.sidebar-glass .data-legend:not([data-dragged]), body.sidebar-glass .koppen-legend:not([data-dragged]){ left:calc(var(--sidebar-w) + 24px); right:auto; }
-      body.sidebar-glass .sidebar.collapsed ~ .map-container .data-legend:not([data-dragged]),
-      body.sidebar-glass .sidebar.collapsed ~ .map-container .koppen-legend:not([data-dragged]){ left:24px; }
+      body:not(.ws-mode) .coord-readout{ left:calc(var(--sidebar-w) + 16px); }
+      body:not(.ws-mode) .sidebar.collapsed ~ .map-container .coord-readout{ left:16px; }
+      body:not(.ws-mode) .data-legend:not([data-dragged]), body:not(.ws-mode) .koppen-legend:not([data-dragged]){ left:calc(var(--sidebar-w) + 24px); right:auto; }
+      body:not(.ws-mode) .sidebar.collapsed ~ .map-container .data-legend:not([data-dragged]),
+      body:not(.ws-mode) .sidebar.collapsed ~ .map-container .koppen-legend:not([data-dragged]){ left:24px; }
+      /* country-info popup (bottom-left) rides the same rail so the overlaying sidebar never hides it. */
+      body:not(.ws-mode) .country-info{ left:calc(var(--sidebar-w) + 24px); }
+      body:not(.ws-mode) .sidebar.collapsed ~ .map-container .country-info{ left:24px; }
+    }
+
+    /* (#R160) RIGHT layer sidebar now OVERLAYS the map too (it no longer pushes the map-container's margin —
+       that was what shifted "地図領域の位置"). So the right-anchored map HUD must slide left by the panel width
+       while it is open, exactly as it used to when the map shrank. Smoothly, and desktop-only / not ws-mode. */
+    @media(min-width:769px){
+      body:not(.ws-mode) .map-controls-top, body:not(.ws-mode) #tool-panel,
+      body:not(.ws-mode) #sat-controller, body:not(.ws-mode) .news-timeline{ transition:right .38s cubic-bezier(0.25,1,0.5,1); }
+      body.lsr-open:not(.ws-mode) .map-controls-top{ right:calc(var(--lsr-w) + 10px); }
+      body.lsr-open:not(.ws-mode) #tool-panel, body.lsr-open:not(.ws-mode) #sat-controller{ right:calc(var(--lsr-w) + 24px); }
+      body.lsr-open:not(.ws-mode) .news-timeline{ right:calc(var(--lsr-w) + 10px); }
     }
 
     /* --- Avatar crop modal (#12) --- */
@@ -4128,20 +4146,13 @@ window.addEventListener('DOMContentLoaded', () => {
   const sidebar = document.getElementById('sidebar');
   if(isMobile()) sidebar.classList.add('collapsed'); /* start collapsed on phone */
   document.getElementById('btn-toggle-sidebar').addEventListener('click', () => {
-    /* (#R159) capture the map anchor BEFORE the flex reflow (which can snap instantly), so the LEFT sidebar never
-       pans the map — desktop solid only (frosted overlays the map; mobile uses the bottom sheet). */
-    const _sbAnchor0=(!document.body.classList.contains('sidebar-glass') && !isMobile()) ? _sbCaptureAnchor('left') : null;
+    /* (#R160) The sidebar now OVERLAYS a fixed full-width map (desktop) or is the bottom sheet (mobile), so the
+       map-container never changes size on toggle — the map simply cannot move. No anchor capture, no per-frame
+       resize, no camera reanchor (all of that machinery is gone). Just slide the panel and let the search-pill
+       layout recompute against the sidebar's new open/closed state. */
     sidebar.classList.toggle('collapsed');
-    try{ applySidebarStyle(true); }catch(_){}   /* frosted: animate the overlay map-padding with the slide (#4) */
-    /* SOLID mode: the map-container is a flex child that physically grows/shrinks as the sidebar
-       slides, so resize every frame keeps the camera centerd in the remaining area. In FROSTED mode
-       the container size is unchanged (the sidebar overlays it) — the animated setPadding above already
-       glides the center, so the per-frame resize would only fight that ease; skip it. */
-    const frosted=document.body.classList.contains('sidebar-glass');
-    /* (#R158) SOLID mode reflows the flex map-container as the sidebar slides — suppress the per-frame buffer resize and
-       snap once at transitionend (no flicker). FROSTED mode overlays the map (fixed size) and glides via setPadding above,
-       so it needs no resize at all. */
-    if(!frosted || isMobile()){ try{ window._sbBeginAnim&&window._sbBeginAnim(null, _sbAnchor0); }catch(_){} }   /* (#R159) desktop solid: anchor (pre-captured) so opening/closing the LEFT sidebar never pans the map */
+    try{ applySidebarStyle(false); }catch(_){}   /* keep the frost/material classes in sync; NO camera padding */
+    try{ window.dispatchEvent(new Event('intmap-sidebar-resize')); }catch(_){}   /* nudge ms-narrow (sidebar size is unchanged, so ResizeObserver won't) */
   });
   /* (#R15) Keyboard shortcut: Esc collapses the sidebar. Ignored while typing in a field, while a modal
      or popup is open (Esc should close those first), or on mobile (it uses the bottom sheet, not a sidebar). */
@@ -4362,38 +4373,19 @@ window.addEventListener('DOMContentLoaded', () => {
      SUPPRESS the per-frame resize while a known sidebar slide is in flight and resize the buffer exactly ONCE at
      transitionend — the canvas CSS-scales its existing buffer for the ~0.4 s (imperceptible) then snaps sharp. Only the
      TIMING of the buffer resize changes; layout, animation curves and camera are untouched. */
-  /* (#R159) The R158 "suppress the per-frame resize, snap ONCE at transitionend" made the open/close feel gross
-     ("開閉の動きがきもくなっている"): the GL buffer CSS-stretched for the whole 0.4 s and then POPPED sharp, and because
-     map.resize() re-centres the geo-centre in the (asymmetrically) regrown container, the map JUMPED sideways at the
-     snap. Replace it with a SMOOTH per-frame rAF resize so the canvas tracks the container continuously (no stretch,
-     no pop), plus an optional EDGE ANCHOR that re-pins one stationary container edge every frame so the map does NOT
-     move at all — the left sidebar must never shift the map ("左サイドバーによって地図の位置は変えなくていい"). */
-  let _sbSuppressUntil=0, _sbEndTimer=0, _sbOnEnd=null, _sbRAF=0, _sbAnimEnd=0, _sbAnchor=null;
-  function _sbStopLoop(){ if(_sbRAF){ try{ cancelAnimationFrame(_sbRAF); }catch(_){} _sbRAF=0; } }
-  /* (#R159) Capture, BEFORE the layout changes, the geo currently under a STATIONARY container edge, stored as an
-     absolute PAGE position. Left sidebar → the RIGHT edge holds still; right sidebar → the LEFT edge. Capturing pre-
-     reflow (and targeting a page position, not a container-local one) makes the anchor correct whether the flex reflow
-     is animated over 0.4 s or snaps instantly. */
-  function _sbCaptureAnchor(side){ try{ if(!map||!map.project) return null; const mc=document.getElementById('map-container'); if(!mc) return null;
-      const r=mc.getBoundingClientRect(); if(!r.width||!r.height) return null;
-      const pageX=(side==='left')?(r.right-1):(r.left+1); const pageY=r.top+Math.round(r.height/2);
-      return { side, pageX, pageY, lngLat:map.unproject([pageX-r.left, pageY-r.top]) }; }catch(_){ return null; } }
-  /* force that geo back to the SAME page position after each resize → the map never visually moves. */
-  function _sbReanchor(){ try{ const a=_sbAnchor; if(!a||!map) return; const mc=document.getElementById('map-container'); if(!mc) return;
-      const r=mc.getBoundingClientRect(); if(!r.width) return; const tx=a.pageX-r.left, ty=a.pageY-r.top;
-      const p=map.project(a.lngLat); const dx=tx-p.x, dy=ty-p.y;
-      if(isFinite(dx)&&isFinite(dy)&&(Math.abs(dx)>0.05||Math.abs(dy)>0.05)) map.panBy([-dx,-dy],{duration:0}); }catch(_){} }
-  function _sbFinishAnim(){ _sbStopLoop(); _sbSuppressUntil=0; _sbAnimEnd=0; if(_sbEndTimer){ clearTimeout(_sbEndTimer); _sbEndTimer=0; } try{ if(map){ map.resize(); _sbReanchor(); } }catch(_){} _sbAnchor=null; const cb=_sbOnEnd; _sbOnEnd=null; if(cb){ try{ cb(); }catch(_){} } }
-  function _sbFrame(){ _sbRAF=0; try{ if(map){ map.resize(); _sbReanchor(); } }catch(_){} if(performance.now()<_sbAnimEnd){ _sbRAF=requestAnimationFrame(_sbFrame); } else { _sbFinishAnim(); } }
-  window._sbBeginAnim=function(onEnd, anchor){ if(onEnd) _sbOnEnd=onEnd;
-    _sbAnchor=(anchor&&typeof anchor==='object')?anchor:(typeof anchor==='string'?_sbCaptureAnchor(anchor):null);   /* object = pre-captured before the reflow (preferred); string = capture now (best-effort) */
-    _sbAnimEnd=performance.now()+480; _sbSuppressUntil=0;   /* run the smooth loop a hair past the 0.4 s CSS slide */
-    if(_sbEndTimer) clearTimeout(_sbEndTimer); _sbEndTimer=setTimeout(_sbFinishAnim,640);   /* safety net if rAF/transitionend stalls */
-    _sbStopLoop(); _sbRAF=requestAnimationFrame(_sbFrame); };
-  window.addEventListener('transitionend',e=>{ try{ if(!e||(e.propertyName!=='margin-left'&&e.propertyName!=='margin-right')) return; const t=e.target; if(t&&(t.id==='map-container'||t.id==='sidebar'||t.id==='layer-sidebar-r'||(t.classList&&t.classList.contains('sidebar')))) _sbFinishAnim(); }catch(_){} },true);
-  let _rsRAF=0; const coalescedResize=()=>{ if(_sbRAF) return; if(_rsRAF) return; _rsRAF=requestAnimationFrame(()=>{ _rsRAF=0; try{ map&&map.resize(); }catch(_){} }); };   /* (#R159) our slide loop already resizes every frame — let the observer stand down while it runs */
+  /* (#R160) The sidebars now OVERLAY a fixed full-width map (desktop; mobile uses the bottom sheet) — see the
+     layout CSS. The map-container NEVER changes size when a panel opens or closes, so there is nothing to resize
+     or re-anchor on toggle: the map physically cannot move. The entire R158/R159 per-frame-resize + edge-anchor
+     machinery (`_sbBeginAnim`/`_sbReanchor`/`_sbCaptureAnchor`/`_sbFinishAnim`) is DELETED — it was the "余計な事"
+     that fought a problem which no longer exists, and it was itself what jerked the map around. We keep only a
+     coalesced resize for GENUINE viewport/container size changes (window resize, devtools, rotation). */
+  let _rsRAF=0; const coalescedResize=()=>{ if(_rsRAF) return; _rsRAF=requestAnimationFrame(()=>{ _rsRAF=0; try{ map&&map.resize(); }catch(_){} }); };
   if(map&&'ResizeObserver' in window) new ResizeObserver(coalescedResize).observe(document.getElementById('map-container'));
   window.addEventListener('resize',coalescedResize);
+  /* (#R160) Back-compat shim: a couple of callers still do `_sbBeginAnim(onEnd)` to "reveal the panel, then
+     notify". There is no camera animation to run anymore (the map doesn't move), so just coalesce a resize in
+     case the viewport genuinely changed and fire the callback on the next frame. */
+  window._sbBeginAnim=function(onEnd){ try{ coalescedResize(); }catch(_){} if(typeof onEnd==='function') requestAnimationFrame(()=>{ try{ onEnd(); }catch(_){} }); };
 
   /* Google-Earth-style navigation feel: stepless wheel zoom centerd on the cursor, a little
      snappier than the default, plus a low-angle tilt limit so you can lean into the horizon. */
@@ -7118,6 +7110,14 @@ window.addEventListener('DOMContentLoaded', () => {
           setPaint(id,p,v){ const m=_m(); if(m&&m.getLayer(id)) m.setPaintProperty(id,p,v); }, setLayout(id,p,v){ const m=_m(); if(m&&m.getLayer(id)) m.setLayoutProperty(id,p,v); },
           setOpacity(id,v){ const m=_m(); if(!(m&&m.getLayer(id))) return; let t=''; try{ t=m.getLayer(id).type; }catch(_){} const p={raster:'raster-opacity',fill:'fill-opacity',line:'line-opacity',circle:'circle-opacity',symbol:'icon-opacity','fill-extrusion':'fill-extrusion-opacity',heatmap:'heatmap-opacity'}[t]; if(p) m.setPaintProperty(id,p,v); },
           on(e,c){ const m=_m(); if(m) m.on(e,c); }, off(e,c){ const m=_m(); if(m) m.off(e,c); }, once(e,c){ const m=_m(); if(m) m.once(e,c); },
+          /* (#R160) Phase-2 contract broadening — the common camera getters, zoom controls, render + feature-state ops
+             that call sites still reach for on the raw map. Each is a 1:1 pass-through (byte-identical behaviour), so
+             adopting them anywhere is safe, and a future adapter (Cesium/Earth) only has to implement these. */
+          getZoom(){ const m=_m(); return m?m.getZoom():null; }, getCenter(){ const m=_m(); return m?m.getCenter():null; },
+          getBearing(){ const m=_m(); return m?m.getBearing():0; }, getPitch(){ const m=_m(); return m?m.getPitch():0; }, getBounds(){ const m=_m(); return m?m.getBounds():null; },
+          zoomTo(z,o){ const m=_m(); if(m) m.zoomTo(z,o); }, zoomIn(o){ const m=_m(); if(m) m.zoomIn(o); }, zoomOut(o){ const m=_m(); if(m) m.zoomOut(o); }, stop(){ const m=_m(); if(m&&m.stop) m.stop(); },
+          resize(){ const m=_m(); if(m&&m.resize) m.resize(); }, triggerRepaint(){ const m=_m(); if(m&&m.triggerRepaint) m.triggerRepaint(); }, getCanvas(){ const m=_m(); return (m&&m.getCanvas)?m.getCanvas():null; },
+          setFeatureState(f,s){ const m=_m(); if(m&&m.setFeatureState) m.setFeatureState(f,s); }, removeFeatureState(f,k){ const m=_m(); if(m&&m.removeFeatureState){ if(k!==undefined) m.removeFeatureState(f,k); else m.removeFeatureState(f); } },
           raw(){ return _m(); } };
         /* Cesium CONTRACT — declared capabilities only; no adapter/SDK/keys yet. Registering a real adapter later
            (IntMapGeoEngine.use(cesiumAdapter)) is all that Phase 2+ needs; nothing here loads Cesium. */
@@ -7126,9 +7126,16 @@ window.addEventListener('DOMContentLoaded', () => {
         return {
           id(){ return _adapter&&_adapter.id; }, capabilities(){ return _adapter&&_adapter.capabilities; }, can(f){ const c=_adapter&&_adapter.capabilities; return !!(c&&c[f]); },
           adapter(){ return _adapter; }, use(a){ if(a&&a.id) _adapter=a; return _adapter; }, contracts(){ return { maplibre:MAPLIBRE_CAPS, cesium:CESIUM_CONTRACT }; },
-          camera:{ flyTo:o=>_adapter.flyTo(o), easeTo:o=>_adapter.easeTo(o), jumpTo:o=>_adapter.jumpTo(o), fitBounds:(b,o)=>_adapter.fitBounds(b,o), setPadding:p=>_adapter.setPadding(p), get:()=>_adapter.getCamera(), setProjection:mo=>_adapter.setProjection(mo) },
+          camera:{ flyTo:o=>_adapter.flyTo(o), easeTo:o=>_adapter.easeTo(o), jumpTo:o=>_adapter.jumpTo(o), fitBounds:(b,o)=>_adapter.fitBounds(b,o), setPadding:p=>_adapter.setPadding(p), get:()=>_adapter.getCamera(), setProjection:mo=>_adapter.setProjection(mo),
+            /* (#R160) camera getters + zoom controls so call sites read/drive the camera through the engine, not the raw map */
+            getZoom:()=>_adapter.getZoom(), getCenter:()=>_adapter.getCenter(), getBearing:()=>_adapter.getBearing(), getPitch:()=>_adapter.getPitch(), getBounds:()=>_adapter.getBounds(),
+            zoomTo:(z,o)=>_adapter.zoomTo(z,o), zoomIn:o=>_adapter.zoomIn(o), zoomOut:o=>_adapter.zoomOut(o), stop:()=>_adapter.stop() },
           coords:{ project:ll=>_adapter.project(ll), unproject:pt=>_adapter.unproject(pt), terrainElevation:(ll,o)=>_adapter.terrainElevation(ll,o), queryRenderedFeatures:(g,o)=>_adapter.queryRenderedFeatures(g,o) },
-          layers:{ hasSource:id=>_adapter.hasSource(id), addSource:(id,d)=>_adapter.addSource(id,d), setSourceData:(id,d)=>_adapter.setSourceData(id,d), removeSource:id=>_adapter.removeSource(id), has:id=>_adapter.hasLayer(id), add:(d,b)=>_adapter.addLayer(d,b), remove:id=>_adapter.removeLayer(id), setVisible:(id,v)=>_adapter.setVisible(id,v), isVisible:id=>_adapter.isVisible(id), setPaint:(id,p,v)=>_adapter.setPaint(id,p,v), setLayout:(id,p,v)=>_adapter.setLayout(id,p,v), setOpacity:(id,v)=>_adapter.setOpacity(id,v) },
+          layers:{ hasSource:id=>_adapter.hasSource(id), addSource:(id,d)=>_adapter.addSource(id,d), setSourceData:(id,d)=>_adapter.setSourceData(id,d), removeSource:id=>_adapter.removeSource(id), has:id=>_adapter.hasLayer(id), add:(d,b)=>_adapter.addLayer(d,b), remove:id=>_adapter.removeLayer(id), setVisible:(id,v)=>_adapter.setVisible(id,v), isVisible:id=>_adapter.isVisible(id), setPaint:(id,p,v)=>_adapter.setPaint(id,p,v), setLayout:(id,p,v)=>_adapter.setLayout(id,p,v), setOpacity:(id,v)=>_adapter.setOpacity(id,v),
+            /* (#R160) feature-state (hover/selection highlighting) through the engine */
+            setFeatureState:(f,s)=>_adapter.setFeatureState(f,s), removeFeatureState:(f,k)=>_adapter.removeFeatureState(f,k) },
+          /* (#R160) render surface — resize / repaint / canvas the renderer owns */
+          render:{ resize:()=>_adapter.resize(), triggerRepaint:()=>_adapter.triggerRepaint(), canvas:()=>_adapter.getCanvas() },
           events:{ on:(e,c)=>_adapter.on(e,c), off:(e,c)=>_adapter.off(e,c), once:(e,c)=>_adapter.once(e,c) },
           raw(){ return _adapter.raw(); }
         };
@@ -8172,18 +8179,18 @@ window.addEventListener('DOMContentLoaded', () => {
          `.map-container{margin-right:var(--lsr-w)}` (also set INLINE by open()) — and the sidebar merely fills
          the vacated strip as an absolute panel. The map's width never depends on the sidebar's flex/transition
          state, so no failure mode of the panel can ever leave it covering the map: worst case is an empty strip. */
-      st.textContent=':root{--lsr-w:min(340px,92vw);}'   /* (#R154/#R159) smaller default width ("デフォルト幅をもう少し小さく") — 430→380→340 */
+      st.textContent=':root{--lsr-w:min(300px,92vw);}'   /* (#R154/#R159/#R160) smaller default width ("もう少し小さく") — 430→380→340→300 */
         +'body.lsr-avail .operation-room{position:relative;}'
         /* (#R154) LEFT-EDGE drag-resizer — mirror of the left sidebar's #sb-resizer so the right sidebar is
            left-right adjustable too ("左サイドバーと同様に左右に調整"). Grows as the cursor moves LEFT. Desktop only. */
         +'#layer-sidebar-r .lsr-resizer{position:absolute;top:0;left:-3px;width:8px;height:100%;cursor:col-resize;z-index:1200;touch-action:none;}'
         +'#layer-sidebar-r .lsr-resizer:hover{background:linear-gradient(to left,transparent,rgba(0,122,255,0.35),transparent);}'
         +'@media(max-width:768px){#layer-sidebar-r .lsr-resizer{display:none;}}'
-        +'body.lsr-avail .map-container{transition:margin-right .38s cubic-bezier(0.25,1,0.5,1);}'
-        +'body.lsr-open .map-container{margin-right:var(--lsr-w);}'
-        /* (#R107) MOBILE: the right sidebar OVERLAYS the map (never shrinks it), rides above the bottom sheet, and the
-           desktop edge-tab is hidden (the layer FAB is the entry point on phones). */
-        +'@media(max-width:768px){body.lsr-open .map-container{margin-right:0 !important;}#layer-sidebar-r{z-index:1460;box-shadow:-6px 0 30px rgba(0,0,0,0.32);}#lsr-toggle{display:none !important;}}'
+        /* (#R160) The right sidebar now OVERLAYS the map on DESKTOP too (previously it pushed the map with
+           margin-right, which resized + recentred the map = "地図領域の位置が動く"). The map-container keeps its
+           fixed full width; the panel slides over the right strip. The right-anchored HUD slides left to clear
+           it (rules above). Mobile already overlaid — this just makes desktop match. */
+        +'@media(max-width:768px){#layer-sidebar-r{z-index:1460;box-shadow:-6px 0 30px rgba(0,0,0,0.32);}#lsr-toggle{display:none !important;}}'
         +'#layer-sidebar-r{position:absolute;top:0;right:0;bottom:0;width:var(--lsr-w);z-index:1000;background:var(--sidebar-bg);backdrop-filter:blur(25px) saturate(160%);-webkit-backdrop-filter:blur(25px) saturate(160%);border-left:1px solid rgba(128,128,128,0.18);display:flex;flex-direction:column;box-sizing:border-box;transform:translateX(102%);transition:transform .38s cubic-bezier(0.25,1,0.5,1);min-height:0;pointer-events:none;visibility:hidden;}'
         +'#layer-sidebar-r.open{transform:translateX(0);pointer-events:auto;visibility:visible;}'
         +'#layer-sidebar-r .lsr-head{display:flex;justify-content:space-between;align-items:center;padding:14px 16px 8px;padding-top:max(14px,env(safe-area-inset-top));}'
@@ -8248,11 +8255,10 @@ window.addEventListener('DOMContentLoaded', () => {
       (function(){ const rh=document.createElement('div'); rh.className='lsr-resizer'; rh.title='Drag to resize'; sb.appendChild(rh);
         let rdrag=false, rsx=0, rsw=0;
         rh.addEventListener('pointerdown',e=>{ if(isMob()) return; rdrag=true; rsx=e.clientX; rsw=sb.offsetWidth; try{ rh.setPointerCapture(e.pointerId); }catch(_){} document.body.style.userSelect='none'; sb.style.transition='none'; e.preventDefault(); e.stopPropagation(); });
-        rh.addEventListener('pointermove',e=>{ if(!rdrag) return; const ls=document.getElementById('sidebar'); const lw=(ls&&!ls.classList.contains('collapsed')&&getComputedStyle(ls).position!=='absolute')?ls.getBoundingClientRect().width:0;
+        rh.addEventListener('pointermove',e=>{ if(!rdrag) return; const ls=document.getElementById('sidebar'); const lw=(ls&&!ls.classList.contains('collapsed'))?ls.getBoundingClientRect().width:0;
           let w=rsw-(e.clientX-rsx); w=Math.max(260,Math.min(Math.max(300,window.innerWidth-lw-320),w));   /* keep ≥320px of map, ≥260px panel */
-          document.documentElement.style.setProperty('--lsr-w', w+'px');
-          try{ const mc=document.querySelector('.map-container'); if(mc&&document.body.classList.contains('lsr-open')) mc.style.marginRight='var(--lsr-w)'; }catch(_){}
-          try{ if(typeof map!=='undefined'&&map) map.resize(); }catch(_){} });
+          document.documentElement.style.setProperty('--lsr-w', w+'px');   /* (#R160) overlay: only the panel width changes; the map stays full-width behind it (no margin push, no resize) */
+          try{ window.dispatchEvent(new Event('intmap-sidebar-resize')); }catch(_){} });
         const end=e=>{ if(!rdrag) return; rdrag=false; try{ rh.releasePointerCapture(e.pointerId); }catch(_){} document.body.style.userSelect=''; sb.style.transition='';
           try{ localStorage.setItem('intmap_lsr_w', String(sb.offsetWidth)); }catch(_){} try{ if(typeof map!=='undefined'&&map) map.resize(); }catch(_){} };
         rh.addEventListener('pointerup',end); rh.addEventListener('pointercancel',end);
@@ -8363,10 +8369,12 @@ window.addEventListener('DOMContentLoaded', () => {
          with a widened left sidebar, a fixed 430px panel swallowed the map ("覆いかぶさる" perception). */
       try{ if(isMob()){ document.documentElement.style.setProperty('--lsr-w','min(430px,92vw)'); }   /* (#R107) mobile: near-full-width overlay */
         else { const ls=document.getElementById('sidebar');
-        const lw=(ls&&!ls.classList.contains('collapsed')&&getComputedStyle(ls).position!=='absolute')?ls.getBoundingClientRect().width:0;
+        /* (#R160) the LEFT sidebar now always OVERLAYS the map (absolute), but it still visually covers its strip,
+           so subtract its width whenever it is open — keep ≥320px of VISIBLE map between the two overlays. */
+        const lw=(ls&&!ls.classList.contains('collapsed'))?ls.getBoundingClientRect().width:0;
         const cap=Math.max(300, Math.round(window.innerWidth-lw-320));   /* keep ≥320px of map */
         let saved=parseInt(localStorage.getItem('intmap_lsr_w')||'',10);   /* (#R154) honour a user-dragged width instead of clobbering it every open */
-        const w=(saved>=260)?Math.min(saved,cap):Math.max(280,Math.min(340, Math.round(window.innerWidth-lw-320)));   /* (#R154/#R159) default cap 430→380→340 (smaller) */
+        const w=(saved>=260)?Math.min(saved,cap):Math.max(280,Math.min(300, Math.round(window.innerWidth-lw-320)));   /* (#R154/#R159/#R160) default cap 430→380→340→300 (smaller) */
         document.documentElement.style.setProperty('--lsr-w', w+'px'); } }catch(_){}
       sb.classList.add('open'); document.body.classList.add('lsr-open');
       /* (#R73) fire any lazy previews that IO missed while the panel was prebuilt off-screen */
@@ -8374,7 +8382,7 @@ window.addEventListener('DOMContentLoaded', () => {
       /* (#R66) INLINE, decoupled: the MAP cedes the strip via its own margin (one line, no cascade, no flex
          math), the panel just slides into the vacated strip. Neither depends on the other. */
       sb.style.transform='translateX(0)'; sb.style.visibility='visible'; sb.style.pointerEvents='auto';
-      try{ const mc=document.querySelector('.map-container'); if(mc) mc.style.marginRight=isMob()?'':'var(--lsr-w)'; }catch(_){}   /* (#R107) mobile overlays, never shrinks the map */
+      try{ const mc=document.querySelector('.map-container'); if(mc&&mc.style.marginRight) mc.style.marginRight=''; }catch(_){}   /* (#R160) overlay: the panel never pushes the map — clear any stale inline margin from an older session */
       /* the Active-layers bar re-homes to the top of the tile browser (returns to the dropdown on close) */
       try{ window._placeActiveSection&&window._placeActiveSection(); }catch(_){} try{ window._refreshActiveLayers&&window._refreshActiveLayers(); }catch(_){}
       /* rows built by late modules (eco/l9/beta, ~1.5 s) — one deferred rebuild picks them up */
@@ -8383,16 +8391,17 @@ window.addEventListener('DOMContentLoaded', () => {
          閉まるように") */
       if(!open._mapCloser){ open._mapCloser=()=>{ try{ if(sb&&sb.classList.contains('open')) close(); }catch(_){} }; }
       try{ map&&map.on('click',open._mapCloser); }catch(_){}
-      /* (#R158) suppress the per-frame resize during the margin-right slide; resize once + notify at transitionend (no flicker) */
-      try{ if(window._sbBeginAnim){ window._sbBeginAnim(()=>{ try{ window.dispatchEvent(new Event('intmap-sidebar-resize')); }catch(_){} }); } else { map&&map.resize(); window.dispatchEvent(new Event('intmap-sidebar-resize')); } }catch(_){} }
+      /* (#R160) overlay: the map-container did NOT change size, so no resize/recentre — just let the search-pill
+         layout recompute against the now-open panel (the right-anchored HUD slides left via CSS). */
+      try{ window.dispatchEvent(new Event('intmap-sidebar-resize')); }catch(_){} }
     function close(){ if(document.body.classList.contains('ws-mode')) return;   /* (#R78d) in workspace mode the layer panel lives in its own window and must never auto-close (that turned the window black) */
       if(sb){ sb.classList.remove('open'); sb.style.transform='translateX(102%)'; sb.style.pointerEvents='none'; setTimeout(()=>{ try{ if(!sb.classList.contains('open')) sb.style.visibility='hidden'; }catch(_){} },400); }
       try{ if(open._mapCloser&&map) map.off('click',open._mapCloser); }catch(_){}
       document.body.classList.remove('lsr-open');
       try{ const mc=document.querySelector('.map-container'); if(mc) mc.style.marginRight=''; }catch(_){}
       try{ window._placeActiveSection&&window._placeActiveSection(); }catch(_){}   /* Active bar back to the classic dropdown */
-      /* (#R158) suppress the per-frame resize during the margin-right slide; resize once + notify at transitionend (no flicker) */
-      try{ if(window._sbBeginAnim){ window._sbBeginAnim(()=>{ try{ window.dispatchEvent(new Event('intmap-sidebar-resize')); }catch(_){} }); } else { map&&map.resize(); window.dispatchEvent(new Event('intmap-sidebar-resize')); } }catch(_){} }
+      /* (#R160) overlay: closing the panel doesn't resize the map — just recompute the search-pill layout. */
+      try{ window.dispatchEvent(new Event('intmap-sidebar-resize')); }catch(_){} }
     function toggle(){ if(sb&&sb.classList.contains('open')) close(); else open(); }
     function apply(){ if(window.imLayerPanel==='right'){ build(); document.body.classList.add('lsr-avail'); if(!isMob()) open(); } else { close(); document.body.classList.remove('lsr-avail'); } }   /* (#R107) build on mobile too; only auto-OPEN on desktop (mobile opens on the layer button) */
     setTimeout(()=>{ try{ if(window.imLayerPanel==='right'){ build(); document.body.classList.add('lsr-avail');
@@ -10337,11 +10346,9 @@ window.addEventListener('DOMContentLoaded', () => {
        open), so follow-ups like "この記事について詳しく"/"translate this"/"背景は？"/"where did this happen" resolve.
        globalData is closure-scoped, so bridge the open article onto window (same pattern as window._imLayerDates). */
     try{ const _a=(item&&item.analysis)||{}; window._imReader={ open:true, title:item&&item.title||'', publisher:item&&item.publisher||'', link:item&&item.link||'', pubDate:item&&item.pubDate||'', loc:(_a.loc&&isFinite(_a.loc[0]))?[_a.loc[0],_a.loc[1]]:null, place:_a.name||'' }; }catch(_){ }
-    try{ const _sb=document.getElementById('sidebar'); const _wasCol=_sb&&_sb.classList.contains('collapsed');
-      /* (#R159) opening the sidebar from the news reader must not jump the map either — capture the anchor BEFORE the reflow */
-      const _a=(_wasCol && !isMobile() && !document.body.classList.contains('sidebar-glass')) ? _sbCaptureAnchor('left') : null;
-      if(_sb) _sb.classList.remove('collapsed');
-      if(map){ if(_a && window._sbBeginAnim){ window._sbBeginAnim(null,_a); } else { setTimeout(()=>{ try{ map.resize(); }catch(_){} },60); } } }catch(_){}
+    /* (#R160) reveal the sidebar to show the article reader. The sidebar overlays a fixed full-width map, so this
+       can't move the map — just drop `collapsed` and let the search-pill layout recompute; no anchor, no resize. */
+    try{ const _sb=document.getElementById('sidebar'); if(_sb&&_sb.classList.contains('collapsed')){ _sb.classList.remove('collapsed'); window.dispatchEvent(new Event('intmap-sidebar-resize')); } }catch(_){}
     try{ if(window.matchMedia('(max-width:768px)').matches && window.__setDetent) window.__setDetent('full'); }catch(_){}
     const cp=document.querySelector('.control-panel'); if(cp) cp.style.display='none';
     const sbBar=document.getElementById('sidebar-search-bar'); if(sbBar) sbBar.style.display='none';   /* (#R79e) by ID, not .search-bar (see renderUI note) */
@@ -17813,31 +17820,14 @@ window.addEventListener('DOMContentLoaded', () => {
     const frosted=(s==='translucent'||s==='glass2');
     document.body.classList.toggle('sidebar-translucent', frosted);
     document.body.classList.toggle('sidebar-glass2', s==='glass2');
-    document.body.classList.toggle('sidebar-glass', frosted);   /* drives the desktop overlay-frost */
-    /* Desktop frosted mode overlays the sidebar on the map so the glass has the map behind it to
-       blur (#23). Keep the map's optical center in the area to the RIGHT of the glass by padding the
-       camera by the sidebar width — ANIMATED so the centerd point glides with the 0.4s slide instead
-       of snapping (#4). Mobile padding is owned by the bottom-sheet detents — leave it. */
-    try{
-      if(map && map.setPadding && !isMobile()){
-        const sb=document.getElementById('sidebar');
-        const collapsed=sb && sb.classList.contains('collapsed');
-        if(frosted){
-          /* FROSTED overlay: the glass sits ON the map (container size unchanged), so glide the optical centre by the
-             sidebar width in lock-step with the 0.4s slide. (#R140) setPadding is instant in MapLibre v5 → animate via easeTo.
-             (#R78e) workspace mode → the sidebar is its own window, never an overlay, so no optical offset. */
-          const pad=(document.body.classList.contains('ws-mode')) ? 0 : (collapsed ? 0 : (sb ? sb.offsetWidth : 440));
-          const _pad={top:0,right:0,bottom:0,left:pad};
-          if(animate && map.easeTo){ try{ map.easeTo({padding:_pad, duration:400, easing:x=>1-Math.pow(1-x,3)}); }catch(_){} }
-          else { try{ map.setPadding(_pad); }catch(_){} requestAnimationFrame(()=>{ try{ map.resize(); }catch(_){} }); }
-        } else {
-          /* (#R159) SOLID mode adds NO optical offset — the flex map-container reflows and the toggle's anchored resize
-             loop owns the camera. Do NOT run a redundant easeTo here (it was a 0→0 padding no-op that still drove a full
-             400ms camera cycle fighting the resize). Only reset a stale left-padding left over from a prior frosted mode. */
-          try{ const cur=map.getPadding&&map.getPadding(); if(cur&&cur.left){ map.setPadding({top:0,right:0,bottom:0,left:0}); } }catch(_){}
-        }
-      }
-    }catch(_){}
+    document.body.classList.toggle('sidebar-glass', frosted);   /* drives the desktop overlay-frost MATERIAL only (blur/translucency) */
+    /* (#R160) NO camera padding on toggle or style change anymore. Both solid and frosted sidebars overlay a
+       FIXED full-width map (see the layout CSS), so the map keeps its own centre and must never be optically
+       shifted — that optical shift was exactly the "地図が勝手に動いてしまう" the user reported. The `animate`
+       argument is kept only for call-site compatibility and is now a no-op. Mobile bottom-sheet padding is
+       owned by the detent system elsewhere and is deliberately left untouched. As a one-time safety net, clear
+       any stray desktop left/right map padding a prior build may have set (fresh maps already start at 0). */
+    try{ if(map && map.getPadding && map.setPadding && !isMobile()){ const cur=map.getPadding(); if(cur && (cur.left||cur.right)) map.setPadding({top:cur.top||0,right:0,bottom:cur.bottom||0,left:0}); } }catch(_){}
   }
 
   /* (#R21) Narrow-desktop watcher: body.ms-narrow drops the search pill to a second row whenever
@@ -17870,7 +17860,9 @@ window.addEventListener('DOMContentLoaded', () => {
         let rightLeft=mapR, stackBottom=66;
         document.querySelectorAll('.map-controls-top .map-view-group, #btn-layers').forEach(el=>{ const r=el.getBoundingClientRect(); if(r.width>0){ rightLeft=Math.min(rightLeft,r.left); stackBottom=Math.max(stackBottom,r.bottom); } });
         let leftRight=mapL;
-        try{ if(document.body.classList.contains('sidebar-glass')){ const sb=document.querySelector('.sidebar'); if(sb&&!sb.classList.contains('collapsed')) leftRight=Math.max(leftRight, sb.getBoundingClientRect().right); } }catch(_){}
+        /* (#R160) the LEFT sidebar now ALWAYS overlays the full-width map on desktop (solid + frosted), so the
+           map rect no longer excludes it — push the pill's left boundary past the open sidebar in every style. */
+        try{ if(!document.body.classList.contains('ws-mode')){ const sb=document.querySelector('.sidebar'); if(sb&&!sb.classList.contains('collapsed')&&getComputedStyle(sb).position==='absolute') leftRight=Math.max(leftRight, sb.getBoundingClientRect().right); } }catch(_){}
         try{ const tg=document.querySelector('.btn-toggle-sidebar'); if(tg){ const r=tg.getBoundingClientRect(); if(r.width>0) leftRight=Math.max(leftRight,r.right); } }catch(_){}
         const half=110, margin=14;   /* half = half of a comfortable ~220px centered pill */
         const collide = ((mapCX + half + margin) > rightLeft) || ((mapCX - half - margin) < leftRight);
@@ -18174,7 +18166,12 @@ window.addEventListener('DOMContentLoaded', () => {
       if(v('setting-label-lang'))    window.imLabelLang=v('setting-label-lang').value;
       if(v('setting-flat-pan'))      window.imFlatPan=v('setting-flat-pan').value;
       if(v('setting-map-color'))     window.imMapColor=v('setting-map-color').value;
-      if(v('setting-layerpanel')){ window.imLayerPanel=v('setting-layerpanel').value; window.imLayerPanelSet=true; /* (#R155) explicit choice → now it persists across the right-default */ try{ window.IntMapLayerSidebar&&window.IntMapLayerSidebar.apply(); }catch(_){} }
+      if(v('setting-layerpanel')){ const _oldLP=window.imLayerPanel; window.imLayerPanel=v('setting-layerpanel').value; window.imLayerPanelSet=true; /* (#R155) explicit choice → now it persists across the right-default */
+        /* (#R160) ROOT CAUSE of "設定を変更すると勝手に右サイドバーが出てくる": apply() ALWAYS re-opens the right
+           panel (if(!isMob()) open()), and it ran on EVERY settings save — so changing any unrelated setting
+           (theme, units, …) reopened a panel the user had deliberately closed. Only reconcile when the layer-panel
+           MODE actually changed; otherwise leave the panel's open/closed state exactly as the user left it. */
+        if(_oldLP!==window.imLayerPanel){ try{ window.IntMapLayerSidebar&&window.IntMapLayerSidebar.apply(); }catch(_){} } }
       if(v('setting-showrank')){ window.imShowRank=v('setting-showrank').value; try{ if(window._countriesActive&&window._countriesActive()&&typeof renderStats==='function') renderStats((typeof _countriesSearchVal==='function')?_countriesSearchVal():searchVal()); }catch(_){} }   /* (#R137) re-render Countries so the rank column appears/disappears immediately */
       if(v('setting-ticker')){ window.imTicker=v('setting-ticker').value; try{ window.IntMapTicker&&window.IntMapTicker.apply(); }catch(_){} }
       const ncWrap=document.getElementById('newscountry-multi');
@@ -30825,14 +30822,14 @@ window.addEventListener('DOMContentLoaded', () => {
         case 'terrain3d': { const ok=(a.on===false)?clickId('btn-view-globe'):clickId('btn-view-3d'); return R(ok, ok?note('✓ 3D '+(a.on===false?'off':'on'))+_featTogHtml('terrain3d'):warn('⚠')); }
         case 'grid': { let ok=false; try{ if(typeof setGrid==='function'){ setGrid(a.on!==false); ok=true; } else ok=clickId('btn-tool-grid'); }catch(_){ ok=clickId('btn-tool-grid'); } return R(ok, ok?note('✓ '+L('Grid','グリッド','Gitter','Сетка','Cuadrícula')+': '+(a.on===false?'off':'on'))+_featTogHtml('grid'):warn('⚠')); }
         case 'resetNorth': case 'resetView': { const ok=clickId('btn-compass'); return R(ok, ok?note('✓ '+L('Reset north','北を上に','Norden zurücksetzen','Сброс на север','Restablecer norte')):warn('⚠')); }
-        case 'zoom': { let tz=null; try{ if(a.to!=null){ tz=+a.to; map.zoomTo(tz,{duration:600}); } else if(a.delta!=null){ tz=map.getZoom()+(+a.delta); map.zoomTo(tz,{duration:400}); } else if(String(a.dir||'')==='out'){ tz=map.getZoom()-1; map.zoomOut(); } else { tz=map.getZoom()+1; map.zoomIn(); } }catch(_){}
+        case 'zoom': { let tz=null; try{ const GE=IntMapGeoEngine.camera; if(a.to!=null){ tz=+a.to; GE.zoomTo(tz,{duration:600}); } else if(a.delta!=null){ tz=GE.getZoom()+(+a.delta); GE.zoomTo(tz,{duration:400}); } else if(String(a.dir||'')==='out'){ tz=GE.getZoom()-1; GE.zoomOut(); } else { tz=GE.getZoom()+1; GE.zoomIn(); } }catch(_){}   /* (#R160) zoom control via IntMapGeoEngine (renderer abstraction) */
           /* (#R61) report the TARGET, not the pre-animation zoom (the old note read the camera mid-flight and
              printed a stale value — a false "done" report). */
-          return R(true, note('✓ '+L('Zoom','ズーム','Zoom','Зум','Zoom')+' → '+(tz!=null&&isFinite(tz)?(+tz).toFixed(1):map.getZoom().toFixed(1)))); }
-        case 'bearing': case 'rotate': { let tb=null; try{ const DIRB={north:0,n:0,northeast:45,ne:45,east:90,e:90,southeast:135,se:135,south:180,s:180,southwest:225,sw:225,west:270,w:270,northwest:315,nw:315,'北':0,'北東':45,'東':90,'南東':135,'南':180,'南西':225,'西':270,'北西':315}; const dd=DIRB[String(a.dir||a.toward||'').toLowerCase().trim()]; tb=(a.deg!=null)?+a.deg:(dd!=null?dd:(a.delta!=null?(map.getBearing()+(+a.delta)):0)); IntMapGeoEngine.camera.easeTo({bearing:tb,pitch:a.pitch!=null?+a.pitch:map.getPitch(),duration:600}); }catch(_){}   /* (#R152) camera execution via IntMapGeoEngine (renderer abstraction) */
-          return R(true, note('✓ '+L('Bearing','方位','Ausrichtung','Азимут','Rumbo')+' → '+Math.round(tb!=null&&isFinite(tb)?tb:map.getBearing())+'°')); }
-        case 'pitch': case 'tilt': { let tp=null; try{ tp=(a.deg!=null)?+a.deg:(a.delta!=null?(map.getPitch()+(+a.delta)):(a.on===false?0:60)); tp=Math.max(0,Math.min(85,tp)); IntMapGeoEngine.camera.easeTo({pitch:tp,duration:600}); }catch(_){}   /* (#R152) camera execution via IntMapGeoEngine */
-          return R(true, note('✓ '+L('Tilt','傾き','Neigung','Наклон','Inclinación')+' → '+Math.round(tp!=null&&isFinite(tp)?tp:map.getPitch())+'°')); }
+          return R(true, note('✓ '+L('Zoom','ズーム','Zoom','Зум','Zoom')+' → '+(tz!=null&&isFinite(tz)?(+tz).toFixed(1):IntMapGeoEngine.camera.getZoom().toFixed(1)))); }
+        case 'bearing': case 'rotate': { let tb=null; try{ const GE=IntMapGeoEngine.camera; const DIRB={north:0,n:0,northeast:45,ne:45,east:90,e:90,southeast:135,se:135,south:180,s:180,southwest:225,sw:225,west:270,w:270,northwest:315,nw:315,'北':0,'北東':45,'東':90,'南東':135,'南':180,'南西':225,'西':270,'北西':315}; const dd=DIRB[String(a.dir||a.toward||'').toLowerCase().trim()]; tb=(a.deg!=null)?+a.deg:(dd!=null?dd:(a.delta!=null?(GE.getBearing()+(+a.delta)):0)); GE.easeTo({bearing:tb,pitch:a.pitch!=null?+a.pitch:GE.getPitch(),duration:600}); }catch(_){}   /* (#R152/#R160) camera read+drive via IntMapGeoEngine (renderer abstraction) */
+          return R(true, note('✓ '+L('Bearing','方位','Ausrichtung','Азимут','Rumbo')+' → '+Math.round(tb!=null&&isFinite(tb)?tb:IntMapGeoEngine.camera.getBearing())+'°')); }
+        case 'pitch': case 'tilt': { let tp=null; try{ const GE=IntMapGeoEngine.camera; tp=(a.deg!=null)?+a.deg:(a.delta!=null?(GE.getPitch()+(+a.delta)):(a.on===false?0:60)); tp=Math.max(0,Math.min(85,tp)); GE.easeTo({pitch:tp,duration:600}); }catch(_){}   /* (#R152/#R160) camera read+drive via IntMapGeoEngine */
+          return R(true, note('✓ '+L('Tilt','傾き','Neigung','Наклон','Inclinación')+' → '+Math.round(tp!=null&&isFinite(tp)?tp:IntMapGeoEngine.camera.getPitch())+'°')); }
         case 'pan': case 'move': { try{ const dir=String(a.dir||a.direction||'').toLowerCase().trim(); const f=(a.fraction!=null?+a.fraction:0.45); const D={north:[0,-1],south:[0,1],east:[1,0],west:[-1,0],northeast:[1,-1],northwest:[-1,-1],southeast:[1,1],southwest:[-1,1],up:[0,-1],down:[0,1],left:[-1,0],right:[1,0],'北':[0,-1],'南':[0,1],'東':[1,0],'西':[-1,0]}; const v=D[dir]||[0,0]; const el=map.getContainer&&map.getContainer(); const W=(el&&el.clientWidth)||800,H=(el&&el.clientHeight)||600; map.panBy([v[0]*W*f, v[1]*H*f],{duration:700}); }catch(_){} return R(true, note('✓ '+L('Pan','移動','Verschieben','Сдвиг','Desplazar')+(a.dir?(' '+esc(a.dir)):''))); }
         case 'tab': { const cmd={news:'tab.news',information:'tab.info',info:'tab.info',companies:'tab.info',company:'tab.info','企業':'tab.info',stats:'tab.stats',statistics:'tab.stats',data:'tab.stats',countries:'tab.stats',nations:'tab.stats',atlas:'tab.atlas',community:'tab.atlas'}[String(a.name||'').toLowerCase()];   /* (#R139) 'companies' → the repurposed info tab */
           const bid={'tab.news':'btn-news','tab.info':'btn-info','tab.stats':'btn-stats','tab.atlas':'btn-community','tab.community':'btn-community'}[cmd];

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test",
     "test:security": "node --test tests/security-logic.mjs",
     "test:monitor": "node --test tests/monitor-logic.test.mjs",
-    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs tests/r149-checks.test.mjs tests/r150-checks.test.mjs tests/r151-checks.test.mjs tests/r152-checks.test.mjs tests/r153-checks.test.mjs tests/r154-checks.test.mjs tests/r155-checks.test.mjs tests/r156-checks.test.mjs tests/r157-checks.test.mjs tests/r158-checks.test.mjs tests/r159-checks.test.mjs && playwright test",
+    "test": "node scripts/static-checks.mjs && node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs tests/r149-checks.test.mjs tests/r150-checks.test.mjs tests/r151-checks.test.mjs tests/r152-checks.test.mjs tests/r153-checks.test.mjs tests/r154-checks.test.mjs tests/r155-checks.test.mjs tests/r156-checks.test.mjs tests/r157-checks.test.mjs tests/r158-checks.test.mjs tests/r159-checks.test.mjs tests/r160-checks.test.mjs && playwright test",
     "report": "playwright show-report"
   },
   "devDependencies": {

--- a/tests/r152-checks.test.mjs
+++ b/tests/r152-checks.test.mjs
@@ -102,9 +102,9 @@ test('R152 #13 IntMapGeoEngine renderer abstraction + MapLibre adapter + Cesium 
   assert.match(html, /const CESIUM_CONTRACT=\{ id:'cesium', implemented:false,/, 'Cesium contract (no SDK)');
   assert.match(html, /camera:\{ flyTo:o=>_adapter\.flyTo\(o\)/, 'camera facade delegates to the adapter');
   assert.match(html, /use\(a\)\{ if\(a&&a\.id\) _adapter=a;/, 'a future renderer can be swapped in');
-  // Atlas camera execution now routes through the engine
-  assert.match(html, /IntMapGeoEngine\.camera\.easeTo\(\{pitch:tp,duration:600\}\)/, 'Atlas pitch routes through the engine');
-  assert.match(html, /IntMapGeoEngine\.camera\.easeTo\(\{bearing:tb/, 'Atlas bearing routes through the engine');
+  // Atlas camera execution routes through the engine (R160 aliases `const GE=IntMapGeoEngine.camera` in these cases)
+  assert.match(html, /const GE=IntMapGeoEngine\.camera;[\s\S]*?GE\.easeTo\(\{pitch:tp,duration:600\}\)/, 'Atlas pitch routes through the engine');
+  assert.match(html, /GE\.easeTo\(\{bearing:tb/, 'Atlas bearing routes through the engine');
 });
 
 test('R152 #8 Companies — monthly time-series, fresher prices, deeper history floor', () => {

--- a/tests/r154-checks.test.mjs
+++ b/tests/r154-checks.test.mjs
@@ -86,13 +86,13 @@ test('R154 #8 Layer panel defaults to the right sidebar (normal mode)', () => {
 });
 
 test('R154 #9 Right sidebar resizable + smaller default', () => {
-  assert.match(html, /:root\{--lsr-w:min\(340px,92vw\);\}/, 'default width 430→380→340 (R159)');
+  assert.match(html, /:root\{--lsr-w:min\(300px,92vw\);\}/, 'default width 430→380→340→300 (R160)');
   assert.match(html, /#layer-sidebar-r \.lsr-resizer\{position:absolute;top:0;left:-3px;/, 'left-edge resize handle CSS');
   assert.match(html, /rh\.className='lsr-resizer';/, 'resizer element created in build()');
   assert.match(html, /let w=rsw-\(e\.clientX-rsx\);/, 'grows as the cursor moves left');
   assert.match(html, /localStorage\.setItem\('intmap_lsr_w', String\(sb\.offsetWidth\)\)/, 'persists the dragged width');
   assert.match(html, /let saved=parseInt\(localStorage\.getItem\('intmap_lsr_w'\)\|\|'',10\);/, 'open() honours the saved width');
-  assert.match(html, /\(saved>=260\)\?Math\.min\(saved,cap\):Math\.max\(280,Math\.min\(340/, 'saved width used, else the 340 default (R159)');
+  assert.match(html, /\(saved>=260\)\?Math\.min\(saved,cap\):Math\.max\(280,Math\.min\(300/, 'saved width used, else the 300 default (R160)');
 });
 
 test('R154 #10 Layer on/off desync — OFF learned layer is hidden', () => {

--- a/tests/r158-checks.test.mjs
+++ b/tests/r158-checks.test.mjs
@@ -51,12 +51,14 @@ test('R158 #8/#9 satellite tile protocol — grey placeholder replaced by real c
   ok('window.IntMapSatProto=', 'testable resolve hook exposed');
 });
 
-test('R158 #10 → R159 sidebar open/close — smooth per-frame resize + edge anchor (no stretch-snap, no map pan)', () => {
-  ok('window._sbBeginAnim=function(onEnd, anchor)', 'the sidebar-slide gate takes a pre-captured anchor (R159)');
-  ok("if(!e||(e.propertyName!=='margin-left'&&e.propertyName!=='margin-right')) return;", 'transitionend on the map-box margin ends the animation');
-  ok('const coalescedResize=()=>{ if(_sbRAF) return;', 'the ResizeObserver stands down while the R159 slide loop resizes every frame');
-  ok('window._sbBeginAnim(null, _sbAnchor0)', 'left toggle anchors the map (pre-captured) so opening/closing never pans it (R159)');
+test('R158 #10 → R160 sidebar open/close — never moves the map (overlay; per-frame/anchor machinery deleted)', () => {
+  // R160 superseded both the R158 (transitionend snap) and R159 (per-frame resize + anchor) schemes with a
+  // structural overlay: the map-container is a fixed full-width backdrop, so a toggle can't resize/recentre it.
+  gone("window._sbBeginAnim=function(onEnd, anchor)", 'the R159 anchor-taking slide gate is gone');
+  gone('window._sbBeginAnim(null, _sbAnchor0)', 'the left toggle no longer drives an anchored slide');
   gone('if (time - start < 450) requestAnimationFrame(sync);', 'the old per-frame 450ms resize loop is gone');
+  ok('const coalescedResize=()=>{ if(_rsRAF) return;', 'a plain coalesced resize remains for GENUINE viewport changes only');
+  ok('body:not(.ws-mode) .map-container{ position:absolute; inset:0; width:100%; }', 'the map is a fixed full-width backdrop under both sidebars');
 });
 
 test('R158 #4 Atlas attach button is "+" and accepts non-image (text) files', () => {

--- a/tests/r159-checks.test.mjs
+++ b/tests/r159-checks.test.mjs
@@ -36,24 +36,24 @@ test('R159 #2 redundant "その他の収集記事" source pile removed; never-ze
   ok("L('Related articles','関連記事','Verwandte Artikel','Похожие статьи','Artículos relacionados')", 'never-zero "Related articles" fallback kept');
 });
 
-test('R159 #3 right sidebar default width smaller (380 → 340)', () => {
-  ok(':root{--lsr-w:min(340px,92vw);}', 'CSS default width 340');
-  ok('Math.max(280,Math.min(340,', 'JS default cap 340 (floor 280 kept)');
+test('R159 #3 right sidebar default width smaller (R160 superseded: 340 → 300)', () => {
+  // R160 shrank it once more ("もう少し小さく"): 380→340→300. Assert the CURRENT value so the check stays truthful.
+  ok(':root{--lsr-w:min(300px,92vw);}', 'CSS default width 300');
+  ok('Math.max(280,Math.min(300,', 'JS default cap 300 (floor 280 kept)');
   gone('--lsr-w:min(380px,92vw)', 'the old 380 default is gone');
+  gone('--lsr-w:min(340px,92vw)', 'the old 340 default is gone');
 });
 
-test('R159 #4 sidebar open/close is smooth and never pans the map (left anchored)', () => {
-  ok('window._sbBeginAnim=function(onEnd, anchor){', 'slide gate takes a pre-captured anchor');
-  ok('function _sbCaptureAnchor(side){', 'anchor captured as a PAGE position BEFORE the reflow (correct even if the reflow snaps instantly)');
-  ok('function _sbReanchor(){', 're-pin helper keeps the map visually stationary');
-  ok('function _sbFrame(){', 'per-frame rAF resize loop (no stretch-then-snap)');
-  ok('if(isFinite(dx)&&isFinite(dy)&&(Math.abs(dx)>0.05||Math.abs(dy)>0.05)) map.panBy([-dx,-dy],{duration:0});', 'anchor compensates the resize pan');
-  ok("const _sbAnchor0=(!document.body.classList.contains('sidebar-glass') && !isMobile()) ? _sbCaptureAnchor('left') : null;", 'the LEFT toggle captures the anchor before the reflow');
-  ok('window._sbBeginAnim(null, _sbAnchor0)', 'the LEFT toggle anchors so the map never moves');
-  ok('const coalescedResize=()=>{ if(_sbRAF) return;', 'the ResizeObserver stands down while the slide loop runs');
-  // the redundant solid-mode easeTo (0→0 padding no-op that still drove a 400ms camera cycle) is gone — now frosted-only
-  ok('SOLID mode adds NO optical offset', 'solid mode no longer runs a redundant easeTo');
-  ok("cur.left){ map.setPadding({top:0,right:0,bottom:0,left:0}); }", 'solid mode only resets a stale left-padding, never animates the camera');
+test('R159 #4 → R160: sidebar open/close never moves the map (STRUCTURAL: overlay, machinery deleted)', () => {
+  // R160 replaced the whole R158/R159 per-frame-resize + edge-anchor scheme with a structural fix: BOTH sidebars
+  // OVERLAY a fixed full-width map, so the map-container never resizes on toggle and the camera is never touched —
+  // it is impossible for the map to move. The old machinery is gone.
+  gone('function _sbCaptureAnchor(side){', 'the R159 anchor-capture machinery is deleted');
+  gone('function _sbReanchor(){', 'the R159 reanchor machinery is deleted');
+  gone('function _sbFrame(){', 'the R159 per-frame resize loop is deleted');
+  gone('map.panBy([-dx,-dy],{duration:0})', 'no per-frame pan compensation anymore');
+  ok('body:not(.ws-mode) .map-container{ position:absolute; inset:0; width:100%; }', 'desktop map-container is a fixed full-width backdrop');
+  ok('body:not(.ws-mode) .sidebar{ position:absolute;', 'desktop sidebar overlays the map in BOTH solid and frosted styles');
 });
 
 test('R159 #6 news-pin band hides when its hover popup opens', () => {

--- a/tests/r159.spec.js
+++ b/tests/r159.spec.js
@@ -49,16 +49,25 @@ test('R159 #1 Atlas markdown renders with no bold and no divider line', async ()
   expect(out).toContain('Section Heading');
 });
 
-test('R159 #4 toggling the LEFT sidebar does not visually move the map', async () => {
+test('R159 #4 → R160 toggling the LEFT sidebar does not move the map (overlay: container fixed, geo-point pixel-stable)', async () => {
   await page.waitForFunction(() => !!(window.__imap && typeof window.__imap.project === 'function'), null, { timeout: 25_000 });
-  // classic (non-ws) mode: the left #sidebar is a real flex sibling of #map-container
+  // classic (non-ws) mode: the left #sidebar exists and is visible. R160: it OVERLAYS a full-width map.
   const classic = await page.evaluate(() => !document.body.classList.contains('ws-mode') && !!document.getElementById('sidebar') && getComputedStyle(document.getElementById('sidebar')).display !== 'none');
-  expect(classic, 'classic-mode flex sidebar present').toBeTruthy();
+  expect(classic, 'classic-mode sidebar present').toBeTruthy();
+  // the sidebar overlays (position:absolute) while the map-container is a fixed full-width backdrop.
+  const overlay = await page.evaluate(() => ({
+    sb: getComputedStyle(document.getElementById('sidebar')).position,
+    mc: getComputedStyle(document.getElementById('map-container')).position,
+    mcw: document.getElementById('map-container').getBoundingClientRect().width,
+  }));
+  expect(overlay.sb, 'sidebar is an absolute overlay').toBe('absolute');
+  expect(overlay.mc, 'map-container is absolutely positioned (full-bleed)').toBe('absolute');
+  expect(Math.abs(overlay.mcw - (await page.evaluate(() => window.innerWidth))), 'map-container spans the full window width').toBeLessThan(2);
 
   // view a region at a normal zoom (as a user would when toggling the sidebar — not the fully-zoomed-out world).
   await page.evaluate(() => window.__imap.jumpTo({ center: [2.3, 48.85], zoom: 6 }));
   await page.waitForTimeout(500);
-  // ensure the sidebar is OPEN (desktop default), then measure a fixed geo-point's absolute page position.
+  // ensure the sidebar is OPEN, then measure a fixed geo-point's absolute page position.
   await page.evaluate(() => { const sb = document.getElementById('sidebar'); if (sb && sb.classList.contains('collapsed')) document.getElementById('btn-toggle-sidebar').click(); });
   await page.waitForTimeout(700);
 
@@ -67,27 +76,27 @@ test('R159 #4 toggling the LEFT sidebar does not visually move the map', async (
     const r = mc.getBoundingClientRect();
     const g = map.unproject([r.width * 0.72, r.height / 2]); // a point in the always-visible right portion
     const p = map.project(g);
-    return { pageX: r.left + p.x, pageY: r.top + p.y, lng: g.lng, lat: g.lat, w: r.width };
+    return { pageX: r.left + p.x, pageY: r.top + p.y, lng: g.lng, lat: g.lat, w: r.width, left: r.left };
   });
 
-  // collapse the sidebar — the flex map-container grows on its LEFT edge
+  // collapse the sidebar — with the overlay layout the map-container does NOT change size
   await page.evaluate(() => document.getElementById('btn-toggle-sidebar').click());
-  await page.waitForTimeout(900); // let the anchored resize loop settle
+  await page.waitForTimeout(900);
 
   const after = await page.evaluate((g) => {
     const map = window.__imap; const mc = document.getElementById('map-container');
     const r = mc.getBoundingClientRect();
     const p = map.project({ lng: g.lng, lat: g.lat });
-    return { pageX: r.left + p.x, pageY: r.top + p.y, w: r.width };
+    return { pageX: r.left + p.x, pageY: r.top + p.y, w: r.width, left: r.left };
   }, before);
 
-  // the container genuinely resized (sidebar collapsed) …
-  expect(Math.abs(after.w - before.w), `container width changed (${before.w}→${after.w})`).toBeGreaterThan(50);
-  // … yet the fixed geo-point stayed at ~the same absolute screen position (anchor). An uncompensated
-  // re-centre would shift it by ~sidebarWidth/2 (>120px); the anchor keeps it within a few px.
-  expect(Math.abs(after.pageX - before.pageX), `map pan X drift ${Math.round(after.pageX - before.pageX)}px`).toBeLessThan(40);
-  expect(Math.abs(after.pageY - before.pageY), `map pan Y drift ${Math.round(after.pageY - before.pageY)}px`).toBeLessThan(40);
+  // R160: the map-container is a FIXED full-width backdrop — it must NOT resize or move on toggle …
+  expect(Math.abs(after.w - before.w), `container width must NOT change (${before.w}→${after.w})`).toBeLessThan(2);
+  expect(Math.abs(after.left - before.left), `container left edge must NOT move`).toBeLessThan(2);
+  // … and because the camera is never touched, the fixed geo-point stays put to the pixel (no reveal-side shift).
+  expect(Math.abs(after.pageX - before.pageX), `map pan X drift ${Math.round(after.pageX - before.pageX)}px`).toBeLessThan(6);
+  expect(Math.abs(after.pageY - before.pageY), `map pan Y drift ${Math.round(after.pageY - before.pageY)}px`).toBeLessThan(6);
 
-  // no exceptions from the animation machinery
+  // no exceptions
   expect(diag.pageErrors, `pageerror(s):\n${diag.pageErrors.join('\n---\n')}`).toHaveLength(0);
 });

--- a/tests/r160-checks.test.mjs
+++ b/tests/r160-checks.test.mjs
@@ -1,0 +1,109 @@
+// R160 source-level regression checks (deterministic, no browser).
+// Batch: (A) right-sidebar default width smaller (340→300); (B) BOTH sidebars OVERLAY a fixed full-width map so
+// opening/closing a panel can NEVER resize or recentre the map ("左サイドバー/右サイドバー開閉で地図が勝手に動く"
+// の根絶) — the R158/R159 per-frame-resize + edge-anchor machinery is deleted; (C) settings save no longer
+// force-reopens the right sidebar ("設定を変更すると勝手に右サイドバーが出てくる"). Literal-substring assertions
+// guard the load-bearing lines.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../', import.meta.url);
+const html = readFileSync(new URL('index.html', root), 'utf8');
+const has = (s) => html.includes(s);
+const ok = (s, msg) => assert.ok(has(s), msg || ('missing: ' + s.slice(0, 90)));
+const gone = (s, msg) => assert.ok(!has(s), msg || ('should be removed: ' + s.slice(0, 90)));
+
+test('R160 (A) right sidebar default width smaller (340 → 300)', () => {
+  ok(':root{--lsr-w:min(300px,92vw);}', 'CSS default width 300');
+  ok('Math.max(280,Math.min(300,', 'JS default cap 300 (floor 280 kept)');
+  gone('--lsr-w:min(340px,92vw)', 'the old 340 default is gone');
+  gone('--lsr-w:min(380px,92vw)', 'the old 380 default is gone');
+});
+
+test('R160 (B1) both sidebars OVERLAY a fixed full-width map (solid AND frosted, desktop, not ws-mode)', () => {
+  // the map is a full-bleed backdrop; the sidebar is an absolute overlay — for EVERY sidebar style, not just frosted
+  ok('body:not(.ws-mode) .map-container{ position:absolute; inset:0; width:100%; }', 'desktop map-container is a fixed full-width backdrop');
+  ok('body:not(.ws-mode) .sidebar{ position:absolute; left:0; top:0; bottom:0; height:100%; z-index:1000;', 'desktop sidebar overlays the map (solid + frosted)');
+  ok('body:not(.ws-mode) .sidebar.collapsed{ margin-left:calc(-1 * var(--sidebar-w)); }', 'collapsing slides the overlay off-screen (reveals the map, never shifts it)');
+  // the old glass-ONLY overlay rules are generalised away (they no longer gate on sidebar-glass)
+  gone('body.sidebar-glass .map-container{ position:absolute; inset:0; width:100%; }', 'overlay layout is no longer frosted-only');
+});
+
+test('R160 (B2) the R158/R159 per-frame-resize + edge-anchor machinery is DELETED', () => {
+  gone('function _sbCaptureAnchor(side){', 'anchor-capture helper deleted');
+  gone('function _sbReanchor(){', 'reanchor helper deleted');
+  gone('function _sbFrame(){', 'per-frame resize loop deleted');
+  gone('function _sbFinishAnim(){', 'finish-anim helper deleted');
+  gone('map.panBy([-dx,-dy],{duration:0})', 'no per-frame pan compensation anymore');
+  gone("const _sbAnchor0=(!document.body.classList.contains('sidebar-glass') && !isMobile()) ? _sbCaptureAnchor('left') : null;", 'left toggle no longer captures an anchor');
+  // a plain coalesced resize survives, for GENUINE viewport changes only (keyed on _rsRAF, not the old _sbRAF loop)
+  ok('const coalescedResize=()=>{ if(_rsRAF) return;', 'plain coalesced resize kept for real window/container resizes');
+  ok('window._sbBeginAnim=function(onEnd){', 'back-compat shim: no animation, just fire the callback');
+});
+
+test('R160 (B3) the LEFT toggle touches nothing but the panel + pill layout (no camera, no resize)', () => {
+  ok("try{ applySidebarStyle(false); }catch(_){}   /* keep the frost/material classes in sync; NO camera padding */", 'toggle only syncs material classes (no camera padding)');
+  ok("try{ window.dispatchEvent(new Event('intmap-sidebar-resize')); }catch(_){}   /* nudge ms-narrow", 'toggle nudges ms-narrow (sidebar size unchanged so RO will not)');
+});
+
+test('R160 (B4) applySidebarStyle no longer shifts the camera on toggle/style change', () => {
+  gone('map.easeTo({padding:_pad, duration:400', 'the frosted optical-center easeTo is gone');
+  gone('const pad=(document.body.classList.contains(\'ws-mode\')) ? 0 : (collapsed ? 0 : (sb ? sb.offsetWidth : 440));', 'no sidebar-width padding computed on toggle');
+  ok('NO camera padding on toggle or style change anymore', 'documented: the sidebar style change never pans the map');
+  // material classes are still driven (blur/translucency)
+  ok("document.body.classList.toggle('sidebar-glass', frosted);", 'the frosted material class is still applied');
+});
+
+test('R160 (B5) the RIGHT sidebar no longer pushes the map; HUD slides to clear the overlay', () => {
+  gone('body.lsr-open .map-container{margin-right', 'the desktop margin-right push is gone (both desktop + mobile variants)');
+  gone("mc.style.marginRight=isMob()?'':'var(--lsr-w)'", 'open() no longer pushes the map via inline margin');
+  ok('if(mc&&mc.style.marginRight) mc.style.marginRight=', 'open() clears any stale inline margin instead');
+  // right-anchored HUD slides left by the panel width while the panel is open
+  ok('body.lsr-open:not(.ws-mode) .map-controls-top{ right:calc(var(--lsr-w) + 10px); }', 'top-right controls clear the open right panel');
+  ok('body.lsr-open:not(.ws-mode) .news-timeline{ right:calc(var(--lsr-w) + 10px); }', 'the news timeline clears the open right panel');
+  // left-anchored HUD shift is generalised to all overlay styles (was glass-only)
+  ok('body:not(.ws-mode) .coord-readout{ left:calc(var(--sidebar-w) + 16px); }', 'coord readout clears the (always-overlaying) left sidebar');
+  ok('body:not(.ws-mode) .country-info{ left:calc(var(--sidebar-w) + 24px); }', 'country-info popup clears the left sidebar');
+  // ms-narrow accounts for the left overlay in every style, not just frosted
+  ok("if(!document.body.classList.contains('ws-mode')){ const sb=document.querySelector('.sidebar'); if(sb&&!sb.classList.contains('collapsed')&&getComputedStyle(sb).position==='absolute')", 'the search pill avoids the left overlay in every sidebar style');
+});
+
+test('R160 (C) settings save no longer force-reopens the right sidebar', () => {
+  // apply() (which always re-opens on desktop) now runs ONLY when the layer-panel MODE actually changed
+  ok('const _oldLP=window.imLayerPanel; window.imLayerPanel=v(\'setting-layerpanel\').value;', 'capture the previous layer-panel mode before overwriting it');
+  ok('if(_oldLP!==window.imLayerPanel){ try{ window.IntMapLayerSidebar&&window.IntMapLayerSidebar.apply(); }catch(_){} } }', 'reconcile the panel ONLY on a real mode change');
+});
+
+// (D) MapLibre-dependency reduction — Phase 2 of the IntMapGeoEngine renderer abstraction (R152 was Phase 1).
+// The adapter/facade contract is broadened with the common camera getters, zoom controls, a render surface and
+// feature-state, and the self-contained Atlas camera-control dispatch cases (zoom/bearing/pitch) now read AND
+// drive the camera through the engine instead of the raw `map` — so a future engine swap needs no call-site edits.
+test('R160 (D1) MapLibreAdapter contract broadened (camera getters, zoom, render, feature-state) — 1:1 pass-through', () => {
+  ok('getZoom(){ const m=_m(); return m?m.getZoom():null; }', 'adapter.getZoom');
+  ok('getCenter(){ const m=_m(); return m?m.getCenter():null; }', 'adapter.getCenter');
+  ok('getBearing(){ const m=_m(); return m?m.getBearing():0; }', 'adapter.getBearing');
+  ok('getPitch(){ const m=_m(); return m?m.getPitch():0; }', 'adapter.getPitch');
+  ok('getBounds(){ const m=_m(); return m?m.getBounds():null; }', 'adapter.getBounds');
+  ok('zoomTo(z,o){ const m=_m(); if(m) m.zoomTo(z,o); }', 'adapter.zoomTo');
+  ok('zoomIn(o){ const m=_m(); if(m) m.zoomIn(o); }', 'adapter.zoomIn');
+  ok('zoomOut(o){ const m=_m(); if(m) m.zoomOut(o); }', 'adapter.zoomOut');
+  ok('resize(){ const m=_m(); if(m&&m.resize) m.resize(); }', 'adapter.resize');
+  ok('triggerRepaint(){ const m=_m(); if(m&&m.triggerRepaint) m.triggerRepaint(); }', 'adapter.triggerRepaint');
+  ok('setFeatureState(f,s){ const m=_m(); if(m&&m.setFeatureState) m.setFeatureState(f,s); }', 'adapter.setFeatureState');
+  ok('removeFeatureState(f,k){ const m=_m(); if(m&&m.removeFeatureState){', 'adapter.removeFeatureState (with/without key)');
+});
+
+test('R160 (D2) IntMapGeoEngine facade exposes the broadened contract', () => {
+  ok('getZoom:()=>_adapter.getZoom(), getCenter:()=>_adapter.getCenter(), getBearing:()=>_adapter.getBearing(), getPitch:()=>_adapter.getPitch(), getBounds:()=>_adapter.getBounds()', 'camera getters on the facade');
+  ok('zoomTo:(z,o)=>_adapter.zoomTo(z,o), zoomIn:o=>_adapter.zoomIn(o), zoomOut:o=>_adapter.zoomOut(o), stop:()=>_adapter.stop()', 'zoom controls on the facade');
+  ok('setFeatureState:(f,s)=>_adapter.setFeatureState(f,s), removeFeatureState:(f,k)=>_adapter.removeFeatureState(f,k)', 'feature-state on the layers namespace');
+  ok('render:{ resize:()=>_adapter.resize(), triggerRepaint:()=>_adapter.triggerRepaint(), canvas:()=>_adapter.getCanvas() }', 'render namespace (resize/repaint/canvas)');
+});
+
+test('R160 (D3) Atlas camera-control dispatch (zoom/bearing/pitch) reads AND drives via the engine', () => {
+  ok('const GE=IntMapGeoEngine.camera; if(a.to!=null){ tz=+a.to; GE.zoomTo(tz,{duration:600}); }', 'zoom case routes through the engine');
+  ok('GE.getZoom()-1; GE.zoomOut();', 'zoom-out reads + drives through the engine');
+  ok('(a.delta!=null?(GE.getBearing()+(+a.delta)):0)); GE.easeTo({bearing:tb', 'bearing case reads getBearing + drives easeTo through the engine');
+  ok('(a.delta!=null?(GE.getPitch()+(+a.delta)):(a.on===false?0:60)); tp=Math.max(0,Math.min(85,tp)); GE.easeTo({pitch:tp,duration:600});', 'pitch case reads getPitch + drives easeTo through the engine');
+});

--- a/tests/r160.spec.js
+++ b/tests/r160.spec.js
@@ -1,0 +1,102 @@
+// R160 behavioural checks in a real browser (classic, non-workspace desktop mode).
+// (B) The RIGHT layer sidebar OVERLAYS the map — opening/closing it never resizes or recentres the map
+//     ("右サイドバーの開閉で地図領域の位置を動かすな"); the right-anchored HUD slides to clear the open panel.
+// (C) Changing a setting no longer force-reopens the right sidebar ("設定を変更すると勝手に右サイドバーが出てくる").
+import { test, expect } from '@playwright/test';
+import { installHermeticRouting, collectPageDiagnostics } from './helpers/network.js';
+
+test.describe.configure({ mode: 'serial' });
+
+let page, diag;
+
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 820 } }); // desktop classic mode
+  await installHermeticRouting(context);
+  // Force CLASSIC (non-workspace) mode so the left/right sidebars are the real classic panels (ws-mode makes them
+  // floating windows). The reported bugs live in classic mode.
+  await context.addInitScript(() => { try { localStorage.setItem('intmap_ws4', JSON.stringify({ on: false })); } catch { /* ignore */ } });
+  page = await context.newPage();
+  diag = collectPageDiagnostics(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 45_000 });
+  await page.waitForFunction(
+    () => typeof window.IntMapLayerSidebar !== 'undefined' && !!window.__imap && typeof window.__imap.project === 'function' && !!document.getElementById('map'),
+    null,
+    { timeout: 45_000 },
+  );
+  await page.waitForTimeout(2000);
+});
+
+test.afterAll(async () => {
+  await page?.context()?.close();
+});
+
+test('R160 (B) opening/closing the RIGHT sidebar never moves the map (fixed full-width container, geo-point stable)', async () => {
+  // view a region at a normal zoom
+  await page.evaluate(() => window.__imap.jumpTo({ center: [2.3, 48.85], zoom: 6 }));
+  await page.waitForTimeout(400);
+  // make sure the right panel is CLOSED to start
+  await page.evaluate(() => window.IntMapLayerSidebar.close());
+  await page.waitForTimeout(500);
+
+  const before = await page.evaluate(() => {
+    const map = window.__imap; const mc = document.getElementById('map-container');
+    const r = mc.getBoundingClientRect();
+    const g = map.unproject([r.width * 0.4, r.height / 2]); // a point that stays visible on both sides of the panel edge
+    const p = map.project(g);
+    return { pageX: r.left + p.x, pageY: r.top + p.y, lng: g.lng, lat: g.lat, w: r.width, right: r.right };
+  });
+
+  // OPEN the right sidebar — with the overlay layout the map-container does NOT change size or move
+  await page.evaluate(() => window.IntMapLayerSidebar.open());
+  await page.waitForTimeout(700);
+
+  const after = await page.evaluate((g) => {
+    const map = window.__imap; const mc = document.getElementById('map-container');
+    const r = mc.getBoundingClientRect();
+    const mr = getComputedStyle(mc).marginRight;
+    const p = map.project({ lng: g.lng, lat: g.lat });
+    return { pageX: r.left + p.x, pageY: r.top + p.y, w: r.width, right: r.right, marginRight: mr };
+  }, before);
+
+  expect(after.marginRight, 'the map is never pushed by a margin-right').toBe('0px');
+  expect(Math.abs(after.w - before.w), `map-container width must NOT change (${before.w}→${after.w})`).toBeLessThan(2);
+  expect(Math.abs(after.right - before.right), `map-container right edge must NOT move`).toBeLessThan(2);
+  expect(Math.abs(after.pageX - before.pageX), `map pan X drift ${Math.round(after.pageX - before.pageX)}px`).toBeLessThan(6);
+  expect(Math.abs(after.pageY - before.pageY), `map pan Y drift ${Math.round(after.pageY - before.pageY)}px`).toBeLessThan(6);
+  expect(diag.pageErrors, `pageerror(s):\n${diag.pageErrors.join('\n---\n')}`).toHaveLength(0);
+});
+
+test('R160 (B) the right-anchored HUD slides left to clear the open right sidebar', async () => {
+  await page.evaluate(() => window.IntMapLayerSidebar.close());
+  await page.waitForTimeout(500);
+  const closedRight = await page.evaluate(() => {
+    const el = document.querySelector('.map-controls-top'); return el ? Math.round(el.getBoundingClientRect().right) : null;
+  });
+  await page.evaluate(() => window.IntMapLayerSidebar.open());
+  await page.waitForTimeout(700); // let the .38s right-transition finish (real browser → transitions run)
+  const openState = await page.evaluate(() => {
+    const el = document.querySelector('.map-controls-top');
+    const panelW = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--lsr-w')) || 300;
+    return { right: el ? Math.round(el.getBoundingClientRect().right) : null, panelW };
+  });
+  // the top-right controls move LEFT by ~ the panel width so they are not hidden behind it
+  expect(closedRight, 'controls anchored to the right when the panel is closed').toBeGreaterThan(openState.right);
+  expect(closedRight - openState.right, `controls shifted left by ~panel width (${closedRight - openState.right}px vs ${openState.panelW}px)`).toBeGreaterThan(openState.panelW - 40);
+});
+
+test('R160 (C) changing a setting does not re-open a right sidebar the user closed', async () => {
+  // open Settings so every control reflects the current state (so Apply changes nothing but what we intend)
+  await page.evaluate(() => document.getElementById('btn-open-settings')?.click());
+  await page.waitForTimeout(300);
+  // user deliberately CLOSES the right sidebar
+  await page.evaluate(() => window.IntMapLayerSidebar.close());
+  await page.waitForTimeout(400);
+  const beforeApply = await page.evaluate(() => document.body.classList.contains('lsr-open'));
+  expect(beforeApply, 'right sidebar is closed before applying settings').toBeFalsy();
+  // Apply settings WITHOUT changing the layer-panel mode
+  await page.evaluate(() => document.getElementById('btn-close-settings')?.click());
+  await page.waitForTimeout(500);
+  const afterApply = await page.evaluate(() => document.body.classList.contains('lsr-open'));
+  expect(afterApply, 'the right sidebar must stay CLOSED after a settings apply (no force-reopen)').toBeFalsy();
+  expect(diag.pageErrors, `pageerror(s):\n${diag.pageErrors.join('\n---\n')}`).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

Root-cause fixes for the re-reported sidebar bugs, plus the next MapLibre-dependency-reduction increment. The R158/R159 attempts only added machinery that *fought* the problem ("余計な事をするな"); R160 removes that machinery and fixes it structurally.

### 1. Toggling either sidebar no longer moves the map (structural)
Both sidebars now **overlay a fixed full-width map** in desktop classic mode — for **both** the solid and frosted styles (frosted already did this; solid was a flex sibling that shrank/recentred the map). The `#map-container` is an absolute full-bleed backdrop, so a toggle can never resize or recentre it — collapsing **reveals** the covered strip instead of shifting the view.
- Deleted the entire R158/R159 per-frame-resize + edge-anchor scheme (`_sbBeginAnim`/`_sbReanchor`/`_sbCaptureAnchor`/`_sbFrame`/`_sbFinishAnim`).
- `applySidebarStyle` no longer touches the camera (removed the optical-centre `setPadding`/`easeTo`).
- Right layer sidebar no longer pushes the map via `margin-right` (desktop now matches mobile's overlay).
- Right-anchored HUD (controls / tools / satellite / news-timeline) slides left to clear the open panel; left-anchored HUD + the `ms-narrow` search pill generalised from glass-only to every overlay style.
- **Verified in real Chromium**: `#map-container` rect is unchanged and a fixed geo-point is pixel-stable through every left/right toggle.

### 2. Right sidebar default width 340 → 300
"もう少し小さく". Floor 280 and the user-dragged persisted width are unchanged.

### 3. Settings save no longer force-reopens the right sidebar
Root cause: settings-apply always called `IntMapLayerSidebar.apply()`, which re-opens the panel on desktop. Now it reconciles **only when the layer-panel mode actually changed**, so changing an unrelated setting leaves a user-closed panel closed.

### 4. MapLibre-dependency reduction — `IntMapGeoEngine` Phase 2
Broadened the adapter/facade contract with the common camera getters, zoom controls, a `render` surface and feature-state (all 1:1 pass-throughs, byte-identical behaviour), and routed the Atlas camera-control dispatch (`zoom`/`bearing`/`pitch`) through the engine. The complex `flyTo` case is deliberately left for a later phase.

## Tests
- New `tests/r160-checks.test.mjs` (10 source checks) + `tests/r160.spec.js` (3 real-browser behaviour checks: right-sidebar no-move, HUD slide, settings-no-reopen).
- Rewrote `r159.spec.js #4` to assert the overlay (container fixed + geo-point pixel-stable); updated broken exact-string asserts in r152/r154/r158/r159.
- `npm test` green: **static + node 162 + Playwright 100** (CI conditions).

## Deploy
`index.html` + tests only — **no Edge Function changes**, no migration. GitHub Pages auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)