### PR TITLE
R168: refactor index.html — cut along SUBJECTS, not blocks (-2,018 lines / -224 KB)

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -661,12 +661,14 @@ IntMap は、世界のニュース・気候・人口・経済・地政学デー�
 
 ```
 index.html                      公開用SPA本体（UI・地図・レイヤー・ニュース・AI呼び出し）。**ビルド無し**は不変。
-                                (#R167) 9,709行 / 0.89MB（#R166時点は 11,810行/1.14MB、#R165時点は 16,740行/1.73MB、
-                                #R164時点は 22,930行/2.65MB、#R163時点は 27,936行/3.20MB、#R162時点は 32,883行/3.77MB。
-                                R162〜R167 で 36,955行から **−74%**）。
+                                (#R168) 7,691行 / 0.64MB（#R167時点は 9,709行/0.89MB、#R166時点は 11,810行/1.14MB、
+                                #R165時点は 16,740行/1.73MB、#R164時点は 22,930行/2.65MB、#R163時点は 27,936行/3.20MB、
+                                #R162時点は 32,883行/3.77MB。R162〜R168 で 36,955行から **−79%**）。
                                 **自己完結が証明できた部分は css/ と js/ に分離済み**（§3.1）。
-                                残りは中核（状態・ブート・地図構築・ニュースパイプライン・認証・描画ツリー）で、
-                                互いの依存が濃いため、以後は「大きな塊」ではなく**継ぎ目**を選んで出す（§3.1 #R167）。
+                                #R167 までで「自己完結したブロック」は尽き、#R168 からは**主題（SUBJECT）**単位で切る
+                                ＝種になる関数から「外部が誰も読まない私有ヘルパー」を吸収した集合（§3.1 #R168）。
+                                残るのは真の中核（状態宣言・ブート・地図構築・ニュース取得/キャッシュ/絞り込み・
+                                レイヤー配線・IntMapOS・セッション永続化・描画ツリー）。
 css/
   intmap.css                        (#R162) アプリのスタイルシート全体（旧 index.html の `<style>` を**逐語**移設）。
                                     JS は `document.styleSheets`/`cssRules` を一切触らないため挙動は完全に同一。
@@ -775,6 +777,35 @@ js/
                                     `IntMapLocate`・注記 `IntMapAnnotations`・レイヤーホバーのポップアップ・
                                     レイヤー検索・滑走路検索 `RunwaySearch`・DEMサンプラ `IntMapTerrain`・
                                     鉄道/海図ラスターオーバーレイ。42KB
+  ── 以下 (#R168) の6本（第7弾・224KB／2,018行）。**主題（SUBJECT）単位**で切った初めての回（§3.1 #R168）。
+     すべて `(map, IM_HOST)` ファクトリで、`map` 生成直後の1か所でまとめて生成し、
+     **index.html が名前で呼び続ける関数には巻き上げシムを残す**（これも初めて）─────────────
+  countries-ui.js                   (#R168) Countries タブの主題。国境/統計ローダ `loadCountryData`（Natural Earth 10m→
+                                    50m→110m）・地図の国レイヤー `addCountryLayers`・順位付き国リスト `renderStats`・
+                                    国カードと詳細本文・Wikipedia 概要キャッシュ。38KB／15文。
+                                    シム5本（renderStats/showCountryDetail/renderCountryDetailBody/
+                                    loadCountryData/addCountryLayers）。RW 3（countryGeo/countryDataLoaded/
+                                    countryDataPromise）
+  news-ui.js                        (#R168) ニュースの**表示層**。地図の news/dash レイヤー構築 `setupIntelLayers`・
+                                    重なりピンの分散 `_spreadDupNewsPins`・フィード描画 `renderUI` と遅延バッチ
+                                    `appendNewsBatch`・記事リーダー（AI翻訳込み）・AI地点付与 `aiGeocodeNews`。49KB／17文。
+                                    ニュースの**データ経路**（取得・キャッシュ・絞り込み）は index.html に残る。
+                                    シム6本。RW 3（bookmarks/renderedCount/newsFeatures）
+  companies-ui.js                   (#R168) Companies タブの主題。企業リストと詳細カード・複数社比較シート
+                                    （棒/表/CSV/時系列）・ロゴ取得と描画・旧ダッシュボード描画。55KB／36文。
+                                    シム5本。RW 3（dashFeatures/_coTimeDeb/_coTimeWired）
+  tool-panel.js                     (#R168) 計測/半径/面積ツールのパネル `updateToolPanel`・その地図フィーチャ生成
+                                    `buildToolFeatures`・地図右クリックのコンテキストメニュー `showContextMenu`。30KB／8文。
+                                    シム3本。RW 7（measurePoints/radiusColor/radiusKm は #R165 で既存＝
+                                    Atlasカーネルとの**共同所有**、radiusOpacity/toolMode/communityAddArmed/
+                                    pendingPostLoc が新規）
+  auth-ui.js                        (#R168) アカウント関連すべて。認証モーダル・アカウントメニュー・パスワード強度と
+                                    HIBP 漏洩照合・パスキー・パスワード設定フロー・お気に入り読込・Realtime購読・
+                                    `bootSupabase()`。59KB／15文。シム3本。RW 3（user＝`currentUser`/bookmarks/geoRaw）。
+                                    `currentUser` は index.html に宣言が残る唯一の真実の源で、書き込みは setter 経由
+  community.js                      (#R168) コミュニティフィードの描画とリスト配線＋コメント/投票/通報のミューテーション。
+                                    12KB／11文。シム2本。RW 7（commCatFilter/commInView/commSearch/communitySort/
+                                    replyingTo と、tool-panel と**共同所有**の communityAddArmed/pendingPostLoc）
   newsgeo.js                        (#R161) **非AIニュース地点解析エンジン `IntMapNewsGeo`**（決定論・単一の真実の源）。
                                     index.html から `<script src="js/newsgeo.js">` で読み込み、同一ファイルを
                                     `supabase/functions/_shared/newsgeo.js` にミラー（`scripts/sync-newsgeo.mjs`／
@@ -880,6 +911,90 @@ Playwright の monitors テストが拾わなければ本番に出ていた。
 - (#R166) `js/map-ui.js` の `opacities` / `setLayerOpacity` … 同じく layers IIFE の中。**レイヤープリセットの
   不透明度保存は分割前から一度も動いていない**（try/catch が ReferenceError を握り潰し、空の `ops` を保存）。
   修正は挙動変更になるので別ラウンド。
+
+### (#R168) 第7弾 — **主題（SUBJECT）で切る**／巻き上げシム／RW所有者は集合へ
+
+#R167 は「自己完結したブロックは尽きた」と報告した。それは**文（statement）**については正しい。
+AST で残り 929 文を測ると 1文あたりの自由参照は 10〜36 で、単独で出せる文は無い。
+しかし**独立している単位は文ではなく主題**だった：
+
+> **種になる関数から出発し、「宣言する名前を外部の誰も読まない文」を吸収し続ける**（＝私有ヘルパーの推移閉包）。
+> 吸収するたびに集合は大きくなるが、**外部依存の面は増えずに減る**。
+
+この `privateClosure` を6つの種（countries / news / companies / tool-panel / auth / community）に適用したところ、
+**102文・224KB・2,018行**が取り出せ、外部依存は 24〜48、外部書き込みは 3〜7 に収束した。
+**6集合は互いに素**で、**全メンバーが宣言文**（FunctionDeclaration か VariableDeclaration）＝
+副作用を持つ文はゼロだった。これが以下の2つを同時に可能にした。
+
+**新機構① 巻き上げシム（hoisted shim）**。これは **index.html が名前で呼び続ける関数を初めて出した回**。
+出した関数ごとに index.html へ1行のシムを残す：
+
+```js
+function renderStats(){ return IM_COUNTRIES_UI.renderStats.apply(this,arguments); }
+```
+
+- **必ず関数宣言**。元の実体も巻き上げ関数宣言だったので、**ファクトリ呼び出しより前にある呼び出し箇所**
+  （`IM_HOST` の getter は約1,300行上にある）が一切変わらない。`const`/アロー にすると TDZ か `this` 落ちになる。
+- **`.apply(this,arguments)`**。レシーバも引数リストもそのまま透過する。
+- 効果として**モジュール間の相互参照が自動的に安全**になる：news が `renderStats` を、companies が
+  `setupIntelLayers` を呼んでも、行き先は index.html のシム1本に集約される。
+- `tests/r168-checks.test.mjs #2` が「返り値リスト＝シムの集合」「シムは index.html に**ちょうど1つ**」
+  「index.html に実体の再宣言が無い」を固定する。
+
+**新機構② 宣言専用ファクトリ（declaration-only）＋1か所での生成**。6本は
+**`map` 生成直後（index.html 2,209行付近）の1ブロックでまとめて生成**する。元の文があった位置ではない。
+これが安全な理由は3つあり、**すべて機械検証している**：
+1. **ファクトリは実行時に何もしない**。`tests/r168-checks.test.mjs #4` が各ファクトリ本体の最上位文が
+   宣言と `return` だけであること、かつ**変数初期化子が何も呼び出さないこと**を acorn で検証する
+   （＝#R167 の TDZ 罠が原理的に起こらない。閉包の値をファクトリ時点で読まない）。
+2. **`map` は1回しか代入されない**（`tests/r168-checks.test.mjs #3` が代入箇所が1つであることも検証）ので、
+   生成位置を早めても掴む値は同じ。
+3. **クロージャ評価中に移設した名前を使う文は全部で5つしかなく**、いずれも生成ブロックより後ろにある
+   （`layerPreviews(…loadCountryData…)` / `window.renderCompanies=` / `window.showCompanyDetail=` /
+   `window._imOpenSetPassword=` / `bootSupabase();`）。#3 がこの5つの位置関係を固定する。
+   さらに **js/ の他モジュールの生成呼び出しは全部このブロックより後ろ**にある。
+
+**規約の拡張：RWメンバーの所有者は「1ファイル」から「ファイル集合」へ**。#R165〜#R167 はたまたま
+全RWメンバーの書き手が1つだった。主題ごと出すとそうはならない——半径/計測の値は
+**Atlasコマンドとユーザーがドラッグするツールパネルの両方**が設定し、ブックマークは
+**ニュースフィードとアカウントメニューの両方**が触り、ニュースピン配列は**時計を動かしたときと
+AI地点付与が終わったとき**の両方で入れ替わる。1所有者ルールは「事実でないことにする」でしか満たせない。
+そこで `tests/r165-checks.test.mjs` の `owner` を **`owners` 配列**に一般化した。監査上の性質は不変で、
+今も強制されている：**メンバーごとに書いてよいファイルの列挙が明示的かつ網羅的で、
+列挙した全ファイルが実際に書いており、それ以外は一切書かない**。RWは10→**29**、IM_HOST は 123→**230アクセサ**
+（getter 201＋setter 29）。**重複アクセサ検出**も追加した（同名 getter を2回書いても JS は通り、後勝ちで静かに壊れる）。
+
+**証明（`tests/r168.spec.js`・実ブラウザ）**。setter が無い代入は classic script では**静かに no-op**なので、
+「エラーが出ない」は無証明——各アサーションは index.html 側に**裸の閉包変数から再導出**させる：
+- `measurePoints` … ツールパネルの Clear が `HOST.measurePoints=[]` → **index.html の `refreshTool()`** が
+  `tool-source` を作り直す＝地図から線が消える（消えなければ書き込みが届いていない）。
+- `radiusKm` … パネルのスライダが `HOST.radiusKm=v` → **index.html の `window._radiusFromPoint()`** が
+  裸の `radiusKm` を新しい円に焼き込む → 円の緯度スパンで判定（150km≒2.7° / 旧既定1000kmなら≒18°）。
+- `bookmarks` … 追加は `push`（getter だけでも通る）→**削除の `HOST.bookmarks=filter(…)` が判別子**。
+  Saved タブの中身は **index.html の `computeFilteredNews()`** が裸の配列から決める。
+- `renderedCount` … `HOST.renderedCount+=n`。**index.html のスクロールハンドラ**が
+  `renderedCount<newsFiltered.length` で次バッチを判断する＝書き込みが落ちれば同じ30件を再追加して重複する
+  （45件が全部ユニークであることを検証）。
+- `countryGeo`/`countryDataLoaded` … **index.html の `#cb-countries` ハンドラ**が裸の両変数から
+  `addCountryLayers()` を再実行する＝地図ソースを剥がしてもチェックし直せば戻る。
+- ⚠ **MapLibre 5 では `source._data` が `setData()` 後に古いまま**。読むのは `source.serialize().data`。
+
+**証明できないものは証明できるふりをしない**（#R167 の規則を継続）。`currentUser`/`geoRaw` は実 Supabase
+セッションが要る経路でしか書かれず、hermetic では到達不能（テストに実資格情報は置かない）。`dashFeatures` は
+#R139 以降そもそも画面上の帰結が無い。`js/community.js` の DOM は `loadCommunity()` が Supabase を待つうえ
+**コミュニティフィードのモードは専用ボタンを持たない**（コミュニティピンのクリックだけが入口＝投稿ゼロならピンもゼロ）。
+いずれも `tests/r168.spec.js` 冒頭に理由付きで明記し、ソースレベル（r165/r168-checks）で固定した。
+なお community フィードが空なのは**分割由来ではない**ことを、同じプローブを **main (730b401) でも実行して確認**した
+（#R166 のフレーク誤帰属の教訓の再適用）。
+
+**抽出は #R167 と同じく決定論スクリプト**（acorn で範囲確定＝直前コメント塊と行頭インデントを含める →
+自由参照だけ `HOST.x` に書換 → **逆変換して元テキストとバイト一致照合**）。今回追加した安全弁：
+- **モンキーパッチ検出**。出す関数が他所で再代入されていて、かつ**集合内から呼ばれている**なら出せない
+  （モジュール内の呼び出しがパッチを迂回する）。実際に `renderUI` が唯一該当し——調べると
+  再代入は index.html:9353、**`return;` で始まる死んだ IIFE（#R22 で撤去された ACLED カード）の中**で、
+  しかも集合内から `renderUI` を呼ぶ文は無い＝二重に安全と確認して出した。
+- **変数のエクスポートは禁止**（シムは関数にしか作れない）。`extendedDashDB` はこれで候補から外し、
+  宣言を index.html に残して `HOST.extendedDashDB` 経由に留めた。
 
 ### (#R167) 第6弾 — 「大きな塊」ではなく**継ぎ目**を選ぶ／純データ／TDZ
 #R166 までで自己完結した塊は出し尽くし、index.html に残ったのは**中核**（状態・ブート・地図構築・

--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -5,6 +5,110 @@
 
 ---
 
+## R168 — **index.html リファクタリング第7弾＝「主題(SUBJECT)」で切る：6モジュール（−2,018行 / −224KB）** (tag `#R168`)
+
+**指示**: 「Index.htmlを徹底的かつ安全にリファクタリングして。」＝標準指示13（単一ファイルを段階的に分割）の継続。
+
+### ① 「もう出せる塊は無い」は文の話であって主題の話ではなかった
+#R167 は「自己完結したブロックは尽きた」と結論した。**文（statement）単位では正しい**——
+AST で残り929文を測ると1文あたりの自由参照は 10〜36 で、単独で出せる文は1つも無い。
+しかし独立している単位は文ではなく**主題**だった。今回の発見はこの一手に尽きる：
+
+> **種になる関数から出発し、「自分が宣言する名前を外部の誰も読まない文」を吸収し続ける**（私有ヘルパーの推移閉包）。
+> 集合は大きくなるのに、**外部依存の面は増えるどころか減る**。
+
+6つの種（countries / news / companies / tool-panel / auth / community）にこれを適用して
+**102文・224KB・2,018行**。しかも測ってみると **6集合は互いに素**、**全メンバーが宣言文**
+（FunctionDeclaration か VariableDeclaration）で、**副作用を持つ文はゼロ**だった。
+これが下の2つを同時に可能にした。
+
+| モジュール | 文 | サイズ | シム | 新規 getter | RW |
+|---|---|---|---|---|---|
+| `js/countries-ui.js` | 15 | 38KB | 5 | 16 | countryGeo / countryDataLoaded / countryDataPromise |
+| `js/news-ui.js` | 17 | 49KB | 6 | 21 | bookmarks / renderedCount / newsFeatures |
+| `js/companies-ui.js` | 36 | 55KB | 5 | 17 | dashFeatures / _coTimeDeb / _coTimeWired |
+| `js/tool-panel.js` | 8 | 30KB | 3 | 17 | radiusOpacity / toolMode / communityAddArmed / pendingPostLoc ＋既存3 |
+| `js/auth-ui.js` | 15 | 59KB | 3 | 14 | user(`currentUser`) / bookmarks / geoRaw |
+| `js/community.js` | 11 | 12KB | 2 | 16 | commCatFilter / commInView / commSearch / communitySort / replyingTo ＋共有2 |
+
+**index.html 9,709行/0.89MB → 7,691行/0.64MB**。R162〜R168 で 36,955行から **−79%**。
+
+### ② 新機構その1 — 巻き上げシム（index.html が「名前で呼ぶ」関数を初めて出した）
+#R162〜#R167 が出したのは `window.X=(function(){…})()` の形か純データで、index.html 側に名前が残る必要が無かった。
+今回は `renderStats` / `renderUI` / `openAuthModal` … を出す＝**index.html が呼び続ける**。そこで1行のシムを残す：
+
+```js
+function renderStats(){ return IM_COUNTRIES_UI.renderStats.apply(this,arguments); }
+```
+
+- **必ず `function` 宣言**。元の実体も巻き上げ関数宣言だったので、**ファクトリ呼び出しより前**にある呼び出し箇所
+  （`IM_HOST` の getter は約1,300行上）が1バイトも変わらない。`const` にすると TDZ、アローにすると `this` 落ち。
+- **`.apply(this,arguments)`** でレシーバも引数列もそのまま透過。
+- 副産物として**モジュール間の相互参照が自動的に安全**になった（news→`renderStats`、companies→`setupIntelLayers` などが
+  すべて index.html のシム1本に集約される）。
+
+### ③ 新機構その2 — 宣言専用ファクトリを1か所（map 生成直後）でまとめて生成
+6本は**元の文があった位置ではなく、`map` 生成直後の1ブロック**で生成する。安全である理由は3つで、全部機械検証した:
+1. **ファクトリは実行時に何もしない**。`tests/r168-checks #4` が acorn で「最上位文は宣言と `return` だけ」
+   「変数初期化子が何も呼び出さない」を検証＝**#R167 の TDZ 罠が原理的に起こらない**。
+2. **`map` は1回しか代入されない**（これも #3 が検証）ので生成を早めても掴む値は同じ。
+3. **クロージャ評価中に移設名を使う文は5つだけ**で全部このブロックより後ろ（`layerPreviews(…loadCountryData…)` /
+   `window.renderCompanies=` / `window.showCompanyDetail=` / `window._imOpenSetPassword=` / `bootSupabase();`）。
+
+### ④ 規約の拡張 — RWメンバーの所有者は「1ファイル」から「ファイル集合」へ
+#R165〜#R167 はたまたま全RWメンバーの書き手が1つだった。主題ごと出すとそうはならない：
+**半径/計測の値は Atlas コマンドとユーザーが触るツールパネルの両方**が設定し、**ブックマークはニュースフィードと
+アカウントメニューの両方**が触り、**ニュースピン配列は時計を動かしたときとAI地点付与が終わったとき**の両方で入れ替わる。
+1所有者ルールは「事実でないことにする」でしか満たせないので、`tests/r165-checks` の `owner` を **`owners` 配列**へ一般化。
+監査上の性質は不変で今も強制されている：**書いてよいファイルの列挙が明示的かつ網羅的で、列挙した全ファイルが実際に書き、
+それ以外は一切書かない**。RW 10→**29**、IM_HOST 123→**230アクセサ**（getter 201＋setter 29）。
+**重複アクセサ検出も追加**（同名 getter を2回書いても JS は通り、後勝ちで静かに壊れる——実際に最初の生成で
+`user`/`countryGeo`/`toolMode` を二重定義しかけた）。
+
+### ⑤ 書き込みの証明は「index.html に裸の閉包変数から再導出させる」
+setter が無い代入は classic script では**静かに no-op**なので「エラーが出ない」は無証明（#R167 の教訓）。
+`tests/r168.spec.js` は毎回 index.html 側のコードに再計算させる:
+- **measurePoints** … Clear が `HOST.measurePoints=[]` → **index.html の `refreshTool()`** が `tool-source` を作り直す＝線が消える。
+- **radiusKm** … スライダが `HOST.radiusKm=v` → **index.html の `window._radiusFromPoint()`** が裸の `radiusKm` を円に焼き込む
+  → 円の緯度スパンで判定（150km≒2.7°／旧既定1000kmなら≒18°）。
+- **bookmarks** … 追加は `push`（getter だけでも通る）＝**削除の `HOST.bookmarks=filter(…)` が判別子**。
+  Saved タブの中身は **index.html の `computeFilteredNews()`** が決める。
+- **renderedCount** … `HOST.renderedCount+=n`。**index.html のスクロールハンドラ**が次バッチを判断するので、
+  落ちれば同じ30件を再追加して重複する（45件が全部ユニークであることを検証）。
+- **countryGeo / countryDataLoaded** … **index.html の `#cb-countries` ハンドラ**が裸の両変数から `addCountryLayers()` を
+  再実行＝地図ソースを剥がしてもチェックし直せば戻る。
+
+### ⑥ 罠と、証明できなかったもの
+- ⚠ **モンキーパッチ**: 出す関数が他所で再代入され、かつ**集合内から呼ばれている**なら出せない（モジュール内の呼び出しが
+  パッチを迂回する）。抽出スクリプトがこれを検出して `renderUI` で止まった。調べると再代入は **index.html:9353＝
+  `return;` で始まる死んだ IIFE（#R22 で撤去された ACLED カード）の中**で、しかも集合内から `renderUI` を呼ぶ文は無い
+  ＝**二重に安全**と確認して出した（クロージャ全体で再代入される関数宣言はこの1つだけ）。
+- ⚠ **変数はエクスポートできない**（シムは関数にしか作れない）。`extendedDashDB` はこれで候補から外し、宣言を index.html に残した。
+- ⚠ **MapLibre 5 の `source._data` は `setData()` 後も古いまま**。読むのは `source.serialize().data`
+  （`_data` が「features: 0」を返して write-through テストが偽の失敗を出した）。
+- ⚠ **`setMode()`/`setTool()` はトグル**。テストで「タブを開く」つもりの2回目のクリックが**閉じて**しまい、
+  スクロールハンドラが `currentMode` で早期 return していた。テストは必ず `.active`/`.tool-on` を見てから押す。
+- **証明できないものは証明できるふりをしない**（#R167 の規則を継続）: `currentUser`/`geoRaw` は実 Supabase セッションが
+  要る経路でしか書かれず hermetic では到達不能（テストに実資格情報は置かない）。`dashFeatures` は #R139 以降そもそも
+  画面上の帰結が無い。`js/community.js` の DOM は `loadCommunity()` が Supabase を待つうえ**コミュニティフィードのモードは
+  専用ボタンを持たない**（入口はコミュニティピンのクリックだけ＝投稿ゼロならピンもゼロ）。すべて spec 冒頭に理由付きで明記し、
+  ソースレベル（r165/r168-checks）で固定した。空フィードが**分割由来でない**ことは、同じプローブを
+  **main (730b401) でも走らせて確認**（#R166 のフレーク誤帰属の教訓の再適用）。
+
+### ⑦ 巻き添えで直したもの
+- `tests/r167-checks #3`（純データ契約）… 4つの表の再束縛文がモジュール側へ移ったので、
+  「index.html が束縛している」から「**アプリのどこかちょうど1ファイルが束縛している**」へ。
+  非変更のAST検査も **index.html のクロージャ＋js/ 全ファイル**に拡張した（消費側が移ったので、むしろ検査は強くなった）。
+- `tests/r152-checks #2` … `currentMode!=='info'` の行が js/news-ui.js に移り `HOST.mode` になったので両綴りを許容。
+- `tests/r165-checks #2(c)` … 書き込み形を `=` だけでなく `+=`/`++` 等も許容（`HOST.renderedCount+=n`）。
+
+### テスト / CI
+`npm test` = static-checks + `test:checks`（**233件**・`tests/r168-checks.test.mjs` を追加登録）+ Playwright（**151件**）。
+新規: `tests/r168-checks.test.mjs`（8件＝ロード/シム契約/生成位置/宣言専用/裸識別子ゼロ/live getter/split-scope/縮小）、
+`tests/r168.spec.js`（10件＝実ブラウザ）。全件グリーン。
+
+---
+
 ## R167 — **index.html リファクタリング第6弾＝「継ぎ目」で切る：純データ27表＋残りの自己完結15本（−2,101行 / −270KB）** (tag `#R167`)
 
 **指示**: 「Index.htmlをリファクタリングして。」＝標準指示13（単一ファイルを段階的に分割）の継続。

--- a/index.html
+++ b/index.html
@@ -740,6 +740,14 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
 <script src="js/news-timeline.js"></script>
 <script src="js/dash-extended.js"></script>
 <script src="js/map-extras.js"></script>
+<!-- (#R168) the seventh split: six SUBJECT modules carved out of the core. Unlike every earlier
+     round these export functions index.html still calls, so each name keeps a hoisted shim there. -->
+<script src="js/countries-ui.js"></script>
+<script src="js/news-ui.js"></script>
+<script src="js/companies-ui.js"></script>
+<script src="js/tool-panel.js"></script>
+<script src="js/auth-ui.js"></script>
+<script src="js/community.js"></script>
 <script>
   /* (#R162) These files are REQUIRED. Say so loudly and early rather than letting a missing
      one surface later as a confusing "cannot read property of undefined".
@@ -761,7 +769,9 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
                  'timeSeries','aiResearch','correlate','worldEvents','edu',
                  'radiation','popArea','slope','rf','sun','transitReach','disaster','earthReplay',
                  /* (#R167) 15 factories in 7 files (js/tables.js carries data, not factories). */
-                 'legal','feedback','onboarding','progressCtl','mobileUI','layoutReflow','newsTimeline','dashExtended','locate','annotations','layerHoverPopup','layerSearch','runwaySearch','terrain','railSeaOverlays'].filter(function(k){ return typeof M[k]!=='function'; });
+                 'legal','feedback','onboarding','progressCtl','mobileUI','layoutReflow','newsTimeline','dashExtended','locate','annotations','layerHoverPopup','layerSearch','runwaySearch','terrain','railSeaOverlays',
+                 /* (#R168) the six subject modules of the seventh split. */
+                 'countriesUi','newsUi','companiesUi','toolPanel','authUi','community'].filter(function(k){ return typeof M[k]!=='function'; });
     if(miss.length) console.error('[IntMap] required module file(s) failed to load: '+miss.join(', ')+' — check the js/ directory is deployed');
     if(missFac.length) console.error('[IntMap] module factories missing: '+missFac.join(', ')+' — the matching js/ file did not load');
     window.__imModuleCheck={ missing:miss, missingFactories:missFac }; })();
@@ -818,13 +828,11 @@ window.addEventListener('DOMContentLoaded', () => {
   let newsLangs; try{ newsLangs=JSON.parse(localStorage.getItem('intmap_news_langs')||'null'); }catch(_){ newsLangs=null; }
   if(!Array.isArray(newsLangs)||!newsLangs.length) newsLangs=Object.keys(NEWS_LANG_NAMES);   /* default: all */
   const KM2MI=0.621371;
-  const saveBookmarks=()=>localStorage.setItem('intmap_bookmarks',JSON.stringify(bookmarks));
   /* (#R22) Fall back to English when a key is missing in the active language (so newly-added DE/RU,
      which only translate the static UI, never render `undefined`). */
   const t=(k)=>{ const o=i18n[currentLang]||i18n.en; const v=o[k]; return (v!==undefined?v:i18n.en[k]); };
   const hasTurf=()=>typeof turf!=='undefined';
   const searchVal=()=>document.getElementById('search-input').value.toLowerCase();
-  const GDP_YEAR='2023', POP_YEAR='2024';
   /* Industry-standard responsive breakpoint (#10): the JS "mobile" test tracks the SAME media
      query the stylesheet uses (Bootstrap/Tailwind-style 768px boundary) via matchMedia, so the
      script and CSS can never disagree by a scrollbar width or a rounding pixel. */
@@ -964,7 +972,72 @@ window.addEventListener('DOMContentLoaded', () => {
      * time and never binds it at factory time — binding it would land in that const's dead zone. */
     get DB(){ return DB; },                         get ensurePlaceLabels(){ return ensurePlaceLabels; },
     get applyLabelLang(){ return applyLabelLang; }, get applySidebarStyle(){ return applySidebarStyle; },
-    get loadDashFromSupabase(){ return loadDashFromSupabase; }, get diskOutlineLines(){ return diskOutlineLines; }
+    get loadDashFromSupabase(){ return loadDashFromSupabase; }, get diskOutlineLines(){ return diskOutlineLines; },
+    /* ── (#R168) members added for the seventh split (countries-ui / news-ui / companies-ui /
+     *    tool-panel / auth-ui / community — six SUBJECT modules carved out of the core). ── */
+    /* READ-WRITE — each of these is state that the subject owning it is the one to change: the
+     *  country loader latches its promise, the tool panel writes the live tool/radius state, auth
+     *  replaces currentUser on every session change, the community feed owns its filters. The
+     *  variables stay declared here as the single source of truth; the owner of each member is
+     *  pinned by tests/r165-checks.test.mjs — widened in #R168 to an owner SET, because bookmarks
+     *  and the radius/measure state genuinely have two writers each. */
+    get _coTimeDeb(){ return _coTimeDeb; }, set _coTimeDeb(v){ _coTimeDeb=v; },
+    get _coTimeWired(){ return _coTimeWired; }, set _coTimeWired(v){ _coTimeWired=v; },
+    get bookmarks(){ return bookmarks; }, set bookmarks(v){ bookmarks=v; },
+    get commCatFilter(){ return commCatFilter; }, set commCatFilter(v){ commCatFilter=v; },
+    get commInView(){ return commInView; }, set commInView(v){ commInView=v; },
+    get commSearch(){ return commSearch; }, set commSearch(v){ commSearch=v; },
+    get communityAddArmed(){ return communityAddArmed; }, set communityAddArmed(v){ communityAddArmed=v; },
+    get communitySort(){ return communitySort; }, set communitySort(v){ communitySort=v; },
+    get countryDataLoaded(){ return countryDataLoaded; }, set countryDataLoaded(v){ countryDataLoaded=v; },
+    get countryDataPromise(){ return countryDataPromise; }, set countryDataPromise(v){ countryDataPromise=v; },
+    get dashFeatures(){ return dashFeatures; }, set dashFeatures(v){ dashFeatures=v; },
+    get geoRaw(){ return geoRaw; }, set geoRaw(v){ geoRaw=v; },
+    get pendingPostLoc(){ return pendingPostLoc; }, set pendingPostLoc(v){ pendingPostLoc=v; },
+    get radiusOpacity(){ return radiusOpacity; }, set radiusOpacity(v){ radiusOpacity=v; },
+    get renderedCount(){ return renderedCount; }, set renderedCount(v){ renderedCount=v; },
+    get replyingTo(){ return replyingTo; }, set replyingTo(v){ replyingTo=v; },
+    /* write halves only — these three already have their live getters above with the rest of the
+     *  mutable state (same shape as `mode` in #R166 and globalData/newsFeatures in #R167). */
+    set countryGeo(v){ countryGeo=v; }, set user(v){ currentUser=v; }, set toolMode(v){ toolMode=v; },
+    /* mutable — reassigned at runtime, read-only for these modules (live getters as ever) */
+    get activeSearchQuery(){ return activeSearchQuery; }, get coFilterOpen(){ return coFilterOpen; },
+    get coFilters(){ return coFilters; }, get coSort(){ return coSort; }, get coSortDir(){ return coSortDir; },
+    get commCaps(){ return commCaps; }, get communityPosts(){ return communityPosts; },
+    get liveCursor(){ return liveCursor; }, get measureSnapClose(){ return measureSnapClose; },
+    get newsFiltered(){ return newsFiltered; }, get newsLangMode(){ return newsLangMode; },
+    get newsPinMode(){ return newsPinMode; }, get statsFilterOpen(){ return statsFilterOpen; },
+    get statsFilters(){ return statsFilters; }, get statsSort(){ return statsSort; },
+    get statsSortDir(){ return statsSortDir; },
+    /* stable helpers and tables (never rebound — getters anyway, see LAZY above) */
+    get COMM_CATEGORIES(){ return COMM_CATEGORIES; }, get NEWS_BATCH(){ return NEWS_BATCH; },
+    get _aiAreaSummarize(){ return _aiAreaSummarize; }, get _coL(){ return _coL; }, get _coName(){ return _coName; },
+    get _companiesSearchVal(){ return _companiesSearchVal; }, get _gcRingUnwrapped(){ return _gcRingUnwrapped; },
+    get _newsHasForeignLang(){ return _newsHasForeignLang; }, get _respreadNews(){ return _respreadNews; },
+    get _sfL(){ return _sfL; }, get _splitLineToWindows(){ return _splitLineToWindows; },
+    get _splitPolyToWindows(){ return _splitPolyToWindows; }, get _syncToolBtns(){ return _syncToolBtns; },
+    get activeDashCategories(){ return activeDashCategories; }, get aiEsc(){ return aiEsc; },
+    get aiFetchUsage(){ return aiFetchUsage; }, get aiReady(){ return aiReady; },
+    get aiSetBtnBusy(){ return aiSetBtnBusy; }, get aiSyncFeatureButtons(){ return aiSyncFeatureButtons; },
+    get applyCountryVisibility(){ return applyCountryVisibility; }, get applyPinMode(){ return applyPinMode; },
+    get bearingDeg(){ return bearingDeg; }, get clearMarkers(){ return clearMarkers; },
+    get closeArticleReader(){ return closeArticleReader; }, get coCompareSet(){ return coCompareSet; },
+    get commCatLabel(){ return commCatLabel; }, get commCollapsed(){ return commCollapsed; },
+    get compareSet(){ return compareSet; }, get compassDir(){ return compassDir; },
+    get ensureBordersLayer(){ return ensureBordersLayer; }, get ensureLabelPill(){ return ensureLabelPill; },
+    get escForReader(){ return escForReader; }, get hideCountryInfo(){ return hideCountryInfo; },
+    get hideMeasureTip(){ return hideMeasureTip; }, get loadGdpPPP(){ return loadGdpPPP; },
+    get loadNewsFromSupabase(){ return loadNewsFromSupabase; }, get newsTitleHTML(){ return newsTitleHTML; },
+    get openComposeModal(){ return openComposeModal; }, get openPinPopup(){ return openPinPopup; },
+    get pushCommunityFeatures(){ return pushCommunityFeatures; }, get rebuildGeoIndex(){ return rebuildGeoIndex; },
+    get recordLogin(){ return recordLogin; }, get refreshNewsPill(){ return refreshNewsPill; },
+    get renderCoCompareFixed(){ return renderCoCompareFixed; }, get renderCommList(){ return renderCommList; },
+    get satHasKey(){ return satHasKey; }, get satProviderById(){ return satProviderById; },
+    get satRenderController(){ return satRenderController; }, get satRevertToFallback(){ return satRevertToFallback; },
+    get satState(){ return satState; }, get scheduleNewsDeclutter(){ return scheduleNewsDeclutter; },
+    get setupCommunityLayer(){ return setupCommunityLayer; }, get showCoCompare(){ return showCoCompare; },
+    get totalDistance(){ return totalDistance; }, get updateAccountButton(){ return updateAccountButton; },
+    get updateOcclusion(){ return updateOcclusion; }
   };
 
   /* ===== i18n ===== */
@@ -2133,6 +2206,50 @@ window.addEventListener('DOMContentLoaded', () => {
           {id:'tool-point',type:'circle',source:'tool-source',filter:['==','$type','Point'],paint:{'circle-radius':['case',['==',['get','snap'],true],8,6],'circle-color':['case',['==',['get','snap'],true],'#0a84ff',['coalesce',['get','color'],'#ff3b30']],'circle-stroke-width':2,'circle-stroke-color':'#fff'}} ] } });
   }catch(e){ console.warn('MapLibre init failed:',e); }
 
+  /* ── (#R168) SEVENTH SPLIT — six SUBJECT modules carved out of the core (Architecture.md §3.1 #R168).
+   *  #R167 emptied the file of self-contained BLOCKS; what remained was one dense core in which no
+   *  single statement is independent. The unit that IS independent is a SUBJECT: a set of statements
+   *  whose private helpers nothing else reads. Each module below is such a set, moved verbatim.
+   *
+   *  These six are the first modules index.html still CALLS BY NAME, so each exported function keeps a
+   *  hoisted `function` shim here. A shim is a function DECLARATION for a reason: the originals were
+   *  hoisted too, so every call site — including ones textually above this line — behaves exactly as
+   *  before, and `.apply(this,arguments)` preserves the receiver and the argument list byte for byte.
+   *
+   *  Instantiated HERE, immediately after `map` exists (it is assigned once, in the try above) and
+   *  before the first statement that evaluates any of these names eagerly. The factories only DECLARE:
+   *  none of them touches closure state while running, so there is no dead zone to fall into. */
+  const IM_COUNTRIES_UI=window.IntMapModules.countriesUi(map,IM_HOST);
+  function renderStats(){ return IM_COUNTRIES_UI.renderStats.apply(this,arguments); }
+  function showCountryDetail(){ return IM_COUNTRIES_UI.showCountryDetail.apply(this,arguments); }
+  function renderCountryDetailBody(){ return IM_COUNTRIES_UI.renderCountryDetailBody.apply(this,arguments); }
+  function loadCountryData(){ return IM_COUNTRIES_UI.loadCountryData.apply(this,arguments); }
+  function addCountryLayers(){ return IM_COUNTRIES_UI.addCountryLayers.apply(this,arguments); }
+  const IM_NEWS_UI=window.IntMapModules.newsUi(map,IM_HOST);
+  function renderUI(){ return IM_NEWS_UI.renderUI.apply(this,arguments); }
+  function setupIntelLayers(){ return IM_NEWS_UI.setupIntelLayers.apply(this,arguments); }
+  function appendNewsBatch(){ return IM_NEWS_UI.appendNewsBatch.apply(this,arguments); }
+  function renderReaderMode(){ return IM_NEWS_UI.renderReaderMode.apply(this,arguments); }
+  function aiGeocodeNews(){ return IM_NEWS_UI.aiGeocodeNews.apply(this,arguments); }
+  function _spreadDupNewsPins(){ return IM_NEWS_UI._spreadDupNewsPins.apply(this,arguments); }
+  const IM_COMPANIES_UI=window.IntMapModules.companiesUi(map,IM_HOST);
+  function renderCompanies(){ return IM_COMPANIES_UI.renderCompanies.apply(this,arguments); }
+  function showCompanyDetail(){ return IM_COMPANIES_UI.showCompanyDetail.apply(this,arguments); }
+  function renderDashboard(){ return IM_COMPANIES_UI.renderDashboard.apply(this,arguments); }
+  function _coCmpEnsureCss(){ return IM_COMPANIES_UI._coCmpEnsureCss.apply(this,arguments); }
+  function _coCmpRender(){ return IM_COMPANIES_UI._coCmpRender.apply(this,arguments); }
+  const IM_TOOL_PANEL=window.IntMapModules.toolPanel(map,IM_HOST);
+  function updateToolPanel(){ return IM_TOOL_PANEL.updateToolPanel.apply(this,arguments); }
+  function buildToolFeatures(){ return IM_TOOL_PANEL.buildToolFeatures.apply(this,arguments); }
+  function showContextMenu(){ return IM_TOOL_PANEL.showContextMenu.apply(this,arguments); }
+  const IM_AUTH_UI=window.IntMapModules.authUi(map,IM_HOST);
+  function bootSupabase(){ return IM_AUTH_UI.bootSupabase.apply(this,arguments); }
+  function _openSetPassword(){ return IM_AUTH_UI._openSetPassword.apply(this,arguments); }
+  function openAuthModal(){ return IM_AUTH_UI.openAuthModal.apply(this,arguments); }
+  const IM_COMMUNITY=window.IntMapModules.community(map,IM_HOST);
+  function renderCommunity(){ return IM_COMMUNITY.renderCommunity.apply(this,arguments); }
+  function wireCommList(){ return IM_COMMUNITY.wireCommList.apply(this,arguments); }
+
   /* Coalesce resizes to one per frame (#32) — the sidebar open/close transition fires the
      ResizeObserver dozens of times; calling map.resize() on each caused a visible flicker. */
   /* (#R158) SIDEBAR-SLIDE FLICKER ("左右のサイドバーを開閉する際の地図のフリッカーを無くして"). Root cause: while a
@@ -2569,73 +2686,7 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   window.triggerLayerHover=function(k,h){ if(!k)return; if(h)forceHoverLayers.add(k); else forceHoverLayers.delete(k); updateGeoLayers(); };
 
-  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
-  const {GDP,HDI,DEM,MILSPEND,LIFE,INTERNET,CAPITAL,CURRENCY,LANGS}=window.IntMapTables;
   let countryGeo=null, countryStats={}, countryDataLoaded=false, countryDataPromise=null;
-  function flagFromISO2(a2){ if(!a2||a2.length!==2||a2==='-9')return'🏳️'; try{return a2.toUpperCase().replace(/./g,c=>String.fromCodePoint(127397+c.charCodeAt(0)));}catch(e){return'🏳️';} }
-  function loadCountryData(){
-    if(countryDataPromise) return countryDataPromise;
-    countryDataPromise=(async()=>{
-      try{
-        let gj=null;
-        /* (#R13) Highest-resolution Natural Earth borders (10 m) so the boundary lines are crisp and
-           track the real borders — the user reported the 50 m lines were too coarse and ran parallel-
-           offset from reality. 10 m gzips to ~4.7 MB and loads async (doesn't block the map), with a
-           graceful fall back to 50 m then 110 m if it can't be fetched. */
-        const NE='https://cdn.jsdelivr.net/gh/nvkelso/natural-earth-vector@master/geojson/';
-        try{ const r=await fetch(NE+'ne_10m_admin_0_countries.geojson'); if(r.ok) gj=await r.json(); }catch(e){}
-        if(!(gj&&gj.features)){ try{ const r=await fetch(NE+'ne_50m_admin_0_countries.geojson'); if(r.ok) gj=await r.json(); }catch(e){} }
-        if(!(gj&&gj.features)){ try{ const r=await fetch(NE+'ne_110m_admin_0_countries.geojson'); if(r.ok) gj=await r.json(); }catch(e){} }
-        if(gj&&gj.features){
-          countryGeo=gj; window.countryGeo=countryGeo;   /* reused by the projection viewer (#16,#17) */
-          gj.features.forEach(f=>{
-            const p=f.properties||{};
-            let code=(p.ISO_A3_EH&&p.ISO_A3_EH!=='-99')?p.ISO_A3_EH:((p.ISO_A3&&p.ISO_A3!=='-99')?p.ISO_A3:(p.ADM0_A3||''));
-            if(!code||code==='-99'){ f.id=undefined; return; }
-            f.id=code; if(f.properties) f.properties.__code=code;  /* used as promoteId so feature ids are stable codes */
-            let area=0; try{ area=turf.area(f)/1e6; }catch(e){}
-            /* (#R15) Natural Earth 10 m assigns minor territory polygons (Ashmore & Cartier, Coral Sea
-               Islands, Indian Ocean Territories …) the SOVEREIGN's ISO_A3_EH code. Whichever such polygon
-               came last in the file overwrote the real country's name/stats — e.g. "Australia" turned into
-               a tiny territory's name. Keep the LARGEST-area feature per code so the mainland always wins. */
-            const existing=countryStats[code];
-            if(existing && existing._area!=null && existing._area>=area) return;
-            const pop=+p.POP_EST||0;
-            const gdp=(GDP[code]!=null)?GDP[code]:(p.GDP_MD!=null?+p.GDP_MD/1000:(p.GDP_MD_EST!=null?+p.GDP_MD_EST/1000:null));
-            const a2=(p.ISO_A2_EH&&p.ISO_A2_EH!=='-99')?p.ISO_A2_EH:p.ISO_A2;
-            /* (#R23) flag non-sovereign / unrecognized features (Scarborough Shoal, Bir Tawil, Bajo Nuevo,
-               ice fields …) so "Random country" + quizzes never serve them as if they were states. */
-            const _nonSov=(p.TYPE==='Indeterminate')||/indetermin|unrecogn/i.test(String(p.FCLASS_TLC||p.featurecla||p.FEATURECLA||''));
-            countryStats[code]={ code, ccn3:String(p.ISO_N3||''), nameEn:p.NAME_EN||p.ADMIN||p.NAME||code, nameJp:p.NAME_JA||p.NAME_EN||p.ADMIN||code,
-              sov:!_nonSov,
-              pop, area:Math.round(area), _area:area, density:(pop&&area)?pop/area:null, region:p.CONTINENT||'', subregion:p.SUBREGION||'',
-              capital:CAPITAL[code]||'', latlng:(p.LABEL_Y!=null&&p.LABEL_X!=null)?[+p.LABEL_Y,+p.LABEL_X]:null, flag:flagFromISO2(a2),
-              currency:CURRENCY[code]||'', languages:LANGS[code]||'', gdp, gdppc:(gdp&&pop)?(gdp*1e9/pop):null,
-              hdi:HDI[code]||null, dem:DEM[code]||null, milSpend:MILSPEND[code]||null, lifeExp:LIFE[code]||null, internet:INTERNET[code]||null };
-          });
-        }
-      }catch(e){ console.warn('country load failed',e); }
-      finally{
-        /* (#R40) ROOT CAUSE of "Isolate / Country borders / Countries(info) を押しても反応しない、再読み込みで治る":
-           if the FIRST border-GeoJSON fetch failed (slow/blocked CDN on a cold load), countryGeo stayed null
-           but countryDataPromise stayed RESOLVED FOREVER, so every later call short-circuited on the cached
-           (empty) promise and nothing ever worked — until a full page reload reset the promise. Now, on a
-           FAILED load, clear the cached promise + flags so the very next call (a click) transparently retries
-           the fetch. On success, latch as before. */
-        const ok=!!(countryGeo&&countryGeo.features&&countryGeo.features.length);
-        if(ok){ countryDataLoaded=true; if(map&&map.isStyleLoaded()) addCountryLayers();
-          /* (#R25/#28) now that countryStats exists, rebuild the geo index so the auto-country/capital
-             entries join the gazetteer → the non-AI news locator gains full global coverage. */
-          try{ rebuildGeoIndex(); }catch(_){}
-          /* (#R127) borders are here now → re-spread any live news pins that were placed as a tight blob while
-             countryGeo was still loading (regionFor had no polygon), so country clusters fill the real territory. */
-          try{ if(typeof _respreadNews==='function') _respreadNews(); }catch(_){}
-        } else { countryDataLoaded=false; countryDataPromise=null; }
-      } }
-    )();
-    countryDataPromise.then(()=>{ try{ loadGdpPPP(); }catch(_){} });   /* (#R22) enrich with PPP once base stats exist */
-    return countryDataPromise;
-  }
   /* (#R22) GDP (PPP) + GDP-per-capita (PPP), live from the World Bank (NY.GDP.MKTP.PP.CD /
      NY.GDP.PCAP.PP.CD, most-recent value per country), merged into countryStats as gdpPPP (billions)
      and gdppcPPP (current international $). Cached 30 days. Used by Stats, the country popup, compare
@@ -2664,77 +2715,10 @@ window.addEventListener('DOMContentLoaded', () => {
     })();
     return gdpPPPPromise;
   }
-  let hoveredCid=null;
-  function addCountryLayers(){
-    if(!map||!map.isStyleLoaded()||!countryGeo||map.getSource('countries')) return;
-    map.addSource('countries',{type:'geojson',data:countryGeo,promoteId:'__code'});
-    map.addLayer({id:'country-fill',type:'fill',source:'countries',layout:{visibility:'none'},paint:{'fill-color':'#007aff','fill-opacity':['case',['boolean',['feature-state','hover'],false],0.30,0]}},'tool-poly');
-    map.addLayer({id:'country-line',type:'line',source:'countries',layout:{visibility:'none'},paint:{'line-color':'#007aff','line-opacity':0.7,'line-width':['case',['boolean',['feature-state','hover'],false],2.4,0.6]}},'tool-poly');
-    /* (#R26) Create the always-on country-BORDERS line HERE (when the countries source first exists), not
-       only inside the cb-borders change handler — that lazy-create meant borders were checked-by-default but
-       NOT drawn on load until you re-toggled them ("デフォルト選択されているのに表示されない"). applyTheme()
-       sets its visibility from bordersOn (default true). */
-    try{ ensureBordersLayer(); }catch(_){}   /* (#R40) borders-only-line now comes from the OFM boundary layer (accurate, basemap-aligned) — created here too in case Countries(info) initializes first */
-    map.on('mousemove','country-fill',(e)=>{ if(!countryInfoOn||toolMode||!e.features.length)return;
-      /* (#R130) during time-travel do NOT highlight / read out the MODERN country under the cursor — that showed
-         modern Ukraine/Lithuania info while hovering interwar Poland. The era name labels identify countries; the
-         click handler above resolves the era entity on demand. */
-      if(window.IntMapTimeBorders&&window.IntMapTimeBorders.active&&window.IntMapTimeBorders.active()){ if(hoveredCid!==null){ try{ map.setFeatureState({source:'countries',id:hoveredCid},{hover:false}); }catch(_){} hoveredCid=null; } return; }
-      const f=e.features[0]; if(hoveredCid!==null)map.setFeatureState({source:'countries',id:hoveredCid},{hover:false}); hoveredCid=f.id; map.setFeatureState({source:'countries',id:hoveredCid},{hover:true}); showCountryInfo(f); });
-    map.on('mouseleave','country-fill',()=>{ if(hoveredCid!==null)map.setFeatureState({source:'countries',id:hoveredCid},{hover:false}); hoveredCid=null; hideCountryInfo(); });
-    /* (#R130) ROOT CAUSE of the long-standing "昔の年代でも地図クリック国選択が現代国境になる" re-report (survived
-       R122–R129): every prior round fixed the era-aware CROSSHAIR pickers (#scp-pick / #csearch-pick) + the resolveHist
-       ladder — which were already correct — but the gesture the user actually performs, a PLAIN click on a country
-       during time-travel, was handled by THIS era-UNAWARE country-fill handler. It resolved against the MODERN
-       countryGeo, so clicking interwar Poland's Lwów gave modern Ukraine and Vilnius gave modern Lithuania (Warsaw/
-       Kraków only looked "right" because their modern carrier is still POL — hence the intermittent, 1920s-Poland
-       feel). Now, during travel, the plain click routes through the SAME era PIP → resolveHist path the pickers use
-       and NEVER falls back to the modern polygon. */
-    map.on('click','country-fill',(e)=>{ if(!(countryInfoOn&&!toolMode&&!window.__scpPick&&e.features.length)) return;
-      const TB=window.IntMapTimeBorders;
-      if(TB&&TB.active&&TB.active()){
-        try{
-          /* defer to a specific place label under the click (city / water / peak / river) so a city still opens as a
-             PLACE, exactly like the era name-label handler (_clk) does — only bare country land opens the country. */
-          const specific=['ofm-city','ofm-other','geo-sea','ofm-water','ofm-water2','ofm-river','ofm-peak'].filter(id=>{ try{ return !!map.getLayer(id); }catch(_){ return false; } });
-          if(specific.length&&e.point&&map.queryRenderedFeatures(e.point,{layers:specific}).length) return;
-          const ll=e.lngLat; let nm=null, geom=null; const fc=TB.currentFC&&TB.currentFC();
-          if(fc&&fc.features&&typeof turf!=='undefined'){ const tp=turf.point([ll.lng,ll.lat]); let bA=Infinity;
-            for(const ff of fc.features){ try{ if(ff.geometry&&turf.booleanPointInPolygon(tp,ff)){ const bb=turf.bbox(ff); const a=(bb[2]-bb[0])*(bb[3]-bb[1]); if(a<bA){ bA=a; nm=ff.properties&&(ff.properties.NAME||ff.properties.name); geom=ff.geometry; } } }catch(_){} } }
-          if(nm&&TB.resolveHist){ const R=TB.resolveHist(nm,ll)||{};
-            if(R.code&&countryStats[R.code]){ showCountryDetail(R.code, R.name||nm); return; }
-            /* a real era entity with no comparable stats carrier — open its era place popup (name/wiki/flag), not the
-               modern country that sits there today. */
-            if(typeof window._imPlacePopup==='function'){ window._imPlacePopup(ll,(R.name||nm),true,{geojson:(R.geometry||geom),wiki:(R.wiki||nm),flag:R.flag}); return; } }
-        }catch(_){}
-        return;   /* during travel, NEVER resolve a country click to the modern polygon */
-      }
-      const f=e.features[0]; const p=f.properties||{}; const id=resolveCountryId(f); showCountryDetail(id, p.NAME_EN||p.ADMIN||p.NAME); });
-    applyCountryVisibility();
-  }
   function applyCountryVisibility(){ if(!map||!map.getLayer('country-fill'))return; const v=countryInfoOn?'visible':'none'; map.setLayoutProperty('country-fill','visibility',v); map.setLayoutProperty('country-line','visibility',v); }
-  const fmtNum=(n)=>n||n===0?Number(Math.round(n)).toLocaleString():'—';
   const fmtMoney=(b)=>!b?'—':(b>=1000?'$'+(b/1000).toFixed(2)+'T':'$'+b.toFixed(0)+'B');
   const fmtPc=(v)=>v?'$'+Math.round(v).toLocaleString():'—';
-  const fmtArea=(a)=>a?Number(Math.round(a)).toLocaleString()+' km²':'—';
   const cName=(s,f)=>(currentLang==='jp'&&s&&s.nameJp)?s.nameJp:(s&&s.nameEn)||f||'—';
-  function showCountryInfo(feat){
-    const id=resolveCountryId(feat), s=countryStats[id], p=document.getElementById('country-info'),
-          name=cName(s,feat.properties&&(feat.properties.NAME_EN||feat.properties.ADMIN||feat.properties.NAME));
-    const haveAny = s && (s.pop||s.gdp||s.area||s.hdi||s.dem||s.milSpend);
-    p.innerHTML=`<div class="ci-name">${s&&s.flag?s.flag+' ':'🏳️ '}${name}</div>
-      <div class="ci-row"><span>${t('statPop')} (${POP_YEAR})</span><b>${s&&s.pop?fmtNum(s.pop):t('dataNA')}</b></div>
-      <div class="ci-row"><span>${t('statGdp')} (${GDP_YEAR})</span><b>${s&&s.gdp?fmtMoney(s.gdp):t('dataNA')}</b></div>
-      <div class="ci-row"><span>${t('statGdpPPP')}</span><b>${s&&s.gdpPPP?fmtMoney(s.gdpPPP):t('dataNA')}</b></div>
-      <div class="ci-row"><span>${t('statGdpPc')}</span><b>${s&&s.gdppc?fmtPc(s.gdppc):t('dataNA')}</b></div>
-      <div class="ci-row"><span>${t('statGdpPcPPP')}</span><b>${s&&s.gdppcPPP?fmtPc(s.gdppcPPP):t('dataNA')}</b></div>
-      <div class="ci-row"><span>${t('statHDI')}</span><b>${s&&s.hdi?s.hdi.toFixed(3):t('dataNA')}</b></div>
-      <div class="ci-row"><span>${t('statDem')}</span><b>${s&&s.dem?s.dem.toFixed(2):t('dataNA')}</b></div>
-      <div class="ci-row"><span>${t('statMil')}</span><b>${s&&s.milSpend?'$'+s.milSpend+'B':t('dataNA')}</b></div>
-      <div class="ci-row"><span>${t('statCapital')}</span><b>${s&&s.capital?s.capital:t('dataNA')}</b></div>
-      <div class="ci-row"><span>${t('statArea')}</span><b>${s&&s.area?fmtArea(s.area):t('dataNA')}</b></div>`;
-    p.style.display='block';
-  }
   function hideCountryInfo(){ document.getElementById('country-info').style.display='none'; }
   function resolveCountryId(feat){
     const p=(feat&&feat.properties)||{};
@@ -2748,141 +2732,9 @@ window.addEventListener('DOMContentLoaded', () => {
     if(nm){ const hit=Object.values(countryStats).find(s=>(s.nameEn||'').toLowerCase()===nm); if(hit) return hit.code; }
     return '';
   }
-  async function enrichCountry(id){
-    if(!id) return null;
-    const s=countryStats[id];
-    if(!s) return null;
-    if(s._enrichedTried) return s;
-    s._enrichedTried=true;
-    try{
-      const r=await fetch(`https://restcountries.com/v3.1/alpha/${encodeURIComponent(id)}?fields=name,capital,languages,currencies,population,area,region,subregion,flag,latlng,timezones,car,callingCodes,demonyms,borders,independent,unMember`);
-      if(!r.ok) return s;
-      const j=await r.json(); const c=Array.isArray(j)?j[0]:j; if(!c) return s;
-      if(!s.capital && c.capital && c.capital.length) s.capital=c.capital[0];
-      if(!s.languages && c.languages) s.languages=Object.values(c.languages).join(', ');
-      if(!s.currency && c.currencies){ const cur=Object.entries(c.currencies)[0]; if(cur) s.currency=`${cur[0]}${cur[1]&&cur[1].name?' ('+cur[1].name+')':''}`; }
-      if(!s.pop && c.population) s.pop=c.population;
-      if((!s.area||s.area<1) && c.area) s.area=c.area;
-      if(!s.density && s.pop && s.area) s.density=s.pop/s.area;
-      if(!s.region && c.region) s.region=c.region;
-      if(!s.subregion && c.subregion) s.subregion=c.subregion;
-      if((!s.flag||s.flag==='🏳️') && c.flag) s.flag=c.flag;
-      if(!s.latlng && c.latlng && c.latlng.length===2) s.latlng=c.latlng;
-      if(c.timezones) s.timezones=c.timezones;
-      if(c.borders) s.borders=c.borders;
-      if(c.independent!=null) s.independent=c.independent;
-      if(c.unMember!=null) s.unMember=c.unMember;
-      if(c.demonyms){ const eng=c.demonyms.eng; if(eng){ s.demonym=(eng.m||eng.f||''); } }
-    }catch(e){}
-    return s;
-  }
   /* (#R39) Wikipedia-style integrated page: an intro placeholder (filled async with a Wikipedia extract +
      thumbnail) then the data GROUPED into Geography / Economy / Society / Politics & defense sections —
      not a bare flat列挙. ("Wikipediaのような統合情報ページにして") */
-  function renderCountryDetailBody(s){
-    if(!s) return `<div class="cm-row"><span>${t('dataNA')}</span><b>—</b></div>`;
-    const _de=currentLang==='de', _jp=currentLang==='jp', _ru=currentLang==='ru', _es=currentLang==='es';
-    const TR=(en,jp,de,ru,es)=>_jp?jp:_de?de:_ru?ru:_es?(es||en):en;
-    const yn=v=>v?TR('Yes','はい','Ja','Да','Sí'):TR('No','いいえ','Nein','Нет','No');
-    const sec=(title,rows)=>{ const r=rows.filter(Boolean); if(!r.length) return ''; return `<div class="cp-sec"><div class="cp-sec-h">${title}</div>`+r.map(([k,v])=>`<div class="cm-row"><span>${k}</span><b>${v}</b></div>`).join('')+`</div>`; };
-    const geo=sec('🌍 '+TR('Geography','地理','Geografie','География','Geografía'),[
-      [t('statRegion'),(s.region||'—')+(s.subregion?' / '+s.subregion:'')],
-      [t('statCapital'),s.capital||'—'],
-      [t('statArea'),fmtArea(s.area)],
-      [t('statDensity'),s.density?fmtNum(Math.round(s.density))+' /km²':'—'],
-      (s.borders&&s.borders.length)?[TR('Borders','隣接','Nachbarländer','Соседи','Fronteras'),s.borders.join(', ')]:null,
-      (s.timezones&&s.timezones.length)?[TR('Timezones','時間帯','Zeitzonen','Часовые пояса','Zonas horarias'),s.timezones.slice(0,3).join(', ')+(s.timezones.length>3?'…':'')]:null
-    ]);
-    /* (#R94) when the master clock has travelled to a past year, the WB-synced rows carry THAT year;
-       HDI (UNDP) and the Democracy Index (EIU) have no WB annual series so they keep their own year. */
-    const _ty=(typeof window!=='undefined'&&window._imTimeYear)||null; const YR=(def)=>_ty||def; const yrTag=()=>(_ty?` (${_ty})`:'');
-    const _milB=(v)=>'$'+(Math.round(v*10)/10)+'B';
-    const econ=sec('💰 '+TR('Economy','経済','Wirtschaft','Экономика','Economía'),[
-      [((s._real||window._imTimeReal)?('GDP · '+TR('real 2011 int$','実質2011年国際ドル','real, int$ 2011','реальный, межд.$ 2011','real int$ 2011')):t('statGdp'))+` (${YR(GDP_YEAR)})`,fmtMoney(s.gdp)],
-      s.gdpPPP?[t('statGdpPPP'),fmtMoney(s.gdpPPP)]:null,
-      [t('statGdpPc')+yrTag(),fmtPc(s.gdppc)],
-      s.gdppcPPP?[t('statGdpPcPPP'),fmtPc(s.gdppcPPP)]:null,
-      [t('statCurrency'),s.currency||'—']
-    ]);
-    const soc=sec('👥 '+TR('Society','社会','Gesellschaft','Общество','Sociedad'),[
-      [t('statPop')+` (${YR(POP_YEAR)})`,fmtNum(s.pop)],
-      s.hdi?[t('statHDI')+' (2022)',s.hdi.toFixed(3)]:null,
-      s.lifeExp?[t('statLife')+yrTag(),s.lifeExp.toFixed(1)+' '+TR('yr','年','J','лет','a')]:null,
-      s.internet?[t('statInet')+yrTag(),(Math.round(s.internet*10)/10)+'%']:null,
-      [t('statLang'),s.languages||'—']
-    ]);
-    const pol=sec('🏛 '+TR('Politics & defense','政治・防衛','Politik & Verteidigung','Политика и оборона','Política y defensa'),[
-      s.dem?[t('statDem')+' (2023)',s.dem.toFixed(2)]:null,
-      s.milSpend?[t('statMil')+` (${YR(2023)})`,_milB(s.milSpend)]:null,
-      s.unMember!=null?[TR('UN member','国連加盟','UN-Mitglied','Член ООН','Miembro de la ONU'),yn(s.unMember)]:null
-    ]);
-    let histNote='';
-    if(s._hist){ const yrs=(s._from?s._from.slice(0,4):'')+'–'+(s._to?s._to.slice(0,4):'');
-      histNote=`<div class="cp-histnote">🏛 <b>${TR('Former state','かつて存在した国家','Ehemaliger Staat','Бывшее государство','Estado desaparecido')}</b> · ${yrs}<br>${TR('GDP & population: Maddison Project (real GDP, 2011 int$). Other indicators: World Bank aggregate of the successor states.','GDP・人口: マディソン・プロジェクト（実質GDP・2011年国際ドル）。その他の指標: 後継国の世界銀行データを合算。','BIP & Bevölkerung: Maddison-Projekt (reales BIP, int$ 2011). Übrige: Weltbank-Summe der Nachfolgestaaten.','ВВП и население: проект Мэддисона (реальный ВВП, межд.$ 2011). Прочее: сумма стран-преемников (Всемирный банк).','PIB y población: Proyecto Maddison (PIB real, int$ 2011). Resto: suma del Banco Mundial de los estados sucesores.')} ${TR('Borders on the map follow the era.','地図の国境も当時のものになります。','Grenzen folgen der Epoche.','Границы на карте — той эпохи.','Las fronteras del mapa siguen la época.')}</div>`; }
-    return `<div id="cp-intro" class="cp-intro"></div>`+histNote+geo+econ+soc+pol;
-  }
-  /* (#R39) Fill the intro with a Wikipedia summary (extract + thumbnail + link) in the active language. */
-  const _cpIntroCache={};
-  function _fillCountryIntro(name){
-    try{
-      const intro=document.getElementById('cp-intro'); if(!intro||!name) return;
-      const wl=currentLang==='jp'?'ja':currentLang==='de'?'de':currentLang==='ru'?'ru':currentLang==='es'?'es':'en';
-      const key=wl+':'+name;
-      const esc=tt=>String(tt==null?'':tt).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
-      const paint=(html)=>{ const i2=document.getElementById('cp-intro'); if(i2&&html) i2.innerHTML=html; };
-      if(_cpIntroCache[key]!=null){ paint(_cpIntroCache[key]); return; }   /* re-render flash-free */
-      fetch('https://'+wl+'.wikipedia.org/api/rest_v1/page/summary/'+encodeURIComponent(String(name).replace(/ /g,'_')))
-        .then(r=>r.ok?r.json():null).then(j=>{
-          if(!j || j.type==='disambiguation'){ _cpIntroCache[key]=''; return; }
-          const extract=j.extract||'', img=(j.thumbnail&&j.thumbnail.source)||'', url=(j.content_urls&&j.content_urls.desktop&&j.content_urls.desktop.page)||'';
-          if(!extract && !img){ _cpIntroCache[key]=''; return; }
-          const html=(img?'<img src="'+esc(img)+'" alt="" class="cp-intro-img" loading="lazy">':'')
-            +(extract?'<p class="cp-intro-text">'+esc(extract)+'</p>':'')
-            +(url?'<a href="'+esc(url)+'" target="_blank" rel="noopener" class="cp-wiki-link">'+t('readWiki')+'</a>':'');
-          _cpIntroCache[key]=html; paint(html);
-        }).catch(()=>{});
-    }catch(_){}
-  }
-  function showCountryDetail(id,fallback){
-    const idStr=String(id||'');
-    let s=countryStats[idStr];
-    const name=cName(s,fallback);
-    const popup=document.getElementById('country-popup');
-    document.getElementById('cp-title').innerHTML=(s&&s.flag?s.flag+' ':'🏳️ ')+name;
-    const body=document.getElementById('cp-body');
-    window._cpCurrent={code:idStr,name:name};   /* read by the isolate + time-series buttons */
-    const _isoSvg='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8V5a2 2 0 0 1 2-2h3M16 3h3a2 2 0 0 1 2 2v3M21 16v3a2 2 0 0 1-2 2h-3M8 21H5a2 2 0 0 1-2-2v-3"/></svg>';
-    const _tsSvg='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m7 14 4-4 3 3 5-6"/></svg>';
-    const _topBtnCss='flex:1;display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:9px 6px;border:none;border-radius:10px;background:var(--input-bg);color:var(--text-main);font-weight:600;font-size:12px;cursor:pointer;';
-    const _aiSvg='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v3M5.6 5.6l2.1 2.1M3 12h3M18 12h3M16.3 7.7l2.1-2.1"/><circle cx="12" cy="14" r="5"/></svg>';
-    const _cmpSvg='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 20V10M12 20V4M18 20v-7"/></svg>';
-    const _aiName=encodeURIComponent(name).replace(/'/g,'%27');
-    const topBtns=()=>`<div style="display:flex;gap:6px;margin:0 0 12px;">`
-      +`<button onclick="window.IntMapIsolate&&window.IntMapIsolate.enter((window._cpCurrent||{}).code)" style="${_topBtnCss}"><span style="color:var(--primary-color);display:inline-flex;">${_isoSvg}</span>${currentLang==='de'?'Nur dieses Land':currentLang==='jp'?'この国だけ':currentLang==='ru'?'Только эту страну':'Isolate'}</button>`
-      +`<button onclick="window.IntMapTimeSeries&&window.IntMapTimeSeries.open()" style="${_topBtnCss}"><span style="color:var(--primary-color);display:inline-flex;">${_tsSvg}</span>${currentLang==='de'?'Zeitverlauf':currentLang==='jp'?'時系列グラフ':currentLang==='ru'?'Динамика':'Time-series'}</button>`
-      +`<button onclick="try{var _n=decodeURIComponent('${_aiName}'),_l=(window._cpCurrent&&window._cpCurrent._ll)||null;if(window.IntMapConsole&&window.IntMapConsole.brief){window.IntMapConsole.brief(_n,_l);}else if(window.IntMapAIResearch){window.IntMapAIResearch.open(_n,_l);}}catch(e){}" style="${_topBtnCss}"><span style="color:var(--primary-color);display:inline-flex;">${_aiSvg}</span>${currentLang==='de'?'KI-Bericht':currentLang==='jp'?'AI調査':currentLang==='ru'?'ИИ-справка':'AI brief'}</button>`
-      +`<button onclick="try{window.IntMapStatsCompare&&window.IntMapStatsCompare.open()}catch(e){}" style="${_topBtnCss}"><span style="color:var(--primary-color);display:inline-flex;">${_cmpSvg}</span>${currentLang==='de'?'Vergleichen':currentLang==='jp'?'国を比較':currentLang==='ru'?'Сравнить':currentLang==='es'?'Comparar':'Compare'}</button>`
-      +`</div>`;
-    if(s && s.latlng) window._cpCurrent._ll={lng:s.latlng[1],lat:s.latlng[0]};
-    body.innerHTML=topBtns()+renderCountryDetailBody(s);
-    _fillCountryIntro((s&&(s._hist||s._histId)&&s.wiki)||name);
-    if(s && s.latlng&&map) map.flyTo({center:[s.latlng[1],s.latlng[0]],zoom:3.5,speed:1.0});
-    /* Asynchronously enrich and re-render (#R9b: keep the action buttons at the top) */
-    if(s) enrichCountry(idStr).then(()=>{ if(popup.style.display==='block'){ body.innerHTML=topBtns()+renderCountryDetailBody(countryStats[idStr]); _fillCountryIntro((s&&(s._hist||s._histId)&&s.wiki)||name); } document.getElementById('cp-title').innerHTML=(s.flag?s.flag+' ':'🏳️ ')+cName(s,fallback); });
-    /* (#R94) let the time-machine refresh THIS card's numbers in place (no re-fly / no re-fetch) when the
-       global clock moves — closes over the live idStr/body/topBtns for the currently-open country. */
-    window._imCountryCardRefresh=()=>{ try{ if(popup.style.display!=='block'||!window._cpCurrent||window._cpCurrent.code!==idStr) return; const s2=countryStats[idStr]; if(s2&&body){ body.innerHTML=topBtns()+renderCountryDetailBody(s2); _fillCountryIntro((s&&(s._hist||s._histId)&&s.wiki)||name); } }catch(_){} };
-    popup.style.display='block';
-    /* Initial centered position (viewport coords). Drag handle wires in once. */
-    if(!popup.dataset.placed){
-      const vw=window.innerWidth, vh=window.innerHeight;
-      const w=popup.offsetWidth||380, h=popup.offsetHeight||400;
-      popup.style.left=Math.max(12,(vw-w)/2)+'px';
-      popup.style.top=Math.max(60,(vh-h)/2)+'px';
-      popup.dataset.placed='1';
-      makeDraggable(popup, popup.querySelector('.country-popup-header'));
-    }
-  }
   /* Close handler for the country popup */
   function _wireCountryPopupClose(){
     const popup=document.getElementById('country-popup');
@@ -3076,11 +2928,6 @@ window.addEventListener('DOMContentLoaded', () => {
   window.convTempText=convTempText;
   function bearingDeg(a,b){ return (turf.bearing(turf.point(a),turf.point(b))+360)%360; }
   function compassDir(deg){ const dirs=['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW']; return dirs[Math.round(deg/22.5)%16]; }
-  function bearingHTML(a,b){ const d=bearingDeg(a,b); return `${d.toFixed(1)}° <span class="unit-sub">(${compassDir(d)})</span>`; }
-  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
-  const {RADIUS_PRESETS}=window.IntMapTables;
-  /* Radius color quick-presets (#R7): R / G / B one-tap swatches alongside the custom color picker. */
-  const RADIUS_COLOR_PRESETS=[{col:'#ff3b30',lbl:'R'},{col:'#34c759',lbl:'G'},{col:'#007aff',lbl:'B'}];
 
   let measureSnapClose=false;        /* true while the cursor hovers the first measure vertex */
   const SNAP_PX=22;                  /* screen-space radius that counts as "on the first point" */
@@ -3175,64 +3022,6 @@ window.addEventListener('DOMContentLoaded', () => {
     return _splitLineToWindows(ring);
   }
 
-  function buildToolFeatures(){
-    /* radius circles (saved) — antimeridian + pole safe (#6,#5) */
-    const f=[];
-    radiusItems.forEach(c=>{
-      try{
-        const steps=c.radiusKm>3000?256:160;
-        diskFillPolys(c.center,c.radiusKm,steps).forEach(poly=>{
-          f.push({type:'Feature',geometry:{type:'Polygon',coordinates:poly},properties:{color:c.color,opacity:c.opacity,noStroke:true}}); });
-        diskOutlineLines(c.center,c.radiusKm,steps).forEach(ln=>{
-          f.push({type:'Feature',geometry:{type:'LineString',coordinates:ln},properties:{color:c.color,ringline:true}}); });
-        f.push({type:'Feature',geometry:{type:'Point',coordinates:c.center},properties:{color:c.color}});
-      }catch(e){}
-    });
-    /* live measure/area/radius preview */
-    if(toolMode==='measure'){
-      const all=measurePoints;
-      for(let i=1;i<all.length;i++){
-        try{ f.push(turf.greatCircle(turf.point(all[i-1]),turf.point(all[i]),{npoints:64})); }
-        catch(e){ f.push(turf.lineString([all[i-1],all[i]])); }
-      }
-      /* Close-affordance (#47): when ≥3 points and the cursor is hovering near the FIRST point,
-         highlight it so it's obvious the next click closes the shape (vs. adding a new point). */
-      measurePoints.forEach((p,i)=>f.push(turf.point(p, (i===0&&measureSnapClose&&measurePoints.length>=3)?{snap:true}:{})));
-      /* Dashed preview from the last fixed point to the live cursor */
-      if(liveCursor && measurePoints.length>=1){
-        const last=measurePoints[measurePoints.length-1];
-        try{ const gc=turf.greatCircle(turf.point(last),turf.point(liveCursor),{npoints:32}); gc.properties={...(gc.properties||{}),preview:true}; f.push(gc); }
-        catch(e){ f.push({type:'Feature',geometry:{type:'LineString',coordinates:[last,liveCursor]},properties:{preview:true}}); }
-      }
-    } else if(toolMode==='area'){
-      if(measurePoints.length>=3){
-        /* Great-circle polygon, antimeridian + pole safe (#5): build the ring in continuous lon,
-           then split into pieces that each stay inside [-180,180] (no seam-jump fill bug). */
-        try{
-          const ring=_gcRingUnwrapped(measurePoints,48);
-          _splitPolyToWindows(ring).forEach(r=>f.push({type:'Feature',geometry:{type:'Polygon',coordinates:[r]},properties:{color:'#007aff',opacity:0.18,noStroke:true}}));
-          _splitLineToWindows(ring).forEach(ln=>f.push({type:'Feature',geometry:{type:'LineString',coordinates:ln},properties:{color:'#007aff',ringline:true}}));
-        }catch(e){ try{ f.push(turf.polygon([[...measurePoints,measurePoints[0]]],{color:'#007aff',opacity:0.18,noStroke:true})); }catch(_){} }
-      } else if(measurePoints.length>=2){
-        try{
-          const gc=turf.greatCircle(turf.point(measurePoints[0]),turf.point(measurePoints[1]),{npoints:48});
-          f.push(gc);
-        }catch(e){ f.push(turf.lineString(measurePoints)); }
-      }
-      measurePoints.forEach(p=>f.push(turf.point(p)));
-      /* Dashed preview while drawing area: great-circle line to cursor + closing arc */
-      if(liveCursor && measurePoints.length>=1){
-        const last=measurePoints[measurePoints.length-1];
-        try{ const gc=turf.greatCircle(turf.point(last),turf.point(liveCursor),{npoints:32}); gc.properties={...(gc.properties||{}),preview:true}; f.push(gc); }
-        catch(e){ f.push({type:'Feature',geometry:{type:'LineString',coordinates:[last,liveCursor]},properties:{preview:true}}); }
-        if(measurePoints.length>=2){
-          try{ const gc=turf.greatCircle(turf.point(liveCursor),turf.point(measurePoints[0]),{npoints:32}); gc.properties={...(gc.properties||{}),preview:true}; f.push(gc); }
-          catch(e){ f.push({type:'Feature',geometry:{type:'LineString',coordinates:[liveCursor,measurePoints[0]]},properties:{preview:true}}); }
-        }
-      }
-    }
-    return f;
-  }
   /* CLAMP coordinates rather than dropping whole features (#5,#25): polar great-circle math can
      push a latitude past ±90 or emit a stray non-finite value. The old code discarded the entire
      feature, so a measurement passing near a pole simply vanished. Now we clamp latitude into the
@@ -3266,7 +3055,6 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   function hideMeasureTip(){ document.getElementById('measure-tooltip').style.display='none'; }
   function totalDistance(p){ let s=0; for(let i=1;i<p.length;i++)s+=turf.distance(turf.point(p[i-1]),turf.point(p[i]),{units:'kilometers'}); return s; }
-  function ringPerimeter(p){ if(p.length<2)return 0; let s=totalDistance(p); if(p.length>=3)s+=turf.distance(turf.point(p[p.length-1]),turf.point(p[0]),{units:'kilometers'}); return s; }
   function ringArea(p){
     if(p.length<3)return 0;
     try{
@@ -3414,140 +3202,9 @@ window.addEventListener('DOMContentLoaded', () => {
     b.innerHTML='<span>📍 '+(currentLang==='jp'?'選択範囲のニュースのみ表示中':currentLang==='de'?'Nur News im gewählten Bereich':currentLang==='ru'?'Показаны новости выбранной области':currentLang==='es'?'Mostrando noticias del área seleccionada':'Showing news in the selected area')+'</span><button onclick="window._clearNewsArea()" style="background:none;border:none;color:var(--primary-color);font-weight:700;cursor:pointer;font-size:12px;white-space:nowrap;">✕ '+(currentLang==='jp'?'解除':currentLang==='de'?'Aufheben':currentLang==='ru'?'Сбросить':currentLang==='es'?'Quitar':'Clear')+'</button>';
   }
 
-  function updateToolPanel(){
-    const p=document.getElementById('tool-panel'); if(!toolMode){ p.style.display='none'; return; } p.style.display='block';
-    const titles={measure:'📏 '+t('measure'),area:'📐 '+t('areaTool'),radius:'⭕ '+t('radius')}; let body='';
-    if(toolMode==='measure'){
-      const tot=hasTurf()?totalDistance(measurePoints):0; let brg='';
-      if(measurePoints.length>=2){
-        const a=measurePoints[measurePoints.length-2], b=measurePoints[measurePoints.length-1];
-        brg=`<div class="tp-row"><span>${t('bearing')} (${currentLang==='jp'?'最終区間':currentLang==='de'?'letzter Abschnitt':currentLang==='ru'?'последний отрезок':currentLang==='es'?'último tramo':'last leg'})</span><b>${bearingHTML(a,b)}</b></div>`;
-        if(measurePoints.length>=3){
-          const s=measurePoints[0], e=measurePoints[measurePoints.length-1];
-          brg+=`<div class="tp-row"><span>${currentLang==='jp'?'始点→終点':currentLang==='de'?'Start → Ende':currentLang==='ru'?'начало → конец':currentLang==='es'?'inicio → fin':'start → end'}</span><b>${bearingHTML(s,e)}</b></div>`;
-        }
-      }
-      body=`<div class="tp-row"><span>${t('points')}</span><b>${measurePoints.length}</b></div><div class="tp-row"><span>${t('total')}</span><b>${distHTML(tot)}</b></div>${brg}${measurePoints.length>=2?`<button class="ai-action-btn" id="tp-profile">📈 ${t('elevProfile')}</button><button class="ai-action-btn" id="tp-finalize">✓ ${t('finalizeMeas')}</button>`:''}`;
-    } else if(toolMode==='area'){
-      const pe=hasTurf()?ringPerimeter(measurePoints):0, ar=(hasTurf()&&measurePoints.length>=3)?ringArea(measurePoints):0;
-      body=`<div class="tp-row"><span>${t('points')}</span><b>${measurePoints.length}</b></div><div class="tp-row"><span>${t('perimeter')}</span><b>${distHTML(pe)}</b></div><div class="tp-row"><span>${t('area')}</span><b>${ar?areaHTML(ar):'—'}</b></div><div class="tp-row" id="tp-pop-row" style="display:none;"><span>${t('popInArea')}</span><b id="tp-pop-val">—</b></div>${measurePoints.length>=3?`<button class="ai-action-btn" id="tp-pop-btn">${t('popInArea')}</button><button class="ai-action-btn" id="news-area-btn">📍 ${t('newsInArea')}</button><button class="ai-action-btn" id="ai-summarize-btn">📰 ${t('aiSumBtn')}</button><button class="ai-action-btn" id="tp-profile">📈 ${t('elevProfile')}</button><button class="ai-action-btn" id="tp-finalize">✓ ${t('finalizeMeas')}</button>`:''}`;
-    } else if(toolMode==='radius'){
-      let opts=`<option value="">${t('presetNone')}</option>`;
-      RADIUS_PRESETS.forEach(grp=>{ opts+=`<optgroup label="${grp.g[currentLang]}">`+grp.items.map(it=>`<option value="${it[1]}">${it[0]} — ${it[1]} km</option>`).join('')+`</optgroup>`; });
-      let list='';
-      if(radiusItems.length){
-        list=`<div class="tp-sub">${radiusItems.length} ${t('radius')}</div><div class="radius-list">`+radiusItems.map((c,i)=>`<div class="radius-list-item"><span class="rl-sw" style="background:${c.color}"></span><span class="rl-main">${c.radiusKm} km · ${c.center[1].toFixed(2)}°,${c.center[0].toFixed(2)}°</span><button class="rl-del" onclick="removeRadiusItem('${c.id}')">✕</button></div>`).join('')+`</div><button class="tp-clear" onclick="clearAllRadius()" style="margin-top:6px;">${t('removeAll')}</button>`;
-      }
-      body=`<div class="tp-row radius-control"><input type="range" id="radius-range" min="1" max="20000" step="10" value="${Math.min(20000,radiusKm)}"><div class="radius-row"><button type="button" id="radius-dec" class="rad-step" title="${currentLang==='jp'?'小さく':currentLang==='de'?'Kleiner':currentLang==='ru'?'Мельче':currentLang==='es'?'Reducir':'Decrease'}">−</button><input type="number" id="radius-num" min="1" value="${radiusKm}"><button type="button" id="radius-inc" class="rad-step" title="${currentLang==='jp'?'大きく':currentLang==='de'?'Größer':currentLang==='ru'?'Крупнее':currentLang==='es'?'Aumentar':'Increase'}">＋</button><select id="radius-unit" style="background:var(--input-bg);color:var(--text-main);border:1px solid var(--glass-border,rgba(128,128,128,0.25));border-radius:6px;padding:2px 4px;font-size:11.5px;"><option value="km">km</option><option value="mi">mi</option></select></div></div>
-        <div class="rad-stats"><div class="rad-stat"><label>${t('circumference')}</label><b id="rad-c">${distHTML(2*Math.PI*radiusKm)}</b></div><div class="rad-stat"><label>${t('area')}</label><b id="rad-a">${areaHTML(Math.PI*radiusKm*radiusKm)}</b></div></div><!-- (#R147) dropped the redundant Radius tile (already shown in the slider + number field) to declutter ("項目数が増え、煩雑…UIを整理") -->
-        <details class="tp-more"><summary>${currentLang==='jp'?'スタイル・プリセット':currentLang==='de'?'Stil und Vorlagen':currentLang==='ru'?'Стиль и пресеты':currentLang==='es'?'Estilo y ajustes':'Style &amp; presets'}</summary>
-        <div class="tp-sub" style="margin-top:4px;">${t('presetLbl')}</div><select class="tp-select" id="radius-preset">${opts}</select>
-        <div class="radius-color-row"><span>${t('color')}</span><div class="rad-presets">${RADIUS_COLOR_PRESETS.map(c=>`<button type="button" class="rad-preset${radiusColor.toLowerCase()===c.col?' on':''}" data-col="${c.col}" title="${c.lbl}" style="background:${c.col}"></button>`).join('')}</div><input type="color" id="radius-color" value="${radiusColor}" title="${currentLang==='jp'?'カスタム色':currentLang==='de'?'Eigene Farbe':currentLang==='ru'?'Свой цвет':currentLang==='es'?'Color personalizado':'Custom color'}"><span class="tp-sub" style="margin:0;">${t('opacity')}</span><input type="range" id="radius-op" min="0" max="0.6" step="0.02" value="${radiusOpacity}" style="flex:1; accent-color:var(--primary-color);"></div></details>
-        ${radiusItems.length?'':`<div class="tp-hint">${t('radiusHint')}</div>`}${list}${radiusItems.length?`<div class="rad-actions"><button class="rad-act" id="tp-pop-btn"><span class="ra-l">${t('popInArea')}</span></button><button class="rad-act" id="news-area-btn"><span class="ra-l">📍 ${t('newsInArea')}</span></button><button class="rad-act" id="ai-summarize-btn"><span class="ra-l">📰 ${t('aiSumBtn')}</span></button></div>`:''}<div class="tp-row" id="tp-pop-row" style="display:none;"><span>${t('popInArea')}</span><b id="tp-pop-val">—</b></div>`;   /* (#R40/#R142/#R146) circles persist; style/colour/opacity in the "Style" disclosure; 3 area actions in a compact grid (not stacked); usage hint hidden once a circle exists */
-    }
-    const footBtns = (toolMode!=='radius')
-      ? `<div class="tp-foot-btns">${measurePoints.length?`<button class="tp-clear" id="tp-undo">↶ ${t('undoPt')}</button>`:''}<button class="tp-clear" id="tp-clear">${t('clear')}</button></div>`
-      : '';
-    p.innerHTML=`<div class="tp-header"><span class="tp-title">${titles[toolMode]}</span><span class="tp-hd-btns"><button class="tp-min-btn" title="${currentLang==='jp'?'最小化':currentLang==='de'?'Minimieren':currentLang==='ru'?'Свернуть':currentLang==='es'?'Minimizar':'Minimize'}">–</button><button class="tp-close" title="${t('close')}">✕</button></span></div>${body}${footBtns}`;
-    p.classList.toggle('tp-radius', toolMode==='radius');   /* (#R22) drives the compact mobile radius layout */
-    if(p.dataset.collapsed==='1'){ p.classList.add('tp-collapsed'); }   /* (#R34) keep minimized state across re-renders */
-    p.querySelector('.tp-close').onclick=exitTool; makeDraggable(p,p.querySelector('.tp-header'));
-    /* (#R34) Minimize button ("Enable − in Radius") — collapses the panel to just its header so the tool no
-       longer covers the centre crosshair on mobile ("Radius widget is too big so it hides the cross pointer"). */
-    { const mb=p.querySelector('.tp-min-btn'); if(mb) mb.onclick=(e)=>{ e.stopPropagation(); const on=p.classList.toggle('tp-collapsed'); p.dataset.collapsed=on?'1':'0'; mb.title=(currentLang==='jp'?(on?'展開':'最小化'):currentLang==='de'?(on?'Ausklappen':'Minimieren'):currentLang==='ru'?(on?'Развернуть':'Свернуть'):currentLang==='es'?(on?'Expandir':'Minimizar'):(on?'Expand':'Minimize')); }; }   /* (#R35) icon (line↔box) is drawn by CSS off .tp-collapsed — no text –/+ */
-    { const sb=p.querySelector('#ai-summarize-btn'); if(sb){ sb.classList.toggle('ai-needs-key',!aiReady()); sb.title=aiReady()?'':t('aiNoKey');
-      /* (#R119) the area summary now runs INSIDE the Atlas thread (analyze scope:"drawn-area" = news in the area +
-         displayed-layer values + WorldPop population, one conversation surface). The legacy popup stays as fallback. */
-      sb.onclick=()=>{ try{ if(window.IntMapConsole&&window.IntMapConsole.runDirect){
-          const q5=currentLang==='jp'?'描画した範囲内の状況を要約・分析して':currentLang==='de'?'Fasse die Lage im gezeichneten Gebiet zusammen':currentLang==='ru'?'Сводка по нарисованной области':currentLang==='es'?'Resume la situación del área dibujada':'Summarize and analyse the situation inside the drawn area';
-          window.IntMapConsole.runDirect(q5,[{type:'analyze',question:q5,scope:'drawn-area'}]); return; } }catch(_){}
-        aiSummarizeArea(); }; } }
-    { const nb=p.querySelector('#news-area-btn'); if(nb) nb.onclick=()=>{ try{ window._searchNewsInArea(); }catch(_){} }; }
-    { const fb=p.querySelector('#tp-finalize'); if(fb) fb.onclick=()=>{ try{ window._finalizeMeasurement(); }catch(_){} }; const pb=p.querySelector('#tp-profile'); if(pb) pb.onclick=()=>{ try{ window._elevationProfile(); }catch(_){} }; }
-    /* (#R118) population inside the drawn polygon / placed circle(s) — WorldPop 100m grid (see IntMapPopArea) */
-    { const pb2=p.querySelector('#tp-pop-btn');
-      const pbL=(txt)=>{ if(!pb2) return; const l=pb2.querySelector('.ra-l'); if(l) l.textContent=txt; else pb2.textContent=txt; };   /* (#R146) label lives in a .ra-l span (grid ellipsis) — update the span, not the button */
-      const showRes=(popv,yr,src,multi)=>{ const row=p.querySelector('#tp-pop-row'), val=p.querySelector('#tp-pop-val');
-        if(row&&val){ row.style.display=''; val.innerHTML=Number(popv).toLocaleString()+' <span style="font-size:10px;color:var(--text-muted);">('+src+' '+yr+(multi?' · Σ':'')+')</span>'; } };
-      /* (#R122/#R139) PROGRESS BAR — the WorldPop summation runs as a server-side task (~10-30 s). WorldPop gives NO
-         true % for a single request (its task API only reports created/finished), so the old time-based ease-out that
-         DECELERATED toward 92% and snapped to 100% read as meaningless ("100%に近づくほど遅くなる／グラフの意味を成さない").
-         Now HONEST (see window._imProgCtl): an INDETERMINATE animated sweep while there is no real fraction, switching
-         to a REAL LINEAR fraction the moment one exists — a large area that must be TILED reports tiles-done/total,
-         and multiple radius circles advance per finished circle (each circle's own tiling fills its band). */
-      const _progLbl=()=>currentLang==='jp'?'WorldPop人口グリッドを集計中…':currentLang==='de'?'WorldPop-Bevölkerungsraster wird summiert…':currentLang==='ru'?'Суммирование сетки населения WorldPop…':currentLang==='es'?'Sumando la cuadrícula de población WorldPop…':'Summing the WorldPop population grid…';
-      const _mkProg=()=>{ let box=p.querySelector('.tp-prog'); if(!box){ box=document.createElement('div'); box.className='tp-prog'; box.style.cssText='margin:7px 0 2px;';
-          box.innerHTML='<div style="display:flex;justify-content:space-between;gap:8px;font-size:10.5px;color:var(--text-muted);margin-bottom:3px;"><span class="tp-prog-lbl" style="min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></span><b class="tp-prog-pct" style="flex:0 0 auto;">0%</b></div><div style="height:7px;border-radius:4px;background:rgba(128,128,128,0.22);overflow:hidden;"><div class="tp-prog-fill" style="height:100%;width:0%;background:linear-gradient(90deg,#0a84ff,#5e5ce6);transition:width .2s;"></div></div>';
-          if(pb2&&pb2.parentNode) pb2.parentNode.insertBefore(box,pb2.nextSibling); else p.appendChild(box); }
-        box.querySelector('.tp-prog-lbl').textContent=_progLbl(); box.classList.remove('indet'); box.style.display='block'; return box; };
-      if(pb2) pb2.onclick=async()=>{ const box=_mkProg(); const P=window._imProgCtl(box); P.busy();
-        const onProg=(f)=>P.set(f);   /* fires only when the area is large enough to be TILED → real tiles-done fraction */
-        try{
-          pb2.disabled=true; pbL(t('popCalcing'));
-          if(toolMode==='area'&&measurePoints.length>=3){
-            const geom={type:'Polygon',coordinates:[[...measurePoints,measurePoints[0]]]};
-            const r=await window.IntMapPopArea.estimate(geom, onProg); P.done(); setTimeout(()=>{ box.style.display='none'; },450);
-            showRes(r.pop,r.year,r.src,false); pb2.style.display='none'; return; }
-          if(toolMode==='radius'&&radiusItems.length){ let tot=0, yr=2020, src='WorldPop'; const N=radiusItems.length;
-            for(let i=0;i<N;i++){ if(N>1) P.set(i/N); else P.busy();
-              const c=radiusItems[i]; const g=window.IntMapPopArea.circleGeom(c.center,c.radiusKm);
-              const r=await window.IntMapPopArea.estimate(g, (N>1)?(f=>P.set((i+Math.max(0,Math.min(1,f)))/N)):onProg); tot+=r.pop; yr=r.year; src=r.src;
-              if(N>1) P.set((i+1)/N); }
-            P.done(); setTimeout(()=>{ box.style.display='none'; },450);
-            showRes(tot,yr,src,N>1); pb2.style.display='none'; return; }
-          box.style.display='none'; pb2.disabled=false; pbL(t('popInArea'));
-        }catch(e){ box.style.display='none'; pb2.disabled=false; pbL(t('popFail')); setTimeout(()=>{ try{ pbL(t('popInArea')); }catch(_){} },2600); } }; }
-    const cl=p.querySelector('#tp-clear'); if(cl) cl.onclick=()=>{ measurePoints=[]; if(toolMode==='area'){ toolMode='measure'; try{ _syncToolBtns(); }catch(_){} } hideMeasureTip(); refreshTool(); updateToolPanel(); };
-    const un=p.querySelector('#tp-undo'); if(un) un.onclick=()=>window._measureUndo();
-    if(toolMode==='radius'){
-      const r=p.querySelector('#radius-range'), n=p.querySelector('#radius-num'), op=p.querySelector('#radius-op'), pre=p.querySelector('#radius-preset'), col=p.querySelector('#radius-color');
-      /* (#R11) When a circle is "active" (just dropped, esp. from a pin / map-click popup), the slider /
-         color / opacity edit THAT circle live — not just the defaults for the next one. */
-      const applyActive=()=>{ if(!window._activeRadiusId) return; const c=radiusItems.find(x=>x.id===window._activeRadiusId); if(c){ c.radiusKm=radiusKm; c.color=radiusColor; c.opacity=radiusOpacity; refreshTool(); } };
-      /* (#R15d) Radius input unit toggle (km/mi) — imperial is selectable even when the app default is
-         metric. The slider stays km internally; only the number field + its unit follow the toggle. */
-      const unitSel=p.querySelector('#radius-unit'); if(unitSel && (window.unitMode==='imperial')) unitSel.value='mi';
-      const rImp=()=>!!(unitSel && unitSel.value==='mi');
-      const dispVal=(km)=> rImp()? Math.round(km/1.60934*100)/100 : km;
-      const refresh=()=>{ const rc=p.querySelector('#rad-c'), ra=p.querySelector('#rad-a'); if(rc) rc.innerHTML=distHTML(2*Math.PI*radiusKm); if(ra) ra.innerHTML=areaHTML(Math.PI*radiusKm*radiusKm); };   /* (#R147) radius tile removed */
-      const setR=(v,fromInput)=>{ radiusKm=v; if(!fromInput)n.value=dispVal(v); r.value=Math.min(20000,v); refresh(); applyActive(); };
-      r.oninput=()=>setR(Math.max(1,+r.value));
-      n.oninput=()=>{ const raw=parseFloat(n.value); if(!isNaN(raw)&&raw>0){ const km=rImp()? raw*1.60934 : raw; setR(km,true); } };
-      /* (#R33) −/＋ steppers for the radius (10% per tap, min 1km). */
-      { const dec=p.querySelector('#radius-dec'), inc=p.querySelector('#radius-inc');
-        const step=(f)=>{ const nv=Math.max(1, Math.round(radiusKm*f)); setR(nv); };
-        if(dec) dec.onclick=()=>step(0.9); if(inc) inc.onclick=()=>step(1.1111); }
-      if(unitSel){ unitSel.onchange=()=>{ n.value=dispVal(radiusKm); }; unitSel.value=rImp()?'mi':'km'; n.value=dispVal(radiusKm); }
-      op.oninput=()=>{ radiusOpacity=parseFloat(op.value); applyActive(); };
-      const markPreset=()=>{ p.querySelectorAll('.rad-preset').forEach(b=>b.classList.toggle('on',(b.getAttribute('data-col')||'').toLowerCase()===radiusColor.toLowerCase())); };
-      col.oninput=()=>{ radiusColor=col.value; markPreset(); applyActive(); };
-      /* R / G / B quick presets (#R7) — one tap sets the circle color; the swatch ring shows the
-         active choice. The color picker remains for any custom color. */
-      p.querySelectorAll('.rad-preset').forEach(b=>{ b.onclick=()=>{ radiusColor=b.getAttribute('data-col'); col.value=radiusColor; markPreset(); applyActive(); }; });
-      pre.onchange=()=>{ const v=parseFloat(pre.value); if(v>0) setR(v); };
-    }
-  }
   /* ===== AI FEATURE 3: spatial news summarization (radius / area) =====
      Collect the news pins whose coordinates fall inside the drawn circle(s) or polygon,
      then ask the LLM for a ~3-line geopolitical read on the region. */
-  async function aiSummarizeArea(){
-    if(!aiGate()) return;
-    if(!hasTurf()){ aiToast('Turf.js unavailable'); return; }
-    let inside=null;
-    if(toolMode==='radius'){
-      if(!radiusItems.length){ aiToast(t('aiSumNoArea')); return; }
-      inside=(lng,lat)=>radiusItems.some(c=>{ try{ return turf.distance(turf.point(c.center),turf.point([lng,lat]),{units:'kilometers'})<=c.radiusKm; }catch(_){ return false; } });
-    } else if(toolMode==='area'){
-      if(measurePoints.length<3){ aiToast(t('aiSumNoArea')); return; }
-      let poly; try{ poly=turf.polygon([[...measurePoints,measurePoints[0]]]); }catch(_){ aiToast(t('aiSumNoArea')); return; }
-      inside=(lng,lat)=>{ try{ return turf.booleanPointInPolygon(turf.point([lng,lat]),poly); }catch(_){ return false; } };
-    } else { return; }
-    const seen=new Set(), picked=[];
-    newsFeatures.forEach(f=>{ const c=f.geometry&&f.geometry.coordinates, p=f.properties||{}; if(!c||!inside(c[0],c[1])) return; const k=p.link||p.title; if(seen.has(k)) return; seen.add(k); picked.push(p); });
-    const uniq=picked.slice(0,40);
-    if(!uniq.length){ aiToast(t('aiSumNoNews')); return; }
-    _aiAreaSummarize(uniq,'aiSumTitle');
-  }
   /* Shared report+run used by BOTH the drawn-area summary and the live-view summary. */
   function _aiAreaSummarize(uniq, titleKey){
     const rep=aiReport({ title:t(titleKey), sub:t('aiSumSub').replace('{n}',uniq.length) });
@@ -4520,23 +4177,8 @@ window.addEventListener('DOMContentLoaded', () => {
 
   /* ===== Date / TZ ===== */
   function parseDate(input){ if(input instanceof Date)return isNaN(input.getTime())?new Date():input; let d=new Date(input); if(isNaN(d.getTime())&&typeof input==='string')d=new Date(input.replace(' ','T')+'Z'); return isNaN(d.getTime())?new Date():d; }
-  const tzOpt=()=>(userTZ==='auto'?undefined:userTZ);
-  const ymd=(d,tz)=>new Intl.DateTimeFormat('en-CA',{timeZone:tz,year:'numeric',month:'2-digit',day:'2-digit'}).format(d);
-  const hm=(d,tz)=>new Intl.DateTimeFormat('en-GB',{timeZone:tz,hour:'2-digit',minute:'2-digit',hour12:false}).format(d);
-  function formatCustomDate(s){ const d=parseDate(s),tz=tzOpt(),now=new Date(); const a=ymd(d,tz),today=ymd(now,tz),yest=ymd(new Date(now.getTime()-864e5),tz),time=hm(d,tz);
-    /* (#R37) localize "today"/"yesterday" for ALL four languages — the old en?…:… else-branch showed Japanese to DE/RU. */
-    const TODAY=({en:'today',jp:'今日',de:'heute',ru:'сегодня'})[currentLang]||'today', YEST=({en:'yesterday',jp:'昨日',de:'gestern',ru:'вчера'})[currentLang]||'yesterday';
-    if(a===today)return `${TODAY} ${time}`; if(a===yest)return `${YEST} ${time}`; const[,M,D]=a.split('-'); return `${+M}/${+D} ${time}`; }
 
-  /* =============================================================================
-   * WEBGL PIN INFRASTRUCTURE — pins are rendered as native MapLibre circle layers
-   * on the WebGL canvas. The map projection math runs on the GPU at the exact
-   * lng/lat, so pins CANNOT drift relative to the map at any zoom or projection.
-   * The hover tooltip is a single shared DOM element positioned by mouse pixel.
-   * ============================================================================= */
-  const INFO_COLORS={ choke:'#ff9500', mil:'#ff3b30', tech:'#007aff', space:'#af52de', energy:'#34c759', hub:'#5856d6', maritime:'#30b0c7' };
   let mapTooltipEl=null, newsFeatures=[], dashFeatures=[];
-  let hoveredNewsId=null, hoveredDashId=null;
 
   function ensureMapTooltip(){
     if(mapTooltipEl) return mapTooltipEl;
@@ -4628,225 +4270,6 @@ window.addEventListener('DOMContentLoaded', () => {
   window._declutterNewsBands=_declutterNewsBands;
   function scheduleNewsDeclutter(){ if(_ndcT) clearTimeout(_ndcT); _ndcT=setTimeout(()=>{ _ndcT=null; _declutterNewsBands(); },90); }
   window.scheduleNewsDeclutter=scheduleNewsDeclutter;
-  function setupIntelLayers(){
-    /* (#R161 MapLibre reduction, Phase 3) the NEWS overlay is created through IntMapGeoEngine.
-       `GE` falls back to nothing only if the engine has not been constructed yet (it is built in
-       map.on('load') before the first call), in which case we simply return and the existing
-       styledata re-run creates the layers. */
-    const GE=window.IntMapGeoEngine;
-    if(!GE||!GE.ready()) return;
-    ensureLabelPill();
-    if(!GE.layers.hasSource('news-points')){
-      GE.layers.addSource('news-points',{type:'geojson',data:{type:'FeatureCollection',features:[]},promoteId:'fid'});
-      GE.layers.add({id:'news-pulse',type:'circle',source:'news-points',filter:['match',['get','mapped'],['true','publisher'],true,false],paint:{
-        'circle-radius':['interpolate',['linear'],['zoom'],0,8,4,14,10,22],
-        'circle-color':['match',['get','mapped'],'publisher','#5856d6','#007aff'],
-        'circle-opacity':0.18,
-        'circle-stroke-width':0
-      }});
-      GE.layers.add({id:'news-dots',type:'circle',source:'news-points',paint:{
-        'circle-radius':['case',['boolean',['feature-state','hover'],false],10,7],
-        'circle-color':['match',['get','mapped'],
-          'true','#007aff',
-          'publisher','#5856d6',
-          'none','#9b59b6',
-          '#9b59b6'],
-        'circle-opacity':['match',['get','mapped'],
-          'true',1.0,
-          'publisher',0.85,
-          'none',0.5,
-          0.5],
-        'circle-stroke-width':2,
-        'circle-stroke-color':'#ffffff'
-      }});
-      /* Title preview "band" to the right of the pin; hidden when hovered (popup takes over).
-         (#R15) Shown for publisher-located pins too, not just subject pins. */
-      GE.layers.add({id:'news-labels',type:'symbol',source:'news-points',layout:{   /* (#R15c) band on ALL pins incl. not-yet-located */
-        'text-field':['get','short'],
-        'text-size':11.5,
-        'text-font':['literal',['Noto Sans Regular']],
-        'text-anchor':'left',
-        'text-offset':[1.25,0],
-        /* (#R36) ROOT CAUSE of "ズームインすると帯が見えなくなる / 空間に余裕があるピンにも帯が出ない / 高速点滅":
-           GL collision is GLOBAL across every symbol layer, so allow-overlap:false made the news bands compete
-           against ALL the base-map place labels (cities/towns/streets). Zooming in spawns more base labels →
-           the bands lose the collision even when there's plenty of room between NEWS pins, and the per-frame
-           re-placement flickered. Fix: take the bands OUT of GL collision entirely (allow-overlap + ignore
-           placement) and decide visibility ourselves with a JS de-clutter that only considers OTHER NEWS bands
-           (see _declutterNewsBands). A band shows iff feature-state `bnd` is true; it runs on moveend (not every
-           frame) so it never blinks. Dense clusters → only the winners show, the rest stay dots; zoom in →
-           pins spread → more win. Independent of base labels. */
-        'symbol-sort-key':['match',['get','mapped'],'true',0,'publisher',1,'none',3,2],
-        'text-allow-overlap':true,
-        'text-ignore-placement':true,
-        'text-optional':false,
-        'text-max-width':14,
-        'icon-image':'news-pill',
-        'icon-text-fit':'both',
-        'icon-text-fit-padding':[2,9,2,9],
-        'icon-allow-overlap':true,
-        'icon-ignore-placement':true,
-        'icon-optional':false
-      },paint:{
-        'text-color':'#ffffff',
-        'text-halo-color':'rgba(0,0,0,0.55)',
-        'text-halo-width':0.8,
-        'text-opacity':['case',['boolean',['feature-state','hover'],false],0,['case',['boolean',['feature-state','bnd'],false],1,0]],
-        'icon-opacity':['case',['boolean',['feature-state','hover'],false],0,['case',['boolean',['feature-state','bnd'],false],1,0]]
-      }});
-      GE.events.on('moveend',scheduleNewsDeclutter); GE.events.on('zoomend',scheduleNewsDeclutter);
-      /* If pins were accumulated before map.load, flush them now. */
-      if(newsFeatures.length){ GE.layers.setSourceData('news-points',{type:'FeatureCollection',features:newsFeatures}); try{scheduleNewsDeclutter();}catch(_){} }
-      try{ refreshNewsPill(); }catch(_){}   /* (#R32) set the band's initial colors for the current theme */
-    }
-    if(!GE.layers.hasSource('dash-points')){
-      GE.layers.addSource('dash-points',{type:'geojson',data:{type:'FeatureCollection',features:[]},promoteId:'fid'});
-      GE.layers.add({id:'dash-pulse',type:'circle',source:'dash-points',paint:{
-        'circle-radius':['interpolate',['linear'],['zoom'],0,10,4,18,10,28],
-        'circle-color':['get','color'],
-        'circle-opacity':0.20,
-        'circle-stroke-width':0
-      }});
-      GE.layers.add({id:'dash-dots',type:'circle',source:'dash-points',paint:{
-        'circle-radius':['case',['boolean',['feature-state','hover'],false],11,8],
-        'circle-color':['get','color'],
-        'circle-stroke-width':2,
-        'circle-stroke-color':'#ffffff'
-      }});
-      if(dashFeatures.length) GE.layers.setSourceData('dash-points',{type:'FeatureCollection',features:dashFeatures});
-    }
-    if(window._intelHandlersBound) return;
-    window._intelHandlersBound=true;
-    /* News hover/click — (#R161 Phase 3) bound through IntMapGeoEngine.events.onLayer */
-    GE.events.onLayer('mousemove','news-dots',e=>{
-      if(!e.features.length) return;
-      GE.render.setCursor('pointer');
-      const f=e.features[0];
-      if(hoveredNewsId!==f.id){
-        if(hoveredNewsId!=null) try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:false});}catch(err){}
-        hoveredNewsId=f.id;
-        try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:true});}catch(err){}
-      }
-      const el=ensureMapTooltip(); el.style.display='block';
-      el.innerHTML=`<div style="display:flex;justify-content:space-between;gap:8px;"><span style="color:var(--primary-color);font-weight:600;font-size:11px;">[${IntMapSafe.html(f.properties.name)}]</span><span style="color:var(--text-muted);font-size:11px;font-weight:500;">${formatCustomDate(f.properties.pubDate)}</span></div><div style="line-height:1.4;font-weight:500;margin-top:4px;">${IntMapSafe.html(f.properties.title)}</div><div style="color:var(--text-muted);margin-top:6px;font-size:11px;">${IntMapSafe.html(f.properties.publisher)}</div>`;   /* (#R138 SEC) news name/title/publisher come from external RSS → escape */
-      positionTooltip(GE.coords.project(f.geometry.coordinates));
-    });
-    GE.events.onLayer('mouseleave','news-dots',()=>{
-      if(hoveredNewsId!=null){ try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:false});}catch(err){} hoveredNewsId=null; }
-      GE.render.setCursor('');
-      if(mapTooltipEl) mapTooltipEl.style.display='none';
-    });
-    /* (#R38) MOBILE: tapping a news pin/band shows a POPUP with a "Read" button rather than jumping straight
-       to the article (the explicit request "直接ニュース記事に行くのではなく、ポップアップが出て、そこに読むボタン").
-       Desktop keeps the direct open (its hover tooltip already previews the item). */
-    function _showMobileNewsPopup(pr){
-      if(!pr) return;
-      let back=document.getElementById('m-news-pop-back');
-      if(!back){ back=document.createElement('div'); back.id='m-news-pop-back'; back.className='m-news-pop-back'; back.innerHTML='<div class="m-news-pop"></div>'; document.body.appendChild(back);
-        back.addEventListener('click',(ev)=>{ if(ev.target===back) back.classList.remove('show'); }); }
-      const pop=back.querySelector('.m-news-pop'), link=pr.link||'';
-      const readLbl=currentLang==='jp'?'記事を読む':currentLang==='de'?'Artikel lesen':currentLang==='ru'?'Читать статью':'Read article';
-      const closeLbl=currentLang==='jp'?'閉じる':currentLang==='de'?'Schließen':currentLang==='ru'?'Закрыть':'Close';
-      pop.innerHTML=`<div class="mnp-head"><span class="mnp-loc">${pr.name?('['+IntMapSafe.html(pr.name)+']'):''}</span><span class="mnp-date">${formatCustomDate(pr.pubDate)}</span></div><div class="mnp-title">${IntMapSafe.html(pr.title||'')}</div><div class="mnp-pub">${IntMapSafe.html(pr.publisher||'')}</div><div class="mnp-actions">${link?`<button class="mnp-read" type="button">${readLbl}</button>`:''}<button class="mnp-close" type="button">${closeLbl}</button></div>`;   /* (#R138 SEC) escape external news fields */
-      const rb=pop.querySelector('.mnp-read'); if(rb) rb.onclick=()=>{ try{ const _u=IntMapSafe.url(link); if(_u) window.open(_u,'_blank','noopener'); }catch(_){} back.classList.remove('show'); };   /* (#R138 SEC) http(s) only — never open a javascript: link */
-      const cb=pop.querySelector('.mnp-close'); if(cb) cb.onclick=()=>back.classList.remove('show');
-      back.classList.add('show');
-    }
-    window._showMobileNewsPopup=_showMobileNewsPopup;
-    GE.events.onLayer('click','news-dots',e=>{
-      if(!e.features.length) return;
-      const p=e.features[0].properties;
-      if(isMobile()){ _showMobileNewsPopup(p); return; }
-      /* Desktop: open the article straight in the device's browser (the in-app mini-browser was removed) */
-      if(p.link){ const _u=IntMapSafe.url(p.link); if(_u) window.open(_u,'_blank','noopener'); }   /* (#R138 SEC) http(s)-only */
-    });
-    /* (#R37) The BAND (news-labels = the place-name pill) is the big, natural tap target — make it clickable
-       too, not just the tiny dot ("地名ラベルを押しても反応しない"). */
-    GE.events.onLayer('click','news-labels',e=>{ if(!e.features.length) return; const p=e.features[0].properties; if(isMobile()){ _showMobileNewsPopup(p); return; } if(p.link){ const _u=IntMapSafe.url(p.link); if(_u) window.open(_u,'_blank','noopener'); }   /* (#R138 SEC) http(s)-only */ });
-    GE.events.onLayer('mousemove','news-labels',e=>{ if(!e.features.length) return; GE.render.setCursor('pointer'); const f=e.features[0];
-      /* (#R159) hovering the BAND itself must hide the band while the popup shows — the band's icon/text-opacity
-         collapses to 0 when this feature's `hover` state is set (same rule the dot uses). The band sits offset to the
-         right of the dot and swallows the pointer, so the news-dots handler never fires here; set the state directly,
-         reusing the shared `hoveredNewsId` so crossing dot↔band never leaves a stuck-hover. */
-      if(hoveredNewsId!==f.id){
-        if(hoveredNewsId!=null) try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:false});}catch(err){}
-        hoveredNewsId=f.id;
-        try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:true});}catch(err){}
-      }
-      const el=ensureMapTooltip(); el.style.display='block';
-      el.innerHTML=`<div style="display:flex;justify-content:space-between;gap:8px;"><span style="color:var(--primary-color);font-weight:600;font-size:11px;">[${IntMapSafe.html(f.properties.name)}]</span><span style="color:var(--text-muted);font-size:11px;font-weight:500;">${formatCustomDate(f.properties.pubDate)}</span></div><div style="line-height:1.4;font-weight:500;margin-top:4px;">${IntMapSafe.html(f.properties.title)}</div><div style="color:var(--text-muted);margin-top:6px;font-size:11px;">${IntMapSafe.html(f.properties.publisher)}</div>`;   /* (#R138 SEC) news name/title/publisher come from external RSS → escape */
-      positionTooltip(GE.coords.project(f.geometry.coordinates)); });
-    GE.events.onLayer('mouseleave','news-labels',()=>{ GE.render.setCursor(''); if(mapTooltipEl) mapTooltipEl.style.display='none';
-      if(hoveredNewsId!=null){ try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:false});}catch(err){} hoveredNewsId=null; }   /* (#R159) restore the band when the pointer leaves it */ });
-    /* (#R37) MOBILE crosshair → news popup, the same way the DESKTOP cursor reveals the pin under it
-       ("モバイル版でも…十字ポインターの位置のニュースは…ポップアップが出るように"). On every settle, look for a news
-       pin/band right under the centre crosshair and show the same popup there; tap it to open the article. */
-    let _xhrNewsId=null, _xhrLink=null, _xhrProps=null;
-    function _crosshairNews(){ try{
-      /* (#R107) DISABLED on mobile per request ("disable hover news pin and popping news popup in mobile version"):
-         no auto hover-highlight of the pin under the crosshair and no auto-popping news tooltip. Tapping a pin/label
-         still opens the article (that handler is separate). Clear any lingering state and bail. */
-      if(mapTooltipEl){ mapTooltipEl.style.display='none'; mapTooltipEl.style.pointerEvents='none'; }
-      if(_xhrNewsId!=null){ try{map.setFeatureState({source:'news-points',id:_xhrNewsId},{hover:false});}catch(_){} _xhrNewsId=null; _xhrLink=null; _xhrProps=null; }
-      return;
-      if(!isMobile()||!map||!map.isStyleLoaded()||!map.getLayer('news-dots')) return;
-      if(toolMode||document.body.classList.contains('pg-we')){ if(mapTooltipEl) mapTooltipEl.style.display='none'; return; }
-      const c=map.project(map.getCenter()); const R=22;
-      const layers=['news-labels','news-dots'].filter(l=>map.getLayer(l));
-      let hits=[]; try{ hits=map.queryRenderedFeatures([[c.x-R,c.y-R],[c.x+R,c.y+R]],{layers}); }catch(_){}
-      if(hits&&hits.length){ let best=hits[0],bd=Infinity; hits.forEach(f=>{ try{ const p=map.project(f.geometry.coordinates); const d=Math.hypot(p.x-c.x,p.y-c.y); if(d<bd){bd=d;best=f;} }catch(_){} }); const f=best, pr=f.properties||{};
-        if(_xhrNewsId!==f.id){ if(_xhrNewsId!=null) try{map.setFeatureState({source:'news-points',id:_xhrNewsId},{hover:false});}catch(_){}
-          _xhrNewsId=f.id; try{map.setFeatureState({source:'news-points',id:f.id},{hover:true});}catch(_){} }
-        _xhrLink=pr.link||null; _xhrProps=pr;
-        const el=ensureMapTooltip(); el.style.display='block'; el.style.pointerEvents='auto'; el.style.cursor='pointer';
-        el.innerHTML=`<div style="display:flex;justify-content:space-between;gap:8px;"><span style="color:var(--primary-color);font-weight:600;font-size:11px;">[${pr.name}]</span><span style="color:var(--text-muted);font-size:11px;font-weight:500;">${formatCustomDate(pr.pubDate)}</span></div><div style="line-height:1.4;font-weight:500;margin-top:4px;">${pr.title}</div><div style="color:var(--text-muted);margin-top:6px;font-size:11px;">${pr.publisher}${' · '+(currentLang==='jp'?'タップで詳細':currentLang==='de'?'Für Details tippen':currentLang==='ru'?'Нажмите для подробностей':'tap for details')}</div>`;
-        try{ positionTooltip(map.project(f.geometry.coordinates)); }catch(_){}
-      } else { if(_xhrNewsId!=null){ try{map.setFeatureState({source:'news-points',id:_xhrNewsId},{hover:false});}catch(_){} _xhrNewsId=null; } _xhrLink=null; _xhrProps=null; if(mapTooltipEl){ mapTooltipEl.style.display='none'; mapTooltipEl.style.pointerEvents='none'; } }
-    }catch(_){} }
-    window._crosshairNews=_crosshairNews;
-    map.on('moveend',_crosshairNews);
-    /* tap the crosshair popup itself → open the article (the dot under the crosshair is too small to hit) */
-    document.addEventListener('click',(ev)=>{ try{ if(!isMobile()||!_xhrProps) return; if(mapTooltipEl&&mapTooltipEl.style.display!=='none'&&mapTooltipEl.contains(ev.target)){ _showMobileNewsPopup(_xhrProps); } }catch(_){} });
-    /* Dash hover/click */
-    map.on('mousemove','dash-dots',e=>{
-      if(!e.features.length) return;
-      map.getCanvas().style.cursor='pointer';
-      const f=e.features[0];
-      if(hoveredDashId!==f.id){
-        if(hoveredDashId!=null){
-          try{map.setFeatureState({source:'dash-points',id:hoveredDashId},{hover:false});}catch(err){}
-          const oc=document.getElementById('card-'+hoveredDashId); if(oc) oc.classList.remove('hovered');
-          const olditem=extendedDashDB.find(i=>i.id===hoveredDashId); if(olditem&&olditem.layerRef) window.triggerLayerHover(olditem.layerRef,false);
-        }
-        hoveredDashId=f.id;
-        try{map.setFeatureState({source:'dash-points',id:hoveredDashId},{hover:true});}catch(err){}
-        const card=document.getElementById('card-'+hoveredDashId);
-        if(card){ card.classList.add('hovered'); }
-        if(f.properties.layerRef) window.triggerLayerHover(f.properties.layerRef,true);
-      }
-      const el=ensureMapTooltip(); el.style.display='block';
-      el.innerHTML=`<div style="color:${f.properties.color};font-weight:600;font-size:14px;">${f.properties.title}</div><div style="line-height:1.4;margin-top:4px;color:var(--text-muted);">${f.properties.body}</div>`;
-      positionTooltip(map.project(f.geometry.coordinates));
-    });
-    map.on('mouseleave','dash-dots',()=>{
-      if(hoveredDashId!=null){
-        try{map.setFeatureState({source:'dash-points',id:hoveredDashId},{hover:false});}catch(err){}
-        const oc=document.getElementById('card-'+hoveredDashId); if(oc) oc.classList.remove('hovered');
-        const olditem=extendedDashDB.find(i=>i.id===hoveredDashId); if(olditem&&olditem.layerRef) window.triggerLayerHover(olditem.layerRef,false);
-        hoveredDashId=null;
-      }
-      map.getCanvas().style.cursor='';
-      if(mapTooltipEl) mapTooltipEl.style.display='none';
-    });
-    map.on('click','dash-dots',e=>{
-      if(!e.features.length) return;
-      const f=e.features[0], id=f.id;
-      map.flyTo({center:f.geometry.coordinates,zoom:4,speed:1.2});
-      const wasInfo=currentMode==='info';
-      if(!wasInfo) setMode('info','btn-info');   /* clicking a pin reveals its card */
-      setTimeout(()=>{ const card=document.getElementById('card-'+id); if(card){ card.scrollIntoView({behavior:'smooth',block:'center'}); card.classList.add('hovered'); setTimeout(()=>card.classList.remove('hovered'),1800); } }, wasInfo?60:280);
-    });
-  }
   window.highlightDashMarker=function(id,on){ if(map&&map.getSource('dash-points')){ try{ map.setFeatureState({source:'dash-points',id},{hover:on}); }catch(e){} } };
   function clearIntelSources(){ if(map){ if(map.getSource('news-points')) map.getSource('news-points').setData({type:'FeatureCollection',features:[]}); if(map.getSource('dash-points')) map.getSource('dash-points').setData({type:'FeatureCollection',features:[]}); newsFeatures=[]; dashFeatures=[]; } }
   /* (#R122/#R123) SPREAD DUPLICATE NEWS PINS — many stories geolocate to the SAME anchor (a country/city point, e.g.
@@ -4861,76 +4284,6 @@ window.addEventListener('DOMContentLoaded', () => {
          border.
      Deterministic (seeded from the anchor) so the layout is stable across re-renders. Degrades to the golden-angle
      disk when countryGeo/turf aren't available yet. */
-  function _spreadDupNewsPins(feats){ try{ if(!Array.isArray(feats)||feats.length<2) return feats;
-    const groups=new Map();
-    feats.forEach(f=>{ if(!f||!f.geometry) return;
-      /* (#R127) remember each pin's ORIGINAL anchor so the spread is IDEMPOTENT — re-running it (once the async
-         country borders finish loading, see _respreadNews) re-groups by the TRUE stacked coords instead of the
-         already-scattered ones (which no longer collide → a permanent tight blob if countryGeo wasn't ready on the
-         first pass — the strongest systemic cause of "密集的に散らすだけ"). */
-      if(!f.__oc){ const c=f.geometry.coordinates; if(!c||!isFinite(+c[0])||!isFinite(+c[1])) return; f.__oc=[+c[0],+c[1]]; }
-      const c=f.__oc; const k=c[0].toFixed(3)+','+c[1].toFixed(3); let g=groups.get(k); if(!g){ g=[]; groups.set(k,g); } g.push(f); });
-    const GA=2.399963229; /* golden angle (rad) */
-    const cg=(window.countryGeo&&window.countryGeo.features&&window.countryGeo.features.length)?window.countryGeo:null;
-    const haveTurf=(typeof turf!=='undefined');
-    const _regCache=new Map();
-    /* the country polygon under an anchor + its bbox / representative centre, AND the LARGEST ring's own bbox +
-       polygon (used to spread when the whole-feature bbox is an antimeridian artifact). */
-    function regionFor(c0){ if(!cg||!haveTurf) return null; const key=c0[0].toFixed(2)+','+c0[1].toFixed(2);
-      if(_regCache.has(key)) return _regCache.get(key);
-      let out=null; try{ const pt=turf.point(c0);
-        for(const f of cg.features){ if(!f.geometry) continue; try{ if(turf.booleanPointInPolygon(pt,f)){
-          const bb=turf.bbox(f);
-          /* (#R124) representative point = centroid of the LARGEST ring (by bbox area), NOT the whole-feature bbox
-             centre — the latter is skewed by outlying territory (Alaska pulls the US centre up into Canada).
-             (#R127) also keep that largest ring's OWN bbox + polygon: a country whose polygon crosses the
-             antimeridian (USA/Aleutians, Russia, Fiji, NZ) has turf.bbox ≈ [-180…180], so sampling the WHOLE bbox
-             lands ~99% in open ocean → EVERY rejection sample misses → the old code collapsed to a 0.12° dot. This
-             is exactly the reported "アメリカに分類された…アメリカの領域内に分散できていない". Sample the mainland ring. */
-          let bc=[(bb[0]+bb[2])/2,(bb[1]+bb[3])/2], rbb=bb.slice(), rPoly=f;
-          try{ const polys=f.geometry.type==='MultiPolygon'?f.geometry.coordinates:[f.geometry.coordinates]; let bestA=-1;
-            polys.forEach(poly=>{ const ring=poly&&poly[0]; if(!ring||ring.length<3) return; let mnx=1e9,mny=1e9,mxx=-1e9,mxy=-1e9,sx=0,sy=0; ring.forEach(p=>{ if(p[0]<mnx)mnx=p[0]; if(p[0]>mxx)mxx=p[0]; if(p[1]<mny)mny=p[1]; if(p[1]>mxy)mxy=p[1]; sx+=p[0]; sy+=p[1]; }); const a=(mxx-mnx)*(mxy-mny); if(a>bestA){ bestA=a; bc=[sx/ring.length,sy/ring.length]; rbb=[mnx,mny,mxx,mxy]; rPoly={type:'Feature',properties:{},geometry:{type:'Polygon',coordinates:[ring]}}; } });
-          }catch(_){}
-          out={f,bb,bc,rbb,rPoly}; break; } }catch(_){} } }catch(_){}
-      _regCache.set(key,out); return out; }
-    function seeded(c0){ let s=Math.abs(Math.round(c0[0]*1000+c0[1]*7919))||1; return ()=>{ s=(s*1103515245+12345)&0x7fffffff; return s/0x7fffffff; }; }
-    groups.forEach(g=>{ if(g.length<2) return; const c0=g[0].__oc.slice();
-      const ptype=String((g[0].properties&&g[0].properties.ptype)||'').toLowerCase();
-      const reg=regionFor(c0);
-      /* country-level = the gazetteer typed it 'country', OR the anchor sits near the containing country's
-         representative centre — a country-representative point (a stacked cluster ON the centroid), not a real city
-         inside it. (#R127) the proximity test now also rescues a country cluster mis-typed 'city' (a "US"/"America"
-         headline that resolved to a city term) — a genuine city almost never sits within ~1.6° of the mainland
-         centroid AND stacks dozens of duplicate stories there. */
-      let countryLevel=false;
-      if(reg){ if(ptype==='country'||ptype==='nation') countryLevel=true;
-        else if(ptype!=='region'&&ptype!=='flashpoint'){ const near=Math.hypot(c0[0]-reg.bc[0],c0[1]-reg.bc[1]); countryLevel = near < (ptype==='city'?1.6:2.6); } }
-      if(countryLevel && reg){
-        /* (#R127) antimeridian-safe: if the whole-feature bbox is absurdly wide it's a dateline artifact → spread
-           over the mainland ring; otherwise the full feature (best coverage for compact archipelagos like
-           Indonesia/Philippines that don't cross 180°). */
-        const crossAM=(reg.bb[2]-reg.bb[0])>180;
-        const sbb=crossAM?reg.rbb:reg.bb, sf=crossAM?reg.rPoly:reg.f, rnd=seeded(c0), cosl=Math.max(0.2,Math.cos(c0[1]*Math.PI/180));
-        const diag=Math.hypot(sbb[2]-sbb[0],sbb[3]-sbb[1]);
-        g.forEach((ft,i)=>{ let placed=null;
-          for(let k=0;k<44;k++){ const lng=sbb[0]+rnd()*(sbb[2]-sbb[0]), lat=sbb[1]+rnd()*(sbb[3]-sbb[1]);
-            try{ if(turf.booleanPointInPolygon(turf.point([lng,lat]),sf)){ placed=[lng,lat]; break; } }catch(_){} }
-          if(!placed){ const r=Math.min(diag*0.42,0.5+0.14*Math.sqrt(i)), ang=i*GA;   /* miss → REGION-scaled disk (mainland diagonal), genuinely wide — not a 0.12° dot */
-            placed=[c0[0]+r*Math.cos(ang)/cosl, c0[1]+r*Math.sin(ang)]; }
-          ft.geometry={type:'Point',coordinates:placed}; });
-      } else {
-        const cosl=Math.max(0.2,Math.cos(c0[1]*Math.PI/180));
-        /* (#R127) widened so a mis-classified or borderless cluster still reads as DISTRIBUTED, not a dense knot;
-           still latitude-corrected and clipped back inside the containing country when one is known. */
-        const base=(ptype==='region')?0.12:(ptype==='city'||ptype==='flashpoint')?0.05:0.08;
-        const cap=(ptype==='region')?1.1:(ptype==='city'||ptype==='flashpoint')?0.32:0.5;
-        g.forEach((ft,i)=>{ if(i===0){ ft.geometry={type:'Point',coordinates:c0.slice()}; return; }   /* leave one pin on the true spot (reset on a re-spread) */
-          let r=Math.min(cap,base*Math.sqrt(i)); const ang=i*GA;
-          let lng=c0[0]+r*Math.cos(ang)/cosl, lat=c0[1]+r*Math.sin(ang);
-          if(reg&&haveTurf){ try{ if(!turf.booleanPointInPolygon(turf.point([lng,lat]),reg.f)){ r*=0.5; lng=c0[0]+r*Math.cos(ang)/cosl; lat=c0[1]+r*Math.sin(ang); } }catch(_){} }
-          ft.geometry={type:'Point',coordinates:[lng,lat]}; }); }
-    });
-    return feats; }catch(_){ return feats; } }
   /* (#R127) re-run the duplicate spread on the CURRENT pins — called once the async country borders finish loading.
      A cold-load race left a country cluster as a tight blob because regionFor() had no polygon yet; the pins kept
      their ORIGINAL anchors in __oc, so re-spreading now fills the real territory. No-op unless news pins are live. */
@@ -5106,75 +4459,6 @@ window.addEventListener('DOMContentLoaded', () => {
     }catch(_){ return false; }
   }
   window._newsHasForeignLang=_newsHasForeignLang;
-  function renderUI(){
-    const feed=document.getElementById('live-news-feed'),
-          cfeed=document.getElementById('countries-feed'),
-          dash=document.getElementById('info-dashboard'),
-          comm=document.getElementById('community-feed'),
-          afeed=document.getElementById('atlas-feed'),   /* (#R112) Atlas tab content area */
-          sb=document.getElementById('sidebar-search-bar'),   /* (#R79e) by ID — #countries-search-bar also has class .search-bar, so querySelector('.search-bar') could grab it after a ws cycle and renderUI would leak the "Filter countries" box into the normal sidebar */
-          filterToggle=document.getElementById('news-filter-toggle');
-    clearMarkers();
-    try{ pushCommunityFeatures(); }catch(_){}   /* show community pins only on the Community tab */
-    /* Hide all panels first (pin-mode toggle now lives inside #ai-geocode-row, #28) */
-    feed.style.display='none'; if(cfeed) cfeed.style.display='none'; dash.style.display='none'; comm.style.display='none'; if(afeed) afeed.style.display='none'; filterToggle.style.display='none';
-    { const _mf=document.getElementById('monitors-feed'); if(_mf) _mf.style.display='none'; }   /* (#R141) hide Monitors feed unless its tab is active */
-    { const gr=document.getElementById('ai-geocode-row'); if(gr) gr.style.display='none'; }
-    /* Stats compare panel only belongs on the Stats tab (#26) */
-    if(currentMode!=='stats'){ const scf=document.getElementById('stats-compare-fixed'); if(scf){ scf.classList.remove('show'); scf.innerHTML=''; } feed.style.paddingBottom=''; }
-    if(currentMode!=='info'){ const cof=document.getElementById('co-compare-fixed'); if(cof){ cof.classList.remove('show'); cof.innerHTML=''; } }   /* (#R152) Companies compare dock only belongs on the Companies tab — mirror the Countries dock hide above so the absolute overlay never lingers over another tab */
-    /* Search-bar UI per tab (#27): News keeps a Search button (matching is slow);
-       Info & Stats filter live as you type, so their button is hidden.
-       Summarize-this-view button shows only on the News tab (#20). */
-    const searchBtn=document.getElementById('btn-search');
-    const sumBtn=document.getElementById('ai-view-summary-btn');
-    const isNewsTab=(currentMode==='news'||currentMode==='saved');
-    if(searchBtn) searchBtn.style.display=isNewsTab?'':'none';
-    /* (#R129) the Countries search bar's "pick on the map" crosshair shows only on the Countries tab (the bar is
-       shared with News/Info); leaving Countries cancels an active pick so the crosshair/handler never lingers. */
-    { const cpk=document.getElementById('csearch-pick'); if(cpk) cpk.classList.toggle('on-tab', currentMode==='stats'); }
-    if(!document.body.classList.contains('ws-mode') && currentMode!=='stats' && window.__countryPickActive && window.__countryPickActive()){ try{ window.__countryPick(false); }catch(_){} }
-    /* (#R85) "要約ボタンがニュースウィンドウを開いてなくても表示される": in workspace mode renderUI still runs with
-       currentMode==='news' even when the News WINDOW is hidden, so the summarize-view button leaked onto the map.
-       Also require the News window to be visible in ws-mode (_wsNewsHidden() is always false outside ws-mode, so
-       the normal News-tab behaviour is unchanged). */
-    if(sumBtn) sumBtn.style.display=(isNewsTab && !(window._wsNewsHidden&&window._wsNewsHidden()))?'':'none';
-    { const ip=document.getElementById('search-input'); if(ip) ip.placeholder = (currentMode==='stats'||currentMode==='info'||currentMode==='monitors') ? (currentLang==='jp'?'絞り込み...':currentLang==='de'?'Filtern…':currentLang==='ru'?'Фильтр…':currentLang==='es'?'Filtrar…':'Filter…') : t('searchPh'); }
-
-    /* (#R11) No tab selected → blank sidebar content (map stays prominent). News pins still load when the
-       user opens the News tab. (#R19) The blank state now hosts the opt-in Apple-style widget board. */
-    if(!currentMode){ if(sb) sb.style.display='none'; try{ window.IntMapWidgets2&&window.IntMapWidgets2.sync(); }catch(_){} try{ updateOcclusion(); }catch(_){} return; }
-    try{ window.IntMapWidgets2&&window.IntMapWidgets2.sync(); }catch(_){}
-    /* (#R112) Atlas tab — the console renders IN FLOW inside #atlas-feed (below the tab bar), exactly like News /
-       Information / Countries. Its own input replaces the news search bar. Workspace mode never reaches here (Atlas
-       is its own window there). */
-    if(currentMode==='atlas'){ if(afeed) afeed.style.display='flex'; if(sb) sb.style.display='none';
-      try{ window.IntMapConsole&&window.IntMapConsole.mountTab&&window.IntMapConsole.mountTab(); }catch(_){}
-      try{ updateOcclusion(); }catch(_){} return; }
-    if(currentMode==='info'){ dash.style.display='flex'; sb.style.display='flex'; renderDashboard(); updateOcclusion(); return; }
-    if(currentMode==='monitors'){ const mf=document.getElementById('monitors-feed'); if(mf) mf.style.display='flex'; sb.style.display='flex';   /* (#R141) Monitors tab */
-      try{ window.IntMapMonitors&&window.IntMapMonitors.render(searchVal()); }catch(_){}
-      try{ updateOcclusion(); }catch(_){} return; }
-    if(currentMode==='community'){ comm.style.display='flex'; sb.style.display='none'; loadCommunity(); updateOcclusion(); return; }
-    if(currentMode==='stats'){ if(cfeed) cfeed.style.display='flex'; sb.style.display='flex'; renderStats(searchVal()); return; }
-    if(currentMode==='news'||currentMode==='saved'){
-      feed.style.display='flex'; sb.style.display='flex';
-      filterToggle.style.display='block';
-      /* (#R30) Translate titles only when the news set actually carries a non-UI language. */
-      { const gr=document.getElementById('ai-geocode-row'); if(gr) gr.style.display=_newsHasForeignLang()?'block':'none'; }
-      try{ aiSyncFeatureButtons(); }catch(_){}
-      /* sync the All / ★ Saved sub-filter (Saved now lives inside the News tab) */
-      document.getElementById('newsfilter-all').textContent = currentLang==='jp'?'すべて':currentLang==='de'?'Alle':currentLang==='ru'?'Все':currentLang==='es'?'Todo':'All';
-      document.getElementById('newsfilter-saved').textContent = currentLang==='jp'?'★ 保存済み':currentLang==='de'?'★ Gespeichert':currentLang==='ru'?'★ Сохранённые':currentLang==='es'?'★ Guardado':'★ Saved';
-      document.getElementById('newsfilter-all').classList.toggle('active', currentMode==='news');
-      document.getElementById('newsfilter-saved').classList.toggle('active', currentMode==='saved');
-      /* sync the segmented control with current mode */
-      document.getElementById('pinmode-loc').classList.toggle('active', newsPinMode==='location');
-      document.getElementById('pinmode-pub').classList.toggle('active', newsPinMode==='publisher');
-      startNews(); return;
-    }
-    feed.style.display='flex'; sb.style.display='none'; feed.innerHTML=`<div class="empty-msg">${t('emptyHint')}</div>`;
-  }
   /* Wire up the in-tab Subject/Publisher segment buttons */
   function setNewsPinMode(mode){
     if(newsPinMode===mode) return;
@@ -5208,65 +4492,9 @@ window.addEventListener('DOMContentLoaded', () => {
      Items the local gazetteer couldn't place sit at fake hash coords (analysis.mapped===false).
      Ask the LLM for the real {name,lat,lng}, then promote them to mapped subject pins. */
   function aiReaffirmLoc(a){ applyPinMode(a); }
-  /* Rebuild news-points from the current filter WITHOUT touching the sidebar feed (so a
-     progressive update during geocoding doesn't reset scroll). Mirrors startNews()'s shape. */
-  function aiRefreshNewsPins(){
-    if(!(map&&map.getSource('news-points'))) return;
-    newsFeatures=[];
-    computeFilteredNews().forEach(item=>{ const a=item.analysis; if(a&&a.loc){
-      const fid='n_'+Math.random().toString(36).slice(2,10);
-      const mappedStr=a.mapped===true?'true':(a.mapped==='publisher'?'publisher':'none');
-      newsFeatures.push({type:'Feature',id:fid,geometry:{type:'Point',coordinates:a.loc},properties:{
-        fid, mapped:mappedStr, ptype:a.ptype||'', title:item.title, name:a.name||'', short:a.short||'', publisher:item.publisher, link:item.link, pubDate:item.pubDate }});
-    }});
-    _spreadDupNewsPins(newsFeatures);   /* (#R122) fan out pins sharing an anchor */
-    map.getSource('news-points').setData({type:'FeatureCollection',features:newsFeatures}); try{scheduleNewsDeclutter();}catch(_){}
-  }
-  const AI_GEO_CAP=120;  /* cover essentially the whole feed in one click (calls are batched) */
   /* Mode-aware AI locator. In Subject mode it geocodes the event location; in Publisher mode
      it geocodes the outlet's HQ. `force` (the button) re-analyses EVERY filtered story incl.
      already-pinned ones; auto mode passes force=false and only fills the gaps. */
-  async function aiGeocodeNews(force){
-    if(!aiGate()) return;
-    const mode=newsPinMode, pub=(mode==='publisher'), cacheKey=pub?'_aiPub':'_aiGeo';
-    const need=it=>{ const a=it.analysis; if(!a) return false;
-      if(force) return true;
-      return pub ? (!a.pubLoc && !a[cacheKey]) : (!a.subjectLoc && !a[cacheKey]); };
-    const todo=computeFilteredNews().filter(need).slice(0,AI_GEO_CAP);
-    const btn=document.getElementById('ai-geocode-btn');
-    if(!todo.length){ aiToast(t('aiGeoNone')); return; }
-    aiSetBtnBusy(btn,true,t('aiGeoBusy'));
-    const sys=pub
-      ? "You are a precise geocoder. Each numbered line is the NAME of a news outlet / publisher. Return the city where that outlet is headquartered. Reply with ONLY a JSON array, one object per identifiable outlet: {\"i\":<index>,\"name\":\"<City, Country>\",\"lat\":<number>,\"lng\":<number>}. Omit outlets you cannot place. No commentary, no code fences."
-      : "You are a precise geocoder for a world news map. For EACH numbered headline, return the SUBJECT LOCATION: the single specific real-world place where the main event/incident actually happens. RULES: (1) NOT the news outlet's HQ or dateline (e.g. ignore 'Reuters, London'). (2) NOT a place where someone merely SPOKE about the event — if an official at the White House in Washington comments on the Middle East, return the specific Middle-East country/city the event concerns, NOT Washington. (3) Be as SPECIFIC as possible — prefer city/landmark over country (e.g. 'Mariupol' over 'Ukraine', 'Rafah' over 'Gaza' when identifiable). Reply with ONLY a JSON array; one object per locatable item: {\"i\":<index number>,\"name\":\"<short English place name, most specific>\",\"lat\":<number>,\"lng\":<number>}. Omit any item with no clear subject location. No commentary, no code fences.";
-    const BATCH=12; let done=0, hit=0, failed=false;
-    try{
-      for(let i=0;i<todo.length;i+=BATCH){
-        const chunk=todo.slice(i,i+BATCH);
-        const list=pub
-          ? chunk.map((it,k)=>`${k}. ${it.publisher||'?'}`).join('\n')
-          : chunk.map((it,k)=>`${k}. ${it.title}${it.desc?' — '+String(it.desc).slice(0,160):''}`).join('\n');
-        let arr=null;
-        try{ arr=await askAIJSON((pub?'Outlets:\n':'Headlines:\n')+list, sys); }
-        catch(e){ aiToast((e&&e.message)||t('aiGeoErr')); failed=true; break; }
-        if(Array.isArray(arr)) arr.forEach(o=>{
-          if(!o||typeof o.lat!=='number'||typeof o.lng!=='number') return;
-          if(o.lat<-90||o.lat>90||o.lng<-180||o.lng>180) return;
-          const it=chunk[o.i]; if(!it||!it.analysis) return;
-          if(pub){ it.analysis.pubLoc=[o.lng,o.lat]; it.analysis.pubName=(currentLang==='jp'?'発信: ':currentLang==='de'?'Quelle: ':currentLang==='ru'?'Источник: ':currentLang==='es'?'Fuente: ':'Source: ')+(o.name||it.publisher||''); }
-          else { it.analysis.subjectLoc=[o.lng,o.lat]; it.analysis.subjectName=o.name||it.analysis.subjectName||''; }
-          applyPinMode(it.analysis); hit++;
-        });
-        /* mark the whole chunk attempted so auto-mode won't re-ask outlets the AI couldn't place */
-        chunk.forEach(it=>{ if(it.analysis) it.analysis[cacheKey]=true; });
-        done+=chunk.length;
-        aiSetBtnBusy(btn,true,t('aiGeoBusy')+' '+done+'/'+todo.length);
-        aiRefreshNewsPins(); /* progressive pin update */
-      }
-    } finally { aiSetBtnBusy(btn,false); }
-    if(currentMode==='news'||currentMode==='saved') startNews(); /* refresh feed chips + pins */
-    if(!failed) aiToast(hit? t('aiGeoDone').replace('{n}',hit) : t('aiGeoNone'));
-  }
   { const gb=document.getElementById('ai-geocode-btn'); if(gb) gb.onclick=()=>aiGeocodeNews(true); }
   aiButtonSyncers.push(function(){ const b=document.getElementById('ai-geocode-btn'); if(!b) return;
     b.classList.toggle('ai-needs-key',!aiReady()); b.title=aiReady()?'':t('aiNoKey');
@@ -5377,42 +4605,6 @@ window.addEventListener('DOMContentLoaded', () => {
     } finally { _translateBusy=false; aiSetBtnBusy(btn,false); }
     aiToast(hit? t('aiTransDone').replace('{n}',hit) : t('aiTransNone'));
   }
-  function appendNewsBatch(){
-    const feed=document.getElementById('live-news-feed');
-    const next=newsFiltered.slice(renderedCount, renderedCount+NEWS_BATCH);
-    next.forEach(item=>{
-      const card=document.createElement('div'); card.className='news-item'; const bm=bookmarks.includes(item.link);
-      let chipCls='loc-chip';
-      if(item.analysis.mapped===true) chipCls='loc-chip';
-      else if(item.analysis.mapped==='publisher') chipCls='loc-chip publisher';
-      else chipCls='loc-chip unmapped';
-      const readLabel = currentLang==='jp'?'記事を読む ↗':currentLang==='de'?'Lesen ↗':currentLang==='ru'?'Читать ↗':currentLang==='es'?'Leer ↗':'Read ↗';
-      card.innerHTML=`<button class="btn-bookmark ${bm?'active':''}">★</button>
-        <div class="news-head"><span class="${chipCls}">${IntMapSafe.html(item.analysis.name)||(currentLang==='jp'?'場所不明':currentLang==='de'?'Ort unbekannt':currentLang==='ru'?'Место неизвестно':currentLang==='es'?'Ubicación desconocida':'Location unknown')}</span><small class="news-date">${formatCustomDate(item.pubDate)}</small></div>
-        <div class="news-title">${newsTitleHTML(item)}</div>
-        <div class="news-foot"><small class="news-pub"${item.publisher?' role="link" tabindex="0" title="'+IntMapSafe.html(item.publisher+' — Wikipedia ↗')+'"':''}>${IntMapSafe.html(item.publisher)}</small><button class="btn-read">${readLabel}</button></div>`;   /* (#R138 SEC) name/publisher from external RSS → escape (newsTitleHTML self-escapes) */
-      card.querySelector('.btn-bookmark').onclick=async(e)=>{ e.stopPropagation();
-        if(currentUser){ const on=await toggleFavorite(item.link,item.title); if(currentMode==='saved')startNews(); else card.querySelector('.btn-bookmark').classList.toggle('active',on); }
-        else { /* guest: keep a local list until they log in */ if(bookmarks.includes(item.link))bookmarks=bookmarks.filter(b=>b!==item.link); else bookmarks.push(item.link); saveBookmarks(); if(currentMode==='saved')startNews(); else card.querySelector('.btn-bookmark').classList.toggle('active'); }
-      };
-      /* (#R11) Read article → open directly in the device's browser (reverted per request). */
-      card.querySelector('.btn-read').onclick=(e)=>{ e.stopPropagation(); const _u=IntMapSafe.url(item.link); if(_u) window.open(_u,'_blank','noopener'); };   /* (#R138 SEC) http(s)-only */
-      /* (#R142) Clicking the OUTLET NAME opens that outlet's Wikipedia page in the UI language (jp→ja subdomain). Uses
-         Special:Search&go=Go so an exact title jumps straight to the article and a near-miss lands on search results
-         instead of a 404 (publisher strings from RSS don't always match a Wikipedia title exactly). stopPropagation so
-         it doesn't also fly the card. */
-      { const pub=card.querySelector('.news-pub');
-        if(pub&&item.publisher){ const openWiki=(e)=>{ e.stopPropagation(); const wl=(currentLang==='jp')?'ja':currentLang; const _u=IntMapSafe.url('https://'+wl+'.wikipedia.org/w/index.php?title=Special:Search&search='+encodeURIComponent(item.publisher)+'&go=Go'); if(_u) window.open(_u,'_blank','noopener'); };
-          pub.onclick=openWiki; pub.addEventListener('keydown',e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); openWiki(e); } }); } }
-      /* Whole card → fly to the map location (replaces the old "Show on map" button) */
-      card.onclick=()=>{ if(map&&item.analysis.loc) map.flyTo({center:item.analysis.loc,zoom:4,speed:1.0}); };
-      item._cardEl=card; /* lets the translation pass update this title in place */
-      feed.appendChild(card);
-      /* Pins are populated in bulk by startNews(); no per-batch pin push here. */
-    });
-    renderedCount+=next.length;
-    updateOcclusion();
-  }
   document.getElementById('live-news-feed').addEventListener('scroll',(e)=>{
     if(currentMode!=='news'&&currentMode!=='saved') return;
     const f=e.target;
@@ -5508,11 +4700,6 @@ window.addEventListener('DOMContentLoaded', () => {
       try{ if(window._imReader&&res&&Array.isArray(res.blocks)&&res.blocks.length){
         window._imReader.body=res.blocks.map(b=>String((b&&(b.v!=null?b.v:(b.text!=null?b.text:b)))||'')).filter(Boolean).join('\n\n').slice(0,6000); } }catch(_){ } });
   }
-  function readerBar(item,mode){
-    const back=currentLang==='jp'?'戻る':currentLang==='de'?'Zurück':currentLang==='ru'?'Назад':currentLang==='es'?'Atrás':'Back';
-    const other=mode==='reader'?(currentLang==='jp'?'🌐 ページ表示':currentLang==='de'?'🌐 Web':currentLang==='ru'?'🌐 Веб':currentLang==='es'?'🌐 Web':'🌐 Web'):(currentLang==='jp'?'📖 リーダー':currentLang==='de'?'📖 Reader':currentLang==='ru'?'📖 Читалка':currentLang==='es'?'📖 Lector':'📖 Reader');
-    return `<div class="nrp-bar"><button class="nrp-back" id="nrp-back-btn">‹ ${back}</button><button class="nrp-mode" id="nrp-mode-btn">${other}</button>${mode==='reader'?`<button class="nrp-mode" id="nrp-translate-btn">✨ ${t('aiTranslate')}</button>`:''}<span class="nrp-src">${escForReader(item.publisher)}</span></div>`;
-  }
   function renderReader(item,res){
     const pane=document.getElementById('news-reader-pane'); if(!pane) return;
     /* If we extracted real body text, default to the clean Reader; otherwise show the
@@ -5520,61 +4707,9 @@ window.addEventListener('DOMContentLoaded', () => {
     const hasText=res.blocks&&res.blocks.length>=2;
     renderReaderMode(item,res, hasText?'reader':'web');
   }
-  function renderReaderMode(item,res,mode){
-    const pane=document.getElementById('news-reader-pane'); if(!pane) return;
-    const metaRow=`<div class="nrp-meta"><span>${escForReader(item.publisher)}</span><span class="nrp-dot"></span><span>${escForReader(formatCustomDate(item.pubDate))}</span></div>`;
-    if(mode==='web'){
-      pane.innerHTML=`${readerBar(item,'web')}
-        <h1 class="nrp-title">${escForReader(item.title)}</h1>${metaRow}
-        <div class="nrp-webwrap"><div class="nrp-webnote" id="nrp-webnote">${currentLang==='jp'?'ページを読み込み中…':currentLang==='de'?'Seite lädt…':currentLang==='ru'?'Загрузка страницы…':currentLang==='es'?'Cargando página…':'Loading page…'}</div><iframe class="nrp-iframe" src="${escForReader(item.link)}" referrerpolicy="no-referrer" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe></div>
-        <a class="nrp-orig" href="${escForReader(item.link)}" target="_blank" rel="noopener">${currentLang==='jp'?'新しいタブで開く':currentLang==='de'?'In neuem Tab öffnen':currentLang==='ru'?'Открыть в новой вкладке':currentLang==='es'?'Abrir en pestaña nueva':'Open in new tab'} ↗</a>`;
-      const ifr=pane.querySelector('.nrp-iframe'); const note=pane.querySelector('#nrp-webnote');
-      if(ifr){ ifr.addEventListener('load',()=>{ if(note) note.style.display='none'; });
-        setTimeout(()=>{ if(note&&note.style.display!=='none') note.innerHTML=currentLang==='jp'?'このサイトは埋め込み表示を許可していません。「📖 リーダー」か「新しいタブで開く」をお使いください。':currentLang==='de'?'Diese Seite erlaubt kein Einbetten. Nutze „📖 Reader“ oder öffne sie in einem neuen Tab.':currentLang==='ru'?'Сайт запрещает встраивание. Используйте «📖 Читалка» или откройте в новой вкладке.':currentLang==='es'?'Este sitio bloquea la inserción. Prueba «📖 Lector» o ábrelo en una pestaña nueva.':'This site blocks embedding. Try “📖 Reader” or open it in a new tab.'; }, 5000); }
-    } else {
-      const locName=(item.analysis&&item.analysis.name)?item.analysis.name:'';
-      const bodyHtml=(res.blocks&&res.blocks.length)
-        ? res.blocks.map(b=> b.t==='h' ? `<h3>${escForReader(b.v)}</h3>` : `<p>${escForReader(b.v)}</p>`).join('')
-        : `<p>${currentLang==='jp'?'本文を自動取得できませんでした。上の「🌐 ページ表示」で元ページを開けます。':currentLang==='de'?'Text konnte nicht extrahiert werden — öffne die Seite über „🌐 Web“ oben.':currentLang==='ru'?'Не удалось извлечь текст — откройте страницу через «🌐 Веб» выше.':currentLang==='es'?'No se pudo extraer el texto — abre la página con «🌐 Web» arriba.':'Could not extract text — use “🌐 Web” above to open the page.'}</p>`;
-      const heroHtml=res.hero?`<img class="nrp-hero" src="${escForReader(res.hero)}" onerror="this.style.display='none'">`:'';
-      const locHtml=locName?`<span class="nrp-loc" id="nrp-loc">${escForReader(locName)}</span>`:'';
-      pane.innerHTML=`${readerBar(item,'reader')}
-        ${heroHtml}${locHtml}
-        <h1 class="nrp-title">${escForReader(item.title)}</h1>${metaRow}
-        <div class="nrp-body">${bodyHtml}</div>
-        <a class="nrp-orig" href="${escForReader(item.link)}" target="_blank" rel="noopener">${currentLang==='jp'?'元記事を開く':currentLang==='de'?'Original öffnen':currentLang==='ru'?'Открыть оригинал':currentLang==='es'?'Abrir original':'Open original'} ↗</a>`;
-      const locEl=pane.querySelector('#nrp-loc');
-      if(locEl) locEl.onclick=()=>{ if(map&&item.analysis&&item.analysis.loc) map.flyTo({center:item.analysis.loc,zoom:4,speed:1.0}); };
-    }
-    pane.querySelector('#nrp-back-btn').onclick=closeArticleReader;
-    const mb=pane.querySelector('#nrp-mode-btn');
-    if(mb) mb.onclick=()=>renderReaderMode(item,res, mode==='web'?'reader':'web');
-    const tb=pane.querySelector('#nrp-translate-btn'); if(tb) tb.onclick=()=>aiTranslateReader(item,res,tb);
-    pane.scrollTop=0;
-  }
   /* ===== AI FEATURE 2: in-reader translation to Japanese =====
      Translates the extracted reader text (res.blocks); toggles original/translated and
      caches the result on `res` so flipping back and forth is instant. */
-  async function aiTranslateReader(item,res,btn){
-    if(!aiGate()) return;
-    const bodyEl=document.querySelector('#news-reader-pane .nrp-body'); if(!bodyEl||!btn) return;
-    const setLbl=on=>{ btn.innerHTML = on ? '↩ '+aiEsc(t('aiShowOriginal')) : '✨ '+aiEsc(t('aiTranslate')); };
-    if(bodyEl.dataset.translated==='1'){ if(res._origHTML!=null) bodyEl.innerHTML=res._origHTML; bodyEl.dataset.translated='0'; setLbl(false); return; }
-    if(res._translatedHTML){ if(res._origHTML==null) res._origHTML=bodyEl.innerHTML; bodyEl.innerHTML=res._translatedHTML; bodyEl.dataset.translated='1'; setLbl(true); return; }
-    const src=((res.blocks||[]).map(b=>b&&b.v).filter(Boolean).join('\n\n')||'').trim();
-    if(!src){ aiToast(t('aiTransNoText')); return; }
-    res._origHTML=bodyEl.innerHTML; btn.disabled=true; btn.innerHTML='<span class="ai-spin"></span>';
-    try{
-      /* (#R39) Translate into the UI language, not always Japanese (DE/RU/EN users got Japanese). */
-      const _tgt=_aiLangName();
-      const sys="You are a professional news translator. Translate the article into natural, fluent "+_tgt+". Keep paragraph breaks. Do not add notes, labels, or the original text — output only the "+_tgt+" translation.";
-      const out=await askAI('Title: '+item.title+'\n\n'+src, sys);
-      const paras=String(out||'').split(/\n{2,}/).map(s=>s.trim()).filter(Boolean);
-      res._translatedHTML=(paras.length?paras:[String(out||'')]).map(p=>`<p>${escForReader(p)}</p>`).join('');
-      bodyEl.innerHTML=res._translatedHTML; bodyEl.dataset.translated='1';
-    }catch(e){ aiToast((e&&e.message)||t('aiError')); }
-    finally{ btn.disabled=false; setLbl(bodyEl.dataset.translated==='1'); }
-  }
   function closeArticleReader(){
     readerOpen=false; readerCurrent=null;
     try{ window._imReader=null; }catch(_){ }   /* (#R80) clear the open-article bridge (vision §2) */
@@ -5711,8 +4846,6 @@ window.addEventListener('DOMContentLoaded', () => {
   window._sfSetKey=(i,k)=>{ if(statsFilters[i]){ statsFilters[i].key=k; _sfRerender(); } };
   window._sfSetOp=(i,op)=>{ if(statsFilters[i]){ statsFilters[i].op=op; _sfRerender(); } };
   window._sfSetVal=(i,raw)=>{ if(statsFilters[i]){ statsFilters[i].raw=raw; statsFilters[i].val=_sfParse(raw); _sfRerender(); } };
-  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
-  const {CO_SECTORS,CO_CC}=window.IntMapTables;
   /* (#R163) moved to js/companies.js — see Architecture.md §3.1. */
   window.IntMapCompanies=window.IntMapModules.companies(map,IM_HOST);
   let coSort='mcap', coSortDir='desc', coFilters=[], coFilterOpen=false;
@@ -5721,21 +4854,6 @@ window.addEventListener('DOMContentLoaded', () => {
      detail; a sticky tray shows the selection and opens a side-by-side bar view. Everything reads mcap()/_coVal, which
      follow the time-machine year, so both the ranking and the comparison reflect past statistics. */
   let coCompareSet=new Set(), _coTimeWired=false, _coTimeDeb=null;
-  /* (#R145) Companies compare view state — mirrors the Countries #scp-view (Bar / Time-series / Table, metric picker). */
-  let _coCmpMode='bar', _coCmpMetOpen=false, _coCmpMet=new Set(['mcap','rev','ni','emp']), _coCmpTsFrom=null, _coCmpTsTo=null, _coCmpCss=0, _coCmpSort={key:null,dir:-1};   /* (#R147) table column sort — Countries-parity */
-  let _coCmpTsMetric='mcap';   /* (#R153) which metric the Time-series plots — only mcap/price have real history; the shared metric picker (rev/ni/emp/pe = snapshot-only) used to be shown in TS mode yet IGNORED (the "手抜き" fake control). */
-  const _CO_CMP_METS=['mcap','rev','ni','emp','pe','price'];
-  const _coCmpMetLbl=k=>{ const m={mcap:_coL('Market cap','時価総額','Marktkap.','Капитализация','Cap. bursátil'),rev:_coL('Revenue','売上高','Umsatz','Выручка','Ingresos'),ni:_coL('Net income','純利益','Nettogewinn','Чистая прибыль','Beneficio neto'),emp:_coL('Employees','従業員数','Mitarbeiter','Сотрудники','Empleados'),pe:_coL('P/E ratio','株価収益率 (P/E)','KGV','P/E','P/E'),price:_coL('Share price','株価','Aktienkurs','Цена акции','Precio acción')}; return m[k]||k; };
-  const _CO_CMP_PAL=['#0a84ff','#ff9f0a','#30d158','#ff375f','#bf5af2','#64d2ff','#ffd60a','#ac8e68'];
-  function _coWireTime(){ if(_coTimeWired||!(window.IntMapTime&&window.IntMapTime.on)) return; _coTimeWired=true;
-    const _apply=hy=>{ try{ IntMapCompanies.setYear(hy, ()=>{ if(document.getElementById('co-cmp-view')){ try{ showCoCompare([...coCompareSet]); }catch(_){} } else if(currentMode==='info'||document.body.classList.contains('ws-mode')){ try{ renderCompanies(); }catch(_){} } }); }catch(_){} };
-    window.IntMapTime.on(e=>{ clearTimeout(_coTimeDeb); _coTimeDeb=setTimeout(()=>{
-      const cur=new Date().getFullYear(); const y=(e&&e.year!=null)?e.year:null; _apply(((e&&e.isLive)||y==null||y>=cur)?null:y);
-    }, 320); });
-    /* (#R142) initial sync: if the map was ALREADY time-travelled before Companies was first opened, the subscription
-       above would miss that past event — reflect the current clock now so the ranking opens on the historical year. */
-    try{ const cur=new Date().getFullYear(); const y=window.IntMapTime.year(); if(!window.IntMapTime.isLive()&&y!=null&&y<cur) _apply(y); }catch(_){}
-  }
   window._coToggleCompare=function(tk){ if(coCompareSet.has(tk)) coCompareSet.delete(tk); else if(coCompareSet.size<10) coCompareSet.add(tk); else { const f=coCompareSet.values().next().value; coCompareSet.delete(f); coCompareSet.add(tk); }
     document.querySelectorAll('#info-dashboard .co-row').forEach(r=>r.classList.toggle('compare-on',coCompareSet.has(r.getAttribute('data-tk'))));
     try{ const c=IntMapCompanies.DATA.find(x=>x.tk===tk); if(c) imToast((coCompareSet.has(tk)?'✓ ':'− ')+_coName(c)); }catch(_){}
@@ -5765,69 +4883,6 @@ window.addEventListener('DOMContentLoaded', () => {
      sticky header + Back, a Bar-chart / Time-series / Table mode segment, a metric picker, palette chips with remove,
      an add-a-company search, a signed zero-axis bar view, an Excel-like table with CSV, and a price-history time-series.
      Reuses the .scp-* visual language (scoped to #co-cmp-view via _coCmpEnsureCss) so Countries stays untouched. */
-  let _coCmpTsGen=0;
-  function _coCmpEnsureCss(){ if(_coCmpCss) return; _coCmpCss=1; const st=document.createElement('style');
-    st.textContent='#co-cmp-view{container-type:inline-size;}'
-      +'#co-cmp-view .scp-stickhead{position:sticky;top:0;z-index:8;background:var(--panel-bg,var(--glass-fill));display:flex;flex-direction:column;gap:6px;margin:0 0 6px;padding:8px 0 6px;}'
-      +'#co-cmp-view .scp-back{display:inline-flex;align-items:center;gap:6px;border:1px solid rgba(0,0,0,0.12);border-radius:10px;background:#fff;color:#111;padding:3px 12px 3px 9px;font-size:12px;font-weight:600;cursor:pointer;flex:0 0 auto;}'
-      +'#co-cmp-view .scp-back:hover{background:#f2f2f4;}'
-      +'#co-cmp-view .scp-cmptitle{font-weight:700;font-size:13px;line-height:1.15;}'
-      +'#co-cmp-view .scp-cmpsub{font-weight:500;font-size:10.5px;color:var(--text-muted);}'
-      +'#co-cmp-view .scp-ctrlrow{display:flex;align-items:center;gap:5px;flex-wrap:wrap;}'
-      +'#co-cmp-view .scp-modes{display:inline-flex;border:1px solid rgba(128,128,128,0.3);border-radius:10px;overflow:hidden;align-self:center;}'
-      +'#co-cmp-view .scp-modes button{border:none;background:transparent;color:var(--text-muted);font-size:13.5px;font-weight:600;padding:5px 9px;cursor:pointer;}'
-      +'#co-cmp-view .scp-modes button + button{border-left:1px solid rgba(128,128,128,0.35);}'
-      +'[data-theme="dark"] #co-cmp-view .scp-modes button + button{border-left-color:rgba(255,255,255,0.6);}'
-      +'#co-cmp-view .scp-modes button.on{background:var(--primary-color);color:#fff;}'
-      +'[data-theme="dark"] #co-cmp-view .scp-modes,[data-theme="dark"] #co-cmp-view .scp-mtog:not(.open){border-color:rgba(255,255,255,0.85);}'
-      +'#co-cmp-view .scp-mtog{display:inline-flex;align-items:center;gap:4px;border:1px solid rgba(128,128,128,0.3);background:var(--input-bg);color:var(--text-main);border-radius:10px;font-size:13.5px;font-weight:600;padding:5px 9px;cursor:pointer;align-self:center;white-space:nowrap;}'
-      +'#co-cmp-view .scp-mtog .scp-mcount{font-weight:500;color:var(--text-muted);font-variant-numeric:tabular-nums;}'
-      +'#co-cmp-view .scp-mtog.open{background:var(--primary-color);border-color:var(--primary-color);color:#fff;}'
-      +'#co-cmp-view .scp-mtog.open .scp-mcount{color:rgba(255,255,255,0.85);}'
-      +'#co-cmp-view .scp-metrics{display:flex;flex-wrap:wrap;gap:5px;margin:2px 0;}'
-      +'#co-cmp-view .scp-m{font-size:11px;padding:4px 9px;border-radius:999px;border:1px solid rgba(128,128,128,0.28);background:transparent;color:var(--text-muted);cursor:pointer;}'
-      +'#co-cmp-view .scp-m.on{background:var(--primary-color);border-color:var(--primary-color);color:#fff;font-weight:600;}'
-      +'[data-theme="dark"] #co-cmp-view .scp-m{border-color:rgba(255,255,255,0.85);}'
-      +'#co-cmp-view .scp-add{height:34px;padding:0 12px;border-radius:10px;border:1px solid rgba(128,128,128,0.3);background:var(--card-bg);color:var(--text-main);font-size:12.5px;outline:none;width:100%;box-sizing:border-box;}'
-      +'#co-cmp-view #co-cmp-list{display:none;position:absolute;left:0;right:0;top:38px;max-height:230px;overflow-y:auto;background:var(--popup-bg);border:1px solid var(--glass-border,rgba(128,128,128,0.3));border-radius:12px;box-shadow:var(--shadow);z-index:40;padding:4px;}'
-      +'#co-cmp-view #co-cmp-list .scp-cr{display:flex;align-items:center;gap:8px;padding:6px 10px;border-radius:8px;cursor:pointer;font-size:12.5px;color:var(--text-main);}'
-      +'#co-cmp-view #co-cmp-list .scp-cr:hover{background:var(--input-bg);}'
-      +'#co-cmp-view .scp-chip{display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:999px;font-size:12px;font-weight:600;background:var(--input-bg);color:var(--text-main);border:1.5px solid transparent;}'   /* (#R152) match the canonical Countries .scp-chip (was missing the transparent border) */
-      +'#co-cmp-view .scp-chip .scp-x{cursor:pointer;color:var(--text-muted);font-weight:700;padding:0 2px;} #co-cmp-view .scp-chip .scp-x:hover{color:#ff453a;}'
-      +'#co-cmp-view .scp-dot{width:9px;height:9px;border-radius:50%;flex:0 0 auto;}'
-      +'#co-cmp-view .scp-sec{margin:12px 0 4px;font-weight:700;font-size:13px;color:var(--text-main);}'
-      +'#co-cmp-view .scp-bars{display:flex;flex-direction:column;gap:5px;margin:4px 0 10px;}'
-      +'#co-cmp-view .scp-brow{display:flex;align-items:center;gap:8px;font-size:12px;}'
-      +'#co-cmp-view .scp-bnm{flex:0 0 116px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-main);}'
-      +'#co-cmp-view .scp-btrack{flex:1;height:14px;border-radius:7px;background:var(--input-bg);overflow:hidden;position:relative;}'
-      +'#co-cmp-view .scp-bfill{position:absolute;top:0;bottom:0;border-radius:4px;}'
-      +'#co-cmp-view .scp-zline{position:absolute;top:-1px;bottom:-1px;width:1.5px;background:var(--text-muted);opacity:0.6;z-index:1;}'
-      +'#co-cmp-view .scp-bval{flex:0 0 104px;font-size:11.5px;white-space:nowrap;text-align:right;font-variant-numeric:tabular-nums;}'
-      +'#co-cmp-view .scp-tblwrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}'
-      +'#co-cmp-view .scp-tbl{width:100%;border-collapse:collapse;font-size:11.5px;margin:4px 0 6px;}'
-      +'#co-cmp-view .scp-tbl td,#co-cmp-view .scp-tbl th{padding:4px 7px;text-align:right;border-bottom:1px solid rgba(128,128,128,0.12);white-space:nowrap;}'
-      +'#co-cmp-view .scp-tbl th{color:var(--text-muted);font-weight:600;}'
-      +'#co-cmp-view .scp-tbl td:first-child,#co-cmp-view .scp-tbl th:first-child{text-align:left;}'
-      +'#co-cmp-view .scp-ttools{display:flex;align-items:center;gap:7px;flex-wrap:wrap;margin:2px 0 8px;}'
-      +'#co-cmp-view .scp-ttools button{height:28px;border-radius:8px;border:1px solid rgba(128,128,128,0.3);background:var(--input-bg);color:var(--text-main);font-size:11.5px;padding:0 10px;cursor:pointer;}'
-      +'#co-cmp-view .scp-ttools button:hover{border-color:var(--primary-color);color:var(--primary-color);}'
-      +'#co-cmp-view .scp-tsrange{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin:0 0 8px;padding:6px 8px;background:var(--input-bg);border:1px solid rgba(128,128,128,0.2);border-radius:9px;font-size:12px;}'
-      +'#co-cmp-view .scp-tsrange select{background:var(--card-bg);color:var(--text-main);border:1px solid rgba(128,128,128,0.25);border-radius:7px;font-size:12px;padding:4px 6px;cursor:pointer;outline:none;}'
-      +'#co-cmp-view .scp-tsrange .scp-tsl{color:var(--text-muted);font-weight:600;}'
-      +'#co-cmp-view .co-ts-note{font-size:10.5px;color:var(--text-muted);margin:2px 0 8px;line-height:1.4;}'
-      +'#co-cmp-view .co-ts-wrap svg{width:100%;height:150px;display:block;}'
-      +'#co-cmp-view .scp-tsmsel{display:inline-flex;gap:4px;margin-left:auto;}'   /* (#R153) TS metric toggle pushed to the right of the year range */
-      +'#co-cmp-view .scp-tsm{background:var(--card-bg);color:var(--text-muted);border:1px solid rgba(128,128,128,0.25);border-radius:7px;font-size:11.5px;font-weight:600;padding:4px 9px;cursor:pointer;}'
-      +'#co-cmp-view .scp-tsm.on{background:var(--primary-color);color:#fff;border-color:var(--primary-color);}'
-      +'#co-cmp-view .co-ts-chart{position:relative;}'
-      +'#co-cmp-view .co-ts-ax{position:absolute;left:4px;font-size:9.5px;color:var(--text-muted);pointer-events:none;font-variant-numeric:tabular-nums;}'
-      +'#co-cmp-view .co-ts-axhi{top:2px;} #co-cmp-view .co-ts-axlo{bottom:2px;}'
-      +'#co-cmp-view .co-ts-cursor{position:absolute;top:0;bottom:0;width:1px;background:var(--text-muted);opacity:0.5;display:none;pointer-events:none;}'
-      +'#co-cmp-view .co-ts-tip{position:absolute;top:2px;display:none;pointer-events:none;background:var(--card-bg);border:1px solid rgba(128,128,128,0.28);border-radius:8px;box-shadow:var(--shadow);padding:5px 8px;font-size:11px;z-index:5;min-width:120px;}'
-      +'#co-cmp-view .co-ts-tth{font-weight:700;margin-bottom:2px;white-space:nowrap;}'
-      +'#co-cmp-view .co-ts-ttr{display:flex;align-items:center;gap:5px;line-height:1.5;white-space:nowrap;} #co-cmp-view .co-ts-ttr b{margin-left:auto;font-variant-numeric:tabular-nums;}'
-      +'#co-cmp-view .co-ts-ttd{width:8px;height:8px;border-radius:50%;flex:0 0 auto;} #co-cmp-view .co-ts-ttn{overflow:hidden;text-overflow:ellipsis;max-width:120px;}';
-    document.head.appendChild(st); }
   function showCoCompare(tks){ const feed=document.getElementById('info-dashboard'); if(!feed) return;
     const cos=(tks||[...coCompareSet]).map(tk=>IntMapCompanies.DATA.find(x=>x.tk===tk)).filter(Boolean);
     if(cos.length<2){ try{ renderCompanies(); }catch(_){} return; }
@@ -5835,115 +4890,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const tray=document.getElementById('co-compare-fixed'); if(tray){ tray.classList.remove('show'); tray.innerHTML=''; }   /* (#R152) dock is now a STATIC overlay — hide it (don't remove the node) while the compare view owns the feed */
     if(!document.getElementById('co-cmp-view')){ feed.innerHTML='<div id="co-cmp-view"></div>'; feed.style.paddingBottom='24px'; }
     _coCmpRender(cos); }
-  function _coCmpRender(cos){ const root=document.getElementById('co-cmp-view'); if(!root) return;
-    const hy=IntMapCompanies.histYear&&IntMapCompanies.histYear();
-    const modes=[['bar',_coL('Bar chart','棒グラフ','Balken','Столбцы','Barras')],['ts',_coL('Time-series','時系列','Zeitreihe','Динамика','Series')],['table',_coL('Table','表','Tabelle','Таблица','Tabla')]];
-    let h='<div class="scp-stickhead"><div style="display:flex;align-items:center;gap:8px;">'
-      +'<button class="scp-back" data-cmpback="1"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="M15 5l-7 7 7 7"/></svg>'+_coL('Back','戻る','Zurück','Назад','Atrás')+'</button>'
-      +'<div><div class="scp-cmptitle">'+_coL('Compare companies','企業を比較','Unternehmen vergleichen','Сравнение компаний','Comparar empresas')+'</div><div class="scp-cmpsub">'+cos.length+'/10</div></div></div>';   /* (#R153) /8→/10: the cap is 10 (matches _coToggleCompare + the dock) */
-    h+='<div class="scp-ctrlrow"><div class="scp-modes">'+modes.map(m=>'<button data-cmpmode="'+m[0]+'" class="'+(_coCmpMode===m[0]?'on':'')+'">'+m[1]+'</button>').join('')+'</div>';
-    if(_coCmpMode!=='ts') h+='<button class="scp-mtog'+(_coCmpMetOpen?' open':'')+'" data-cmpmtog="1">'+_coL('Metrics','指標','Kennzahlen','Показатели','Métricas')+' <span class="scp-mcount">'+_coCmpMet.size+'/'+_CO_CMP_METS.length+'</span></button>';   /* (#R153) the generic multi-metric picker only applies to Bar/Table — HIDE it in Time-series mode where it did nothing (rev/ni/emp/pe have no history); TS has its own metric toggle inside the chart */
-    h+='</div>';
-    if(_coCmpMetOpen&&_coCmpMode!=='ts') h+='<div class="scp-metrics">'+_CO_CMP_METS.map(k=>'<button class="scp-m'+(_coCmpMet.has(k)?' on':'')+'" data-cmpmet="'+k+'">'+IntMapSafe.html(_coCmpMetLbl(k))+'</button>').join('')+'</div>';
-    h+='<div style="position:relative;margin:6px 0 2px;"><input class="scp-add" id="co-cmp-add" placeholder="'+_coL('Add a company…','企業を追加…','Firma hinzufügen…','Добавить компанию…','Añadir empresa…')+'" autocomplete="off"><div id="co-cmp-list"></div></div>';
-    h+='<div style="display:flex;flex-wrap:wrap;gap:6px;margin:4px 0 2px;">'+cos.map((c,i)=>'<span class="scp-chip"><span class="scp-dot" style="background:'+_CO_CMP_PAL[i%_CO_CMP_PAL.length]+'"></span>'+IntMapSafe.html(_coName(c))+' <span class="scp-x" data-cmpx="'+IntMapSafe.html(c.tk)+'">×</span></span>').join('')+'</div>';
-    if(hy) h+='<div class="stats-timebanner co-banner" style="margin:4px 0 0;"><b>'+hy+(currentLang==='jp'?'年':'')+'</b> · '+_coL('market cap at year-end · today\'s share counts · other figures latest reported','その年の年末時点の時価総額 · 株数は現在値 · 他の指標は最新報告値','Marktkap. zum Jahresende · heutige Aktienzahl · übrige Angaben aktuell','капитализация на конец года · число акций текущее · прочие показатели последние','cap. a fin de año · acciones actuales · demás cifras recientes')+'</div>';
-    h+='</div><div id="co-cmp-body"></div>';
-    root.innerHTML=h; _coCmpBody(cos); _coCmpWire(cos); }
-  function _coCmpBody(cos){ const body=document.getElementById('co-cmp-body'); if(!body) return;
-    const met=_CO_CMP_METS.filter(k=>_coCmpMet.has(k));
-    if(_coCmpMode==='table'){ const tmet=met.length?met:_CO_CMP_METS; body.innerHTML=_coCmpTable(cos,tmet); const b=body.querySelector('[data-cmpcsv]'); if(b) b.onclick=()=>_coCmpCsv(cos,tmet); body.querySelectorAll('[data-cmpsort]').forEach(th=>th.onclick=()=>{ const k=th.getAttribute('data-cmpsort'); if(_coCmpSort.key===k) _coCmpSort.dir=-_coCmpSort.dir; else { _coCmpSort.key=k; _coCmpSort.dir=-1; } _coCmpBody(cos); }); }   /* (#R147) sortable columns */
-    else if(_coCmpMode==='ts'){ _coCmpTs(cos,body); }
-    else body.innerHTML=_coCmpBar(cos,met); }
-  function _coCmpBar(cos,met){ if(!met.length) return '<div class="co-ts-note">'+_coL('Pick at least one metric above.','上で指標を1つ以上選択してください。','Mindestens eine Kennzahl wählen.','Выберите хотя бы один показатель.','Elige al menos una métrica.')+'</div>';
-    let h='';
-    met.forEach(k=>{ const fin=cos.map(c=>_coVal(c,k)).filter(v=>isFinite(v)); if(!fin.length) return;
-      const hi=Math.max(0,Math.max.apply(null,fin)), lo=Math.min(0,Math.min.apply(null,fin)); const span=(hi-lo)||1; const zero=(0-lo)/span*100;
-      h+='<div class="scp-sec">'+IntMapSafe.html(_coCmpMetLbl(k))+'</div><div class="scp-bars">';
-      cos.forEach((c,i)=>{ const v=_coVal(c,k); const col=_CO_CMP_PAL[i%_CO_CMP_PAL.length]; let fill='';
-        if(isFinite(v)){ const pv=(v-lo)/span*100; const l=Math.min(zero,pv), w=Math.max(1,Math.abs(pv-zero)); fill='<span class="scp-bfill" style="left:'+l.toFixed(2)+'%;width:'+w.toFixed(2)+'%;background:'+col+'"></span>'; }
-        const zl=(lo<0)?'<span class="scp-zline" style="left:'+zero.toFixed(2)+'%"></span>':'';
-        h+='<div class="scp-brow"><span class="scp-bnm">'+IntMapSafe.html(_coName(c))+'</span><span class="scp-btrack">'+zl+fill+'</span><span class="scp-bval">'+(isFinite(v)?IntMapSafe.html(_coMetric(c,k)):'—')+'</span></div>'; });
-      h+='</div>'; });
-    return h||'<div class="co-ts-note">'+_coL('No data for the selected metrics.','選択した指標のデータがありません。','Keine Daten.','Нет данных.','Sin datos.')+'</div>'; }
-  function _coCmpTable(cos,met){ const ths=met.map(k=>{ const act=_coCmpSort.key===k, arr=act?(_coCmpSort.dir<0?' ▼':' ▲'):''; return '<th class="scp-th-sort'+(act?' on':'')+'" data-cmpsort="'+k+'" style="cursor:pointer;user-select:none;white-space:nowrap;">'+IntMapSafe.html(_coCmpMetLbl(k))+arr+'</th>'; }).join('');
-    let h='<div class="scp-ttools"><button data-cmpcsv="1">'+_coL('Export CSV','CSV書き出し','CSV-Export','Экспорт CSV','Exportar CSV')+'</button></div><div class="scp-tblwrap"><table class="scp-tbl"><thead><tr><th>'+_coL('Company','企業','Firma','Компания','Empresa')+'</th>'+ths+'</tr></thead><tbody>';
-    let rows=cos.slice(); const sk=_coCmpSort.key;   /* (#R147) sort rows by the active metric column, blanks last */
-    if(sk&&met.indexOf(sk)>=0){ const d=_coCmpSort.dir; rows.sort((a,b)=>{ const va=_coVal(a,sk),vb=_coVal(b,sk),fa=isFinite(va),fb=isFinite(vb); if(!fa&&!fb) return 0; if(!fa) return 1; if(!fb) return -1; return (va-vb)*d; }); }
-    rows.forEach(c=>{ h+='<tr><td>'+IntMapSafe.html(_coName(c))+'</td>'+met.map(k=>'<td>'+IntMapSafe.html(_coMetric(c,k))+'</td>').join('')+'</tr>'; });
-    return h+'</tbody></table></div>'; }
-  function _coCmpCsv(cos,met){ const esc=s=>{ s=String(s==null?'':s); return /[",\n]/.test(s)?'"'+s.replace(/"/g,'""')+'"':s; };
-    const rows=[[_coL('Company','企業','Firma','Компания','Empresa')].concat(met.map(k=>_coCmpMetLbl(k)))];
-    cos.forEach(c=>rows.push([_coName(c)].concat(met.map(k=>{ const v=_coVal(c,k); return isFinite(v)?v:''; }))));
-    const csv='﻿'+rows.map(r=>r.map(esc).join(',')).join('\r\n'); const blob=new Blob([csv],{type:'text/csv;charset=utf-8'}); const url=URL.createObjectURL(blob);
-    const a=document.createElement('a'); a.href=url; a.download='companies-compare.csv'; document.body.appendChild(a); a.click(); setTimeout(()=>{ try{ a.remove(); URL.revokeObjectURL(url); }catch(_){} },200); }
-  async function _coCmpTs(cos,body){ const cur=new Date().getFullYear(); if(_coCmpTsTo==null) _coCmpTsTo=cur; if(_coCmpTsFrom==null) _coCmpTsFrom=cur-20;   /* (#R153) default the Time-series to a DEEPER 20-year window (was 10) so the available deep history is visible immediately ("もっと昔も見れる"); the picker still reaches Yahoo's keyless floor of 1962 for the oldest names */
-    if(_coCmpTsFrom>_coCmpTsTo) _coCmpTsFrom=_coCmpTsTo; const from=_coCmpTsFrom, to=_coCmpTsTo, gen=++_coCmpTsGen;
-    const metric=(_coCmpTsMetric==='price')?'price':'mcap';   /* (#R153) the TS metric picker now DRIVES the chart (was ignored) */
-    const yrs=[]; for(let y=cur;y>=1962;y--) yrs.push(y); const opt=sel=>yrs.map(y=>'<option value="'+y+'"'+(y===sel?' selected':'')+'>'+y+'</option>').join('');   /* (#R152) 1990→1962: reach back as far as Yahoo has data ("もっと昔も見れる"); names without data that far show "no history" honestly */
-    const mBtn=(k)=>'<button class="scp-tsm'+(metric===k?' on':'')+'" data-cmptsm="'+k+'" type="button">'+IntMapSafe.html(_coCmpMetLbl(k))+'</button>';   /* (#R153) TS metric toggle — only mcap/price have real history */
-    body.innerHTML='<div class="scp-tsrange"><span class="scp-tsl">'+_coL('Years','期間','Jahre','Годы','Años')+'</span><select data-cmptsfrom="1">'+opt(from)+'</select><span>–</span><select data-cmptsto="1">'+opt(to)+'</select><span class="scp-tsmsel">'+mBtn('mcap')+mBtn('price')+'</span></div>'
-      +'<div class="co-ts-wrap" id="co-ts-wrap"><div class="co-ts-note">'+_coL('Loading price history…','株価履歴を読み込み中…','Kursverlauf wird geladen…','Загрузка истории цен…','Cargando histórico…')+'</div></div>';
-    const wf=body.querySelector('[data-cmptsfrom]'), wt=body.querySelector('[data-cmptsto]');
-    if(wf) wf.onchange=()=>{ _coCmpTsFrom=+wf.value; _coCmpTs(cos,body); }; if(wt) wt.onchange=()=>{ _coCmpTsTo=+wt.value; _coCmpTs(cos,body); };
-    body.querySelectorAll('[data-cmptsm]').forEach(b=>b.onclick=()=>{ _coCmpTsMetric=b.getAttribute('data-cmptsm'); _coCmpTs(cos,body); });
-    const series=await Promise.all(cos.map(async c=>{ if(c.sh<=0) return {c,data:null}; try{ return {c,data:await IntMapCompanies.priceSeriesFine(c.tk,from,to)}; }catch(_){ return {c,data:null}; } }));   /* (#R152) MONTHLY series for a high-precision curve */
-    if(gen!==_coCmpTsGen) return; const wrap=document.getElementById('co-ts-wrap'); if(!wrap) return;
-    const W=600,H=150,padL=6,padR=6,padT=10,padB=6, innerW=W-padL-padR, innerH=H-padT-padB;
-    const lines=[]; let vmin=Infinity,vmax=-Infinity;
-    series.forEach(s=>{ const arr=s.data; if(!arr||arr.length<2) return;
-      let pts;
-      if(metric==='mcap'){ const sh=s.c.sh; if(!(sh>0)) return; pts=arr.filter(p=>p[1]>0).map(p=>({fy:p[0],v:p[1]*sh,ts:p[2]})); }   /* (#R153) ABSOLUTE market cap = today's share count × historical price (same approximation the time-machine already uses); (#R158) carry the point's real timestamp */
-      else { const base=arr[0][1]; if(!(base>0)) return; pts=arr.filter(p=>p[1]>0).map(p=>({fy:p[0],v:p[1]/base*100,ts:p[2]})); }   /* share price indexed to 100 at the first point */
-      if(pts.length<2) return;
-      pts.forEach(p=>{ if(p.v<vmin)vmin=p.v; if(p.v>vmax)vmax=p.v; }); lines.push({c:s.c,col:_CO_CMP_PAL[cos.indexOf(s.c)%_CO_CMP_PAL.length],pts}); });
-    if(!lines.length){ wrap.innerHTML='<div class="co-ts-note">'+_coL('No price history for these companies (US-listed live names only).','これらの企業の株価履歴がありません（米国上場のライブ銘柄のみ）。','Kein Kursverlauf (nur live gelistete US-Namen).','Нет истории цен (только листингованные в США).','Sin histórico (solo cotizadas en EE. UU.).')+'</div>'; return; }
-    const lo=(metric==='mcap')?0:vmin, hi=(metric==='mcap')?(vmax||1):vmax; const vspan=(hi-lo)||1;   /* (#R153) mcap on a real $ axis from 0; indexed price on [min,max] */
-    const _sp=((to+1)>from)?((to+1)-from):1; const X=fy=>padL+((to>from)?(fy-from)/_sp:0.5)*innerW; const Y=v=>padT+(1-(v-lo)/vspan)*innerH;   /* (#R152) X by fractional year over [from, to+1) */
-    let svg='<svg viewBox="0 0 '+W+' '+H+'" preserveAspectRatio="none">';
-    if(metric==='price'&&vmin<=100&&vmax>=100){ const y1=Y(100).toFixed(1); svg+='<line x1="'+padL+'" y1="'+y1+'" x2="'+(W-padR)+'" y2="'+y1+'" stroke="var(--text-muted)" stroke-opacity="0.3" stroke-dasharray="3 3" vector-effect="non-scaling-stroke"/>'; }
-    lines.forEach(ln=>{ svg+='<path d="'+ln.pts.map((p,j)=>(j?'L':'M')+X(p.fy).toFixed(1)+' '+Y(p.v).toFixed(1)).join(' ')+'" fill="none" stroke="'+ln.col+'" stroke-width="2" vector-effect="non-scaling-stroke"/>'; });
-    svg+='</svg>';
-    const axHi=(metric==='mcap')?('<span class="co-ts-ax co-ts-axhi">'+IntMapSafe.html(fmtMoney(hi))+'</span><span class="co-ts-ax co-ts-axlo">$0</span>'):'';   /* (#R153) real $ axis labels for the mcap view */
-    const missing=cos.filter(c=>!lines.find(l=>l.c===c));
-    let note=(metric==='mcap')
-      ? _coL('Market cap: today\'s share count × historical price · US-listed live names only','時価総額：現在の株数×当時の株価 · 米国上場のライブ銘柄のみ','Marktkap.: heutige Aktienzahl × historischer Kurs · nur live gelistete US-Namen','Капитализация: текущее число акций × историческая цена · только листингованные в США','Cap. bursátil: acciones actuales × precio histórico · solo cotizadas en EE. UU.')
-      : _coL('Share price indexed to 100 at '+from+' · US-listed live names only','株価を'+from+'年＝100に指数化 · 米国上場のライブ銘柄のみ','Aktienkurs indexiert auf 100 ('+from+') · nur live gelistete US-Namen','Цена акции: индекс 100 в '+from+' · только листингованные в США','Precio de acción base 100 en '+from+' · solo cotizadas en EE. UU.');
-    if(missing.length) note+=' · '+_coL('no history','履歴なし','kein Verlauf','нет истории','sin histórico')+': '+missing.map(c=>IntMapSafe.html(_coName(c))).join(', ');
-    wrap.innerHTML='<div class="co-ts-chart" style="position:relative;">'+svg+axHi+'<div class="co-ts-cursor"></div><div class="co-ts-tip"></div></div><div class="co-ts-note">'+note+'</div>';
-    /* (#R153) crosshair tooltip (Countries-parity) — hover shows the year + each company's value at that year. */
-    const chart=wrap.querySelector('.co-ts-chart'), cursor=wrap.querySelector('.co-ts-cursor'), tip=wrap.querySelector('.co-ts-tip');
-    /* (#R158) hover date shows the MATCHED data point's REAL month/day (was Math.round(year) only — "月/日が出ない").
-       The monthly series now carries each point's raw timestamp, so the tooltip reads the actual date localised. */
-    const _tsLoc=currentLang==='jp'?'ja-JP':currentLang==='de'?'de-DE':currentLang==='ru'?'ru-RU':currentLang==='es'?'es-ES':'en-US';
-    const _fmtTsD=(ts,fyFb)=>{ try{ if(ts!=null&&isFinite(+ts)) return new Date(+ts).toLocaleDateString(_tsLoc,{year:'numeric',month:'short',day:'numeric'}); }catch(_){} return String(Math.round(fyFb)); };
-    if(chart&&cursor&&tip){ const onMove=(e)=>{ const rc=chart.getBoundingClientRect(); if(!rc.width) return; const fx=Math.min(1,Math.max(0,(e.clientX-rc.left)/rc.width)); const fyr=from+fx*_sp;
-        cursor.style.left=(fx*100).toFixed(2)+'%'; cursor.style.display='block';
-        const rows=lines.map(ln=>{ let best=ln.pts[0],bd=Infinity; ln.pts.forEach(p=>{ const d=Math.abs(p.fy-fyr); if(d<bd){bd=d;best=p;} }); return {c:ln.c,col:ln.col,p:best}; });
-        let hdTs=null,hdBd=Infinity; rows.forEach(r=>{ if(r.p&&r.p.ts!=null){ const d=Math.abs(r.p.fy-fyr); if(d<hdBd){ hdBd=d; hdTs=r.p.ts; } } });   /* (#R158) date of the nearest actual point */
-        tip.innerHTML='<div class="co-ts-tth">'+IntMapSafe.html(_fmtTsD(hdTs,Math.min(to,Math.max(from,fyr))))+'</div>'+rows.map(r=>'<div class="co-ts-ttr"><span class="co-ts-ttd" style="background:'+r.col+'"></span><span class="co-ts-ttn">'+IntMapSafe.html(_coName(r.c))+'</span><b>'+(metric==='mcap'?IntMapSafe.html(fmtMoney(r.p.v)):(Math.round(r.p.v)+''))+'</b></div>').join('');
-        tip.style.display='block'; tip.style.left=Math.min(Math.max(4,e.clientX-rc.left+12), Math.max(4,rc.width-150))+'px'; };
-      chart.addEventListener('mousemove',onMove); chart.addEventListener('mouseleave',()=>{ cursor.style.display='none'; tip.style.display='none'; }); } }
-  function _coCmpWire(cos){ const root=document.getElementById('co-cmp-view'); if(!root) return;
-    const bk=root.querySelector('[data-cmpback]'); if(bk) bk.onclick=()=>{ root.remove(); try{ renderCompanies(); }catch(_){} };
-    root.querySelectorAll('[data-cmpmode]').forEach(b=>b.onclick=()=>{ _coCmpMode=b.getAttribute('data-cmpmode'); _coCmpRender(cos); });
-    const mt=root.querySelector('[data-cmpmtog]'); if(mt) mt.onclick=()=>{ _coCmpMetOpen=!_coCmpMetOpen; _coCmpRender(cos); };
-    root.querySelectorAll('[data-cmpmet]').forEach(b=>b.onclick=()=>{ const k=b.getAttribute('data-cmpmet'); if(_coCmpMet.has(k)){ if(_coCmpMet.size>1) _coCmpMet.delete(k); } else _coCmpMet.add(k); _coCmpRender(cos); });
-    root.querySelectorAll('[data-cmpx]').forEach(b=>b.onclick=()=>{ coCompareSet.delete(b.getAttribute('data-cmpx')); const left=[...coCompareSet]; if(left.length<2){ root.remove(); try{ renderCompanies(); }catch(_){} } else showCoCompare(left); });
-    const inp=root.querySelector('#co-cmp-add'), list=root.querySelector('#co-cmp-list'); if(inp&&list){ const have=new Set(cos.map(c=>c.tk));
-      const upd=()=>{ const q=inp.value.trim().toLowerCase(); if(!q){ list.style.display='none'; return; }
-        const hits=IntMapCompanies.DATA.filter(c=>!have.has(c.tk)&&(((_coName(c)||'').toLowerCase().includes(q))||c.tk.toLowerCase().includes(q)||(c.n||'').toLowerCase().includes(q))).slice(0,30);
-        if(!hits.length){ list.style.display='none'; return; }
-        list.innerHTML=hits.map(c=>'<div class="scp-cr" data-cmpadd="'+IntMapSafe.html(c.tk)+'">'+IntMapSafe.html(_coName(c))+' <span style="color:var(--text-muted);font-size:11px;">'+IntMapSafe.html(c.tk)+'</span></div>').join(''); list.style.display='block';
-        list.querySelectorAll('[data-cmpadd]').forEach(r=>r.onmousedown=e=>{ e.preventDefault(); const tk=r.getAttribute('data-cmpadd'); if(coCompareSet.size<10){ coCompareSet.add(tk); showCoCompare([...coCompareSet]); } }); };
-      inp.oninput=upd; inp.onfocus=upd; inp.onblur=()=>setTimeout(()=>{ try{ list.style.display='none'; }catch(_){} },180); } }
-  const _coSec=(k)=>{ const s=CO_SECTORS[k]; return s?_coL(s[0],s[1],s[2],s[3],s[4]):k; };
-  const _coCountry=(cc)=>{ const c=CO_CC[cc]; return c?(currentLang==='jp'?c[1]:c[0]):cc; };
-  const _coFlag=(cc)=>{ const c=CO_CC[cc]; return c?c[2]:''; };
   const _coName=(c)=>(currentLang==='jp'&&c.nJp)?c.nJp:c.n;
-  const CO_IND=()=>[['mcap',_coL('Market cap','時価総額','Marktkap.','Капитализация','Cap. bursátil')],['rev',_coL('Revenue','売上高','Umsatz','Выручка','Ingresos')],['ni',_coL('Net income','純利益','Nettogewinn','Чистая прибыль','Beneficio neto')],['pe',_coL('P/E ratio','株価収益率 (P/E)','KGV','P/E','P/E')],['emp',_coL('Employees','従業員数','Mitarbeiter','Сотрудники','Empleados')],['price',_coL('Share price','株価','Aktienkurs','Цена акции','Precio acción')],['fnd',_coL('Founded','設立年','Gegründet','Год основания','Fundada')],['name',_coL('Name','名称','Name','Название','Nombre')]];
-  function _coVal(c,key){ const _pr=IntMapCompanies.priceOf(c); switch(key){ case 'rev':return c.rev; case 'ni':return c.ni; case 'emp':return c.emp; case 'fnd':return c.fnd; case 'price':return _pr>0?_pr:NaN; case 'pe':{ const mc=IntMapCompanies.mcap(c); return (c.ni>0&&mc>0)?(mc/c.ni):NaN; } case 'name':return 0; default:return IntMapCompanies.mcap(c); } }
-  function _coMetric(c,key){ const _pr=IntMapCompanies.priceOf(c); switch(key){ case 'rev':return fmtMoney(c.rev); case 'ni':return (c.ni<0?'-':'')+fmtMoney(Math.abs(c.ni)); case 'emp':return (c.emp?c.emp.toLocaleString():'—'); case 'fnd':return ''+c.fnd; case 'price':return _pr>0?('$'+_pr.toFixed(2)):'—'; case 'pe':{ const v=_coVal(c,'pe'); return (isFinite(v)&&v>0)?v.toFixed(1):'—'; } case 'mcap':{ const m=IntMapCompanies.mcap(c); return isFinite(m)?fmtMoney(m):'—'; } default:{ const m=IntMapCompanies.mcap(c); return isFinite(m)?fmtMoney(m):'—'; } } }
   window.setCoSort=function(k){ const D={mcap:'desc',rev:'desc',ni:'desc',pe:'asc',emp:'desc',price:'desc',fnd:'desc',name:'asc'}; coSort=k; coSortDir=D[k]||'desc'; renderCompanies(); };
   window.toggleCoSortDir=function(){ coSortDir=(coSortDir==='asc')?'desc':'asc'; renderCompanies(); };
   window._coSfToggle=()=>{ coFilterOpen=!coFilterOpen; renderCompanies(); };
@@ -5959,231 +4906,9 @@ window.addEventListener('DOMContentLoaded', () => {
      scratch (blank → 404 → favicon fetch → swap). Cache the RESOLVED logo per domain so a rebuild emits the
      already-working src (or the monogram) directly — no re-ladder, no flash. Plus debounce the price-driven
      re-render so the list repaints a few times, not ~25 times, during the load. */
-  const _coLogoCache=new Map();   /* dom -> resolved logo url, or 'mono' once both remote sources failed */
-  function _coLogoInner(dom,nm,hue){
-    const d=String(dom||''), r=_coLogoCache.get(d);
-    if(r==='mono'){ const ch=(String(nm||'?').trim().slice(0,1)||'?').toUpperCase(); return '<span class="co-mono" style="background:hsl('+hue+',55%,45%)">'+IntMapSafe.html(ch)+'</span>'; }
-    const step=r?'1':'0';   /* a cached url is already resolved → on any later error skip straight to the monogram */
-    const src=r||('https://logo.clearbit.com/'+encodeURIComponent(d));
-    return '<img class="co-logo" alt="" data-dom="'+IntMapSafe.html(d)+'" data-name="'+IntMapSafe.html(nm)+'" data-hue="'+hue+'" data-step="'+step+'" src="'+IntMapSafe.html(src)+'">';
-  }
-  function _coWireLogo(img){ if(!img) return;
-    img.onload=function(){ try{ if(this.src && this.dataset.dom) _coLogoCache.set(this.dataset.dom,this.src); }catch(_){} };
-    img.onerror=function(){ const s=+this.dataset.step||0, dom=this.dataset.dom||'';
-      if(s===0){ this.dataset.step='1'; this.src='https://www.google.com/s2/favicons?domain='+encodeURIComponent(dom)+'&sz=64'; }
-      else { this.onerror=null; try{ if(dom) _coLogoCache.set(dom,'mono'); }catch(_){} const mono=document.createElement('span'); mono.className='co-mono'; mono.textContent=(this.dataset.name||'?').trim().slice(0,1).toUpperCase(); try{ mono.style.background='hsl('+(this.dataset.hue||0)+',55%,45%)'; }catch(_){} this.replaceWith(mono); } };
-  }
-  let _coRrT=null;
-  function _coRerenderSoon(){ if(_coRrT) return; _coRrT=setTimeout(()=>{ _coRrT=null; if(currentMode==='info'||document.body.classList.contains('ws-mode')){ try{ renderCompanies(); }catch(_){} } },350); }
-  function renderCompanies(q){
-    const feed=document.getElementById('info-dashboard'); if(!feed) return;
-    if(document.getElementById('co-cmp-view')) return;   /* (#R142) the compare view owns the feed — don't clobber it */
-    try{ _coWireTime(); }catch(_){}   /* (#R142) subscribe to the time machine once */
-    try{ clearMarkers(); }catch(_){}
-    if(q==null) q=_companiesSearchVal();   /* (#R153) reads the ws-mode Companies filter box too (Countries parity) — was '' in ws-mode → un-filterable */
-    let arr=IntMapCompanies.DATA.slice();
-    if(q){ const ql=String(q).toLowerCase(); arr=arr.filter(c=>c.n.toLowerCase().includes(ql)||(c.nJp&&c.nJp.includes(q))||c.tk.toLowerCase().includes(ql)||_coSec(c.sec).toLowerCase().includes(ql)); }
-    const actF=coFilters.filter(f=>f&&f.key&&isFinite(f.val));
-    if(actF.length) arr=arr.filter(c=>actF.every(f=>{ const v=_coVal(c,f.key); if(!isFinite(v)) return false; return f.op==='lte'?(v<=f.val):(v>=f.val); }));
-    const key=coSort, dir=coSortDir;
-    arr.sort((a,b)=>{ if(key==='name'){ const av=_coName(a),bv=_coName(b); const cc=av.localeCompare(bv,currentLang==='jp'?'ja':undefined); return dir==='asc'?cc:-cc; }
-      const av=_coVal(a,key), bv=_coVal(b,key); const aok=isFinite(av), bok=isFinite(bv); if(!aok&&!bok)return 0; if(!aok)return 1; if(!bok)return -1; return dir==='asc'?(av-bv):(bv-av); });
-    /* (#R142) rank = the company's standing in the CURRENTLY-SORTED metric by VALUE (largest = 1), independent of
-       sort DIRECTION — so toggling asc/desc actually moves "#1" and the number means something (the old code printed
-       the row position i+1, which stayed 1,2,3… for every sort → "順序を変えても順位が変わらない"). Name/text sort
-       falls back to the canonical market-cap rank so the badge stays meaningful. Rank is over the displayed set. */
-    const _rankKey=(key==='name'||key==='fnd')?'mcap':key;
-    const _rankOf=new Map(); arr.slice().filter(c=>isFinite(_coVal(c,_rankKey))).sort((a,b)=>_coVal(b,_rankKey)-_coVal(a,_rankKey)).forEach((c,ri)=>_rankOf.set(c.tk,ri+1));
-    const IND=CO_IND();
-    const _arrow=up=>'<svg class="ssd-arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">'+(up?'<path d="M12 19.5V5M6.5 11l5.5-6 5.5 6"/>':'<path d="M12 4.5V19M6.5 13l5.5 6 5.5-6"/>')+'</svg>';
-    const dirLbl=_arrow(dir==='asc')+'<span class="ssd-labels" data-dir="'+(dir==='asc'?'asc':'desc')+'"><span class="ssd-l ssd-l-asc">'+t('sortAsc')+'</span><span class="ssd-l ssd-l-desc">'+t('sortDesc')+'</span></span>';
-    const _FIND=IND.filter(([k])=>k!=='name');
-    const nAct=coFilters.filter(f=>f&&f.key&&isFinite(f.val)).length;
-    const funnel='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h18l-7 8v6l-4 2v-8z"/></svg>';
-    const filterBtn=`<button type="button" class="stats-filter-btn${coFilterOpen?' on':''}${nAct?' has':''}" onclick="_coSfToggle()" title="${_sfL('Filter by value','値でフィルター','Nach Wert filtern','Фильтр по значению','Filtrar por valor')}">${funnel}${nAct?`<span class="sf-badge">${nAct}</span>`:''}</button>`;   /* (#R152) Countries-parity: filter button now has the same tooltip Countries has */
-    const sfPanel=(()=>{ if(!coFilterOpen) return ''; const opts=(sel)=>_FIND.map(([k,l])=>`<option value="${k}"${sel===k?' selected':''}>${l}</option>`).join('');
-      const rows=coFilters.map((f,i)=>`<div class="sf-row"><select onchange="_coSfSetKey(${i},this.value)">${opts(f.key)}</select><select class="sf-op" onchange="_coSfSetOp(${i},this.value)"><option value="gte"${f.op!=='lte'?' selected':''}>≥</option><option value="lte"${f.op==='lte'?' selected':''}>≤</option></select><input type="text" class="sf-val" value="${(f.raw||'').replace(/"/g,'&quot;')}" placeholder="${_sfL('value (5B, 100000…)','値（5B, 100000…）','Wert','значение','valor')}" onchange="_coSfSetVal(${i},this.value)"><button type="button" class="sf-x" onclick="_coSfRemove(${i})">✕</button></div>`).join('');
-      return `<div class="stats-filter-panel">${rows||`<div class="sf-empty">${_sfL('No conditions yet.','条件がありません。','Keine Bedingungen.','Нет условий.','Sin condiciones.')}</div>`}<div class="sf-actions"><button type="button" class="sf-add" onclick="_coSfAdd()">+ ${_sfL('Add condition','条件を追加','Bedingung','Условие','Añadir')}</button>${coFilters.length?`<button type="button" class="sf-clear" onclick="_coSfClear()">${_sfL('Clear','クリア','Löschen','Очистить','Limpiar')}</button>`:''}</div></div>`; })();
-    let html=`<div class="stats-toolbar"><select class="stats-sort-sel" onchange="setCoSort(this.value)">${IND.map(([k,l])=>`<option value="${k}"${coSort===k?' selected':''}>${l}</option>`).join('')}</select><button type="button" class="stats-sort-dir" onclick="toggleCoSortDir()" title="${t('sortDir')}">${dirLbl}</button>${filterBtn}</div>${sfPanel}`;
-    const _hy=(IntMapCompanies.histYear&&IntMapCompanies.histYear())||null;   /* (#R142) time-machine year (null = present) */
-    html+=_hy?`<div class="stats-timebanner co-banner"><b>${_hy}${currentLang==='jp'?'年':''}</b> · ${_coL('market cap at year-end · today\'s share counts · other figures latest reported','その年の年末時点の時価総額 · 株数は現在値 · 他の指標は最新報告値','Marktkap. zum Jahresende · heutige Aktienzahl · übrige Angaben aktuell','капитализация на конец года · число акций текущее · прочие показатели последние','cap. a fin de año · acciones actuales · demás cifras recientes')}</div>`:`<div class="stats-timebanner co-banner">${_coL('Market cap live where available · figures: latest reported','時価総額は可能な限りライブ · 指標は最新の報告値','Marktkap. live, wo verfügbar · Angaben: zuletzt berichtet','Капитализация в реальном времени, где возможно · показатели: последние отчётные','Cap. en vivo cuando es posible · cifras: últimas reportadas')}</div>`;
-    if(!arr.length) html+=`<div class="empty-msg">${t('noMatch')}</div>`;
-    arr.forEach((c,i)=>{ const nm=_coName(c);
-      const cn=_coCountry(c.cc), fl=_coFlag(c.cc);
-      const sub=_coSec(c.sec)+(cn?(' / '+(fl?fl+' ':'')+cn):'');
-      const hue=[...nm].reduce((a,ch)=>a+ch.charCodeAt(0),0)%360;
-      const logo=_coLogoInner(c.dom,nm,hue);   /* (#R147) cached-logo builder — no flicker */
-      html+=`<div class="stat-row co-row${coCompareSet.has(c.tk)?' compare-on':''}" data-tk="${IntMapSafe.html(c.tk)}" title="${IntMapSafe.html(nm)}">${(window.imShowRank!=='off')?`<span class="stat-rank">${_rankOf.get(c.tk)||'—'}</span>`:''}<span class="stat-flag co-logo-box">${logo}</span><div class="stat-main"><div class="stat-name">${IntMapSafe.html(nm)}</div><div class="stat-sub">${IntMapSafe.html(sub)}</div></div><div class="stat-val">${_coMetric(c,key)}</div></div>`;
-    });
-    const st0=feed.scrollTop;
-    feed.innerHTML=html;
-    try{ feed.scrollTop=st0; }catch(_){}
-    feed.querySelectorAll('.co-logo').forEach(_coWireLogo);   /* (#R147) shared cached-logo wiring */
-    /* (#R142) single-click selects the row for comparison, double-click opens the detail overlay — mirrors Countries. */
-    feed.querySelectorAll('.co-row').forEach(row=>{ let ct=null; row.onclick=()=>{ const tk=row.getAttribute('data-tk');
-      if(ct){ clearTimeout(ct); ct=null; try{ showCompanyDetail(tk); }catch(_){} return; }
-      ct=setTimeout(()=>{ ct=null; try{ window._coToggleCompare(tk); }catch(_){} },250); }; });
-    feed.style.paddingBottom='92px';   /* (#R152) reserve room for the absolute-overlay compare dock, matching Countries (was 24px for the old in-feed sticky tray) */
-    try{ renderCoCompareFixed(); }catch(_){}   /* (#R142) re-attach the compare selection tray after the rebuild */
-    if(!(IntMapCompanies.histYear&&IntMapCompanies.histYear())){ try{ IntMapCompanies.loadPrices(_coRerenderSoon); }catch(_){} }   /* (#R142) live prices only in the present; historical prices come from setYear; (#R147) debounced re-render kills repaint churn */
-  }
   window.renderCompanies=renderCompanies;
-  /* Company detail overlay — every indicator for one company + a link to its site (all figures honestly sourced). */
-  function showCompanyDetail(tk){ const c=IntMapCompanies.DATA.find(x=>x.tk===tk); if(!c) return;
-    let ov=document.getElementById('co-detail-ov'); if(ov) ov.remove();
-    ov=document.createElement('div'); ov.id='co-detail-ov'; ov.className='co-detail-ov';
-    const nm=_coName(c); const hue=[...nm].reduce((a,ch)=>a+ch.charCodeAt(0),0)%360;
-    const mc=IntMapCompanies.mcap(c), live=IntMapCompanies.isLive(c);
-    const peV=_coVal(c,'pe');
-    const rows=[ [_coL('Market cap','時価総額','Marktkap.','Капитализация','Cap. bursátil'), fmtMoney(mc)+' · '+(live?_coL('live','ライブ','live','в реальном времени','en vivo'):_coL('reported','報告値','berichtet','отчёт','reportado'))],
-      [_coL('Share price','株価','Aktienkurs','Цена акции','Precio acción'), c.price>0?('$'+c.price.toFixed(2)):'—'],
-      [_coL('P/E ratio','株価収益率 (P/E)','KGV','P/E','P/E'), (isFinite(peV)&&peV>0)?peV.toFixed(1):'—'],
-      [_coL('Revenue','売上高','Umsatz','Выручка','Ingresos'), fmtMoney(c.rev)],
-      [_coL('Net income','純利益','Nettogewinn','Чистая прибыль','Beneficio neto'), (c.ni<0?'-':'')+fmtMoney(Math.abs(c.ni))],
-      [_coL('Employees','従業員数','Mitarbeiter','Сотрудники','Empleados'), c.emp?c.emp.toLocaleString():'—'],
-      [_coL('Founded','設立年','Gegründet','Год основания','Fundada'), ''+c.fnd],
-      [_coL('Sector','セクター','Sektor','Сектор','Sector'), _coSec(c.sec)],
-      [_coL('Headquarters','本社','Hauptsitz','Штаб-квартира','Sede'), (_coFlag(c.cc)?_coFlag(c.cc)+' ':'')+_coCountry(c.cc)] ];
-    const site='https://'+c.dom;
-    ov.innerHTML=`<div class="co-detail" role="dialog" aria-modal="true"><button class="co-detail-x" type="button" aria-label="Close">✕</button>`+
-      `<div class="co-detail-head"><span class="co-logo-box co-logo-lg">${_coLogoInner(c.dom,nm,hue)}</span>`+
-      `<div class="co-detail-title"><div class="co-detail-name">${IntMapSafe.html(nm)}</div><div class="co-detail-tk">${IntMapSafe.html(c.tk)}</div></div></div>`+
-      `<div class="co-detail-btns"><button class="co-detail-btn${coCompareSet.has(c.tk)?' on':''}" data-cmp="1" type="button">${coCompareSet.has(c.tk)?_coL('In comparison','比較中','Im Vergleich','В сравнении','En comparación'):_coL('Compare','比較する','Vergleichen','Сравнить','Comparar')}${coCompareSet.size?` (${coCompareSet.size}/8)`:''}</button></div>`+
-      `<div class="co-detail-rows">${rows.map(r=>`<div class="co-drow"><span>${IntMapSafe.html(r[0])}</span><b>${IntMapSafe.html(String(r[1]))}</b></div>`).join('')}</div>`+
-      (c.sh>0?`<div class="co-detail-spark" id="co-detail-spark"><div class="co-spark-note">${_coL('Loading share-price history…','株価履歴を読み込み中…','Kursverlauf wird geladen…','Загрузка истории цен…','Cargando histórico…')}</div></div>`:'')+
-      `<a class="co-detail-link" href="${IntMapSafe.html(IntMapSafe.url(site)||'#')}" target="_blank" rel="noopener">${IntMapSafe.html(c.dom)} ↗</a></div>`;
-    document.body.appendChild(ov);
-    const close=()=>{ try{ ov.remove(); }catch(_){} };
-    ov.addEventListener('click',e=>{ if(e.target===ov) close(); });
-    const xb=ov.querySelector('.co-detail-x'); if(xb) xb.onclick=close;
-    /* (#R146) Compare from the detail (Countries parity): add this company; open the compare view once ≥2 are selected */
-    const cmpB=ov.querySelector('[data-cmp]'); if(cmpB) cmpB.onclick=()=>{ const wasIn=coCompareSet.has(c.tk);
-      try{ window._coToggleCompare(c.tk); }catch(_){} try{ renderCoCompareFixed(); }catch(_){}
-      if(!wasIn && coCompareSet.size>=2){ close(); try{ window._coShowCompare(); }catch(_){} }
-      else { close(); } };
-    const img=ov.querySelector('.co-logo'); if(img) _coWireLogo(img);   /* (#R147) shared cached-logo wiring */
-    /* (#R153) real share-price SPARKLINE in the detail (Countries-parity enrichment — the detail was a static rows-only
-       stub). Uses the same monthly full-history data as the compare Time-series; snapshot-only names show an honest note. */
-    if(c.sh>0){ (async()=>{ try{ const cur=new Date().getFullYear(), from=cur-15, to=cur;
-        const data=await IntMapCompanies.priceSeriesFine(c.tk, from, to); const el=document.getElementById('co-detail-spark'); if(!el) return;
-        const pts=(data||[]).filter(p=>p&&p[1]>0);
-        if(pts.length<2){ el.innerHTML='<div class="co-spark-note">'+_coL('No share-price history (snapshot figure only).','株価履歴なし（スナップショットのみ）。','Kein Kursverlauf (nur Momentaufnahme).','Нет истории цен (только снимок).','Sin histórico (solo instantánea).')+'</div>'; return; }
-        const W=280,H=52,pad=3; let vmin=Infinity,vmax=-Infinity; const fmin=pts[0][0], fmax=pts[pts.length-1][0];
-        pts.forEach(p=>{ if(p[1]<vmin)vmin=p[1]; if(p[1]>vmax)vmax=p[1]; });
-        const span=(vmax-vmin)||1, fsp=(fmax-fmin)||1; const X=f=>pad+(f-fmin)/fsp*(W-2*pad), Y=v=>pad+(1-(v-vmin)/span)*(H-2*pad);
-        const d=pts.map((p,i)=>(i?'L':'M')+X(p[0]).toFixed(1)+' '+Y(p[1]).toFixed(1)).join(' ');
-        const first=pts[0][1], last=pts[pts.length-1][1], chg=first>0?(last-first)/first*100:0, up=chg>=0, col=up?'#30d158':'#ff453a';
-        el.innerHTML='<div class="co-spark-head"><span>'+_coL('Share price','株価','Aktienkurs','Цена акции','Precio acción')+' · '+Math.round(fmin)+'–'+Math.round(fmax)+'</span><span style="color:'+col+';font-weight:700;">'+(up?'+':'')+chg.toFixed(0)+'%</span></div>'
-          +'<svg viewBox="0 0 '+W+' '+H+'" preserveAspectRatio="none" class="co-spark-svg"><path d="'+d+'" fill="none" stroke="'+col+'" stroke-width="1.6" vector-effect="non-scaling-stroke"/></svg>'
-          +'<div class="co-spark-note">$'+first.toFixed(2)+' → $'+last.toFixed(2)+' · '+_coL('monthly close, split-adjusted (Yahoo)','月次終値・分割調整済（Yahoo）','Monatsschluss, splitbereinigt (Yahoo)','мес. закрытие, скорр. (Yahoo)','cierre mensual, ajustado (Yahoo)')+'</div>';
-      }catch(_){ const el=document.getElementById('co-detail-spark'); if(el) el.innerHTML=''; } })(); }
-  }
   window.showCompanyDetail=showCompanyDetail;
 
-  function renderStats(q){
-    const feed=document.getElementById('countries-feed')||document.getElementById('live-news-feed'); clearMarkers();
-    /* (#R69) the 5-country comparison view owns the feed while it is open — a deferred renderStats (e.g. the
-       loadCountryData().then below firing after the user opened the comparison) must NOT clobber it; its own
-       "Back to statistics" button removes the view before calling renderStats. */
-    if(document.getElementById('scp-view')) return;
-    if(!countryDataLoaded){ feed.innerHTML=`<div class="empty-msg">${t('loadingData')}</div>`; loadCountryData().then(()=>{ if(currentMode==='stats')renderStats(searchVal()); }); return; }
-    /* (#R94b) hide successors while a former state is shown. (#R101) also drop non-sovereign geographic features
-       (reefs / glaciers / no-man's-land — Scarborough Shoal, Southern Patagonian Ice Field, Bir Tawil …) that are
-       flagged sov:false; they are neither states, unrecognized states, nor regions and don't belong in Countries. */
-    let arr=Object.values(countryStats).filter(s=>s.nameEn && !s._histHidden && s.sov!==false);
-    if(arr.length===0){ feed.innerHTML=`<div class="empty-msg">${t('noData')}</div>`; return; }
-    if(q) arr=arr.filter(s=>s.nameEn.toLowerCase().includes(q)||(s.nameJp&&s.nameJp.includes(q)));
-    /* (#R122) apply the numeric threshold filters (each active condition must hold; a country missing that
-       indicator is excluded from a threshold on it — honest, not counted as passing). */
-    const _actF=statsFilters.filter(f=>f&&f.key&&isFinite(f.val));
-    if(_actF.length) arr=arr.filter(s=>_actF.every(f=>{ const v=s[f.key]; if(!isFinite(v)) return false; return f.op==='lte'?(v<=f.val):(v>=f.val); }));
-    const key=statsSort, dir=statsSortDir;
-    /* (#R102) sort by the chosen indicator in the chosen direction. Numeric: missing/zero values sort to the END in
-       BOTH directions (so ascending never fills the top with un-populated countries). Name: locale-aware A–Z / Z–A. */
-    arr.sort((a,b)=>{
-      if(key==='name'){ const av=(currentLang==='jp'?(a.nameJp||a.nameEn||''):(a.nameEn||'')), bv=(currentLang==='jp'?(b.nameJp||b.nameEn||''):(b.nameEn||'')); const c=av.localeCompare(bv,currentLang==='jp'?'ja':undefined); return dir==='asc'?c:-c; }
-      const av=a[key], bv=b[key]; const aOk=isFinite(av)&&av>0, bOk=isFinite(bv)&&bv>0;
-      if(!aOk&&!bOk) return 0; if(!aOk) return 1; if(!bOk) return -1;
-      return dir==='asc'?(av-bv):(bv-av);
-    });
-    /* (#R102) indicator PULLDOWN + ascending/descending toggle (replaces the old button row). */
-    /* (#R105) + GDP per capita, GDP (PPP) and GDP per capita (PPP) selectable in the Countries pulldown (real WB data). */
-    const IND=[['gdp',t('sortGdp')],['gdppc',t('statGdpPc')],['gdpPPP',t('statGdpPPP')],['gdppcPPP',t('statGdpPcPPP')],['pop',t('sortPop')],['area',t('sortArea')],['hdi',t('sortHDI')],['milSpend',t('sortMil')],['lifeExp',t('sortLife')],['tfr',t('sortTfr')],['name',t('sortName')]];
-    /* (#R104) refined minimal SVG arrow instead of the plain-text ↑ / ↓ glyphs; both labels stacked so the button
-       width never changes on toggle (see .ssd-labels CSS). */
-    const _ssdArrow=up=>'<svg class="ssd-arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">'+(up?'<path d="M12 19.5V5M6.5 11l5.5-6 5.5 6"/>':'<path d="M12 4.5V19M6.5 13l5.5 6 5.5-6"/>')+'</svg>';
-    const dirLbl=_ssdArrow(dir==='asc')+'<span class="ssd-labels" data-dir="'+(dir==='asc'?'asc':'desc')+'"><span class="ssd-l ssd-l-asc">'+t('sortAsc')+'</span><span class="ssd-l ssd-l-desc">'+t('sortDesc')+'</span></span>';
-    /* (#R122) numeric-filter control next to the sort. Indicators = the sortable numeric ones (drop 'name'). */
-    const _FIND=IND.filter(([k])=>k!=='name');
-    const _nActF=statsFilters.filter(f=>f&&f.key&&isFinite(f.val)).length;
-    const _funnel='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h18l-7 8v6l-4 2v-8z"/></svg>';
-    const filterBtn=`<button type="button" class="stats-filter-btn${statsFilterOpen?' on':''}${_nActF?' has':''}" onclick="_sfToggle()" title="${_sfL('Filter by value','数値で絞り込み','Nach Wert filtern','Фильтр по значению','Filtrar por valor')}">${_funnel}${_nActF?`<span class="sf-badge">${_nActF}</span>`:''}</button>`;
-    const _sfPanel=(()=>{ if(!statsFilterOpen) return '';
-      const opts=(sel)=>_FIND.map(([k,l])=>`<option value="${k}"${sel===k?' selected':''}>${l}</option>`).join('');
-      const rows=statsFilters.map((f,i)=>`<div class="sf-row"><select onchange="_sfSetKey(${i},this.value)">${opts(f.key)}</select><select class="sf-op" onchange="_sfSetOp(${i},this.value)"><option value="gte"${f.op!=='lte'?' selected':''}>≥</option><option value="lte"${f.op==='lte'?' selected':''}>≤</option></select><input type="text" class="sf-val" value="${(f.raw||'').replace(/"/g,'&quot;')}" placeholder="${_sfL('value (5M, 20000…)','値（5M, 20000…）','Wert','значение','valor')}" onchange="_sfSetVal(${i},this.value)"><button type="button" class="sf-x" onclick="_sfRemove(${i})" title="${t('remove')||'✕'}">✕</button></div>`).join('');
-      return `<div class="stats-filter-panel">${rows||`<div class="sf-empty">${_sfL('No conditions yet.','条件がありません。','Keine Bedingungen.','Нет условий.','Sin condiciones.')}</div>`}<div class="sf-actions"><button type="button" class="sf-add" onclick="_sfAdd()">+ ${_sfL('Add condition','条件を追加','Bedingung','Условие','Añadir')}</button>${statsFilters.length?`<button type="button" class="sf-clear" onclick="_sfClear()">${_sfL('Clear','クリア','Löschen','Очистить','Limpiar')}</button>`:''}</div></div>`; })();
-    let html=`<div class="stats-toolbar"><select class="stats-sort-sel" onchange="setStatsSort(this.value)">${IND.map(([k,l])=>`<option value="${k}"${statsSort===k?' selected':''}>${l}</option>`).join('')}</select><button type="button" class="stats-sort-dir" onclick="toggleStatsSortDir()" title="${t('sortDir')}">${dirLbl}</button>${filterBtn}</div>${_sfPanel}`;
-    /* (#R101) in time-machine (historical) mode the figures are REAL GDP (Maddison, 2011 int$), not nominal. */
-    const _histY=window._imTimeYear||null;
-    /* (#R102) the value column now carries ONLY the number ($3.4T etc.) — no indicator name on the card, per request. */
-    const metricVal=(s)=>{ switch(key){
-      case 'pop': return fmtNum(s.pop);
-      case 'area': return fmtArea(s.area);
-      case 'gdppc': return (s.gdppc&&isFinite(s.gdppc))?('$'+Math.round(s.gdppc).toLocaleString()):'—';
-      case 'gdpPPP': return (s.gdpPPP&&isFinite(s.gdpPPP))?fmtMoney(s.gdpPPP):'—';
-      case 'gdppcPPP': return (s.gdppcPPP&&isFinite(s.gdppcPPP))?('$'+Math.round(s.gdppcPPP).toLocaleString()):'—';
-      case 'hdi': return s.hdi?(+s.hdi).toFixed(3):'—';
-      case 'milSpend': return s.milSpend?'$'+s.milSpend+'B':'—';
-      case 'lifeExp': return (s.lifeExp&&isFinite(s.lifeExp))?((+s.lifeExp).toFixed(1)+(currentLang==='jp'?'歳':currentLang==='de'?' J':currentLang==='ru'?' л':currentLang==='es'?' a':' yr')):'—';
-      case 'tfr': return (s.tfr&&isFinite(s.tfr))?(+s.tfr).toFixed(2):'—';
-      default: return fmtMoney(s.gdp);   /* gdp + name */
-    } };
-    /* (#R94/#R101) Time-machine status bar — year + the CURRENTLY-SORTED indicator. (#R103) it used to always say
-       "real GDP" no matter which indicator was chosen ("どの指標を選んでもGDPとなっている") — reflect the selection. */
-    const _L5b=(en,jp,de,ru,es)=>currentLang==='jp'?jp:currentLang==='de'?de:currentLang==='ru'?ru:currentLang==='es'?es:en;
-    const _bMetric=(key==='pop')?_L5b('population','人口','Bevölkerung','население','población')
-      :(key==='area')?_L5b('area','面積','Fläche','площадь','superficie')
-      :(key==='hdi')?'HDI'
-      :(key==='milSpend')?_L5b('military spending','軍事費','Militärausgaben','военные расходы','gasto militar')
-      :(key==='lifeExp')?_L5b('life expectancy','平均寿命','Lebenserwartung','прод. жизни','esperanza de vida')
-      :(key==='tfr')?_L5b('fertility rate','合計特殊出生率','Geburtenrate','рождаемость','fecundidad')
-      :_L5b('real GDP (2011 int$)','実質GDP（2011年国際ドル）','reales BIP (int$ 2011)','реальный ВВП (межд.$ 2011)','PIB real (int$ 2011)');
-    try{ const _ty=_histY, _pw=window._imTimePreWB;
-      if(_ty){ html+=`<div class="stats-timebanner"><b>${_ty}${currentLang==='jp'?'年':''}</b> · ${_bMetric}</div>`; }
-      else if(_pw){ html+=`<div class="stats-timebanner warn"><b>${_pw}</b> · ${currentLang==='jp'?'最新の入手可能な値':currentLang==='de'?'neueste verfügbare Werte':currentLang==='ru'?'последние доступные значения':currentLang==='es'?'últimos valores disponibles':'latest available figures'}</div>`; }
-    }catch(_){}
-    /* (#R70) the separate "Compare countries (up to 5)" button is RETIRED per instruction — country-row clicks
-       build the selection and the dock's view button opens the unified comparison. */
-    if(arr.length===0) html+=`<div class="empty-msg">${t('noMatch')}</div>`;
-    /* (#R137) optional rank number on the far left (Settings → "Rank numbers", default OFF). The rank is the row's
-       position in the CURRENT sort+filter, so it tracks whatever indicator/direction is active. */
-    const _showRank=(window.imShowRank!=='off');   /* (#R139) rank numbers now default ON (show unless explicitly turned off) */
-    /* (#R142) rank = the country's standing in the CURRENTLY-SORTED indicator by VALUE (largest = 1), NOT the row
-       position — so toggling ascending/descending actually moves "#1" (the old i+1 kept showing 1,2,3… top-to-bottom
-       for every sort/direction → "順序を変えても順位が変わらない"). In time-machine mode s[key] already holds the
-       historical value, so the rank is the historical rank. Name sort falls back to the GDP rank. Rank over the shown set. */
-    const _rankKey=(key==='name')?'gdp':key;
-    const _rankOf=new Map(); arr.slice().filter(s=>isFinite(s[_rankKey])&&s[_rankKey]>0).sort((a,b)=>b[_rankKey]-a[_rankKey]).forEach((s,ri)=>_rankOf.set(s.code,ri+1));
-    arr.forEach((s,i)=>{
-      const active=compareSet.has(s.code)?'compare-on':'';
-      /* (#R102) region / capital separated by a SLASH (was a middot); the value column shows the number only. */
-      const subline=`${s.region||''}${(s.region&&s.capital)?' / ':''}${s.capital||''}`;
-      const rankHTML=_showRank?`<span class="stat-rank">${_rankOf.get(s.code)||'—'}</span>`:'';
-      /* (#R115) native hover tooltip = the FULL country name (the .stat-name is ellipsized on narrow cards). */
-      html+=`<div class="stat-row ${active}" data-ccn="${s.code}" title="${String(cName(s)||'').replace(/"/g,'&quot;')}">${rankHTML}<span class="stat-flag">${s.flag||'🏳️'}</span><div class="stat-main"><div class="stat-name">${cName(s)}</div><div class="stat-sub">${subline}</div></div><div class="stat-val">${metricVal(s)}</div></div>`;
-    });
-    feed.innerHTML=html;
-    feed.querySelectorAll('.stat-row').forEach(row=>{
-      /* Single-click → add/remove from compare; double-click → open detail */
-      let clickTimer=null;
-      row.onclick=(e)=>{
-        if(clickTimer){ clearTimeout(clickTimer); clickTimer=null; showCountryDetail(row.getAttribute('data-ccn')); return; }
-        clickTimer=setTimeout(()=>{ window._toggleCompare(row.getAttribute('data-ccn')); clickTimer=null; },250);
-      };
-    });
-    feed.style.paddingBottom='92px';   /* leave room for the fixed compare panel */
-    renderCompareFixed();
-  }
   /* (#R79b) Countries is "active" either as the normal Stats tab OR as its own visible workspace window
      (in ws-mode currentMode isn't 'stats', which used to hide the compare dock → "比較機能が消えている"). */
   function _countriesActive(){ try{ if(currentMode==='stats') return true; if(document.body.classList.contains('ws-mode')){ const w=document.querySelector('.ws-win.ws-countries'); return !!(w&&w.style.display!=='none'); } }catch(_){} return false; }
@@ -6219,84 +4944,6 @@ window.addEventListener('DOMContentLoaded', () => {
    * ===================================================================== */
   let extendedDashDB=[];
 
-  /* Cache & lazy-fetch the lead image from a Wikipedia URL */
-  const wikiImgCache={};
-  async function fetchWikiImage(wikiUrl){
-    if(!wikiUrl) return null;
-    if(wikiImgCache[wikiUrl]!==undefined) return wikiImgCache[wikiUrl];
-    try{
-      const m=wikiUrl.match(/^https?:\/\/([a-z]+)\.wikipedia\.org\/wiki\/(.+)$/);
-      if(!m) { wikiImgCache[wikiUrl]=null; return null; }
-      const lang=m[1], title=m[2];
-      const r=await fetch(`https://${lang}.wikipedia.org/api/rest_v1/page/summary/${title}`);
-      if(!r.ok){ wikiImgCache[wikiUrl]=null; return null; }
-      const j=await r.json();
-      const url=(j&&j.thumbnail&&j.thumbnail.source)||(j&&j.originalimage&&j.originalimage.source)||null;
-      wikiImgCache[wikiUrl]=url; return url;
-    }catch(e){ wikiImgCache[wikiUrl]=null; return null; }
-  }
-  function applyWikiImageBackground(info){
-    if(info.img||!info.wiki) return;
-    const wikiUrl=info.wiki[currentLang]||info.wiki.en;
-    fetchWikiImage(wikiUrl).then(url=>{
-      if(!url) return;
-      const card=document.getElementById('card-'+info.id); if(!card) return;
-      const img=card.querySelector('.wiki-card-img');
-      if(img){ img.style.backgroundImage=`url('${url}')`; img.classList.remove('wc-noimg'); }   /* (#R23) real image loaded → restore the gradient */
-    });
-  }
-  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
-  const {_DASH_BADGE}=window.IntMapTables;
-  function dashBadgeLabel(b){ if(!b||currentLang==='en') return b||''; const e=_DASH_BADGE[b]; return (e&&e[currentLang])||b; }
-  function renderDashboard(){
-    /* (#R139) The Information dashboard was RETIRED — the "info" tab is now COMPANIES. Every renderDashboard() call
-       site (tab render, ws window, search input, Supabase/cache hooks) delegates here, so they all render Companies
-       and can never clobber the Companies view. The original dashboard body below is retained (dead) to avoid
-       touching the many references it holds; it is unreachable. */
-    try{ return renderCompanies(); }catch(_){ }
-    const dash=document.getElementById('info-dashboard'); clearMarkers(); const dict=i18n[currentLang];
-    const q=(currentMode==='info')?searchVal():'';   /* live text filter (#27) */
-    /* (#R20) World Events Archive — the Information tab is split into Places (the original cards)
-       and Events (curated historical events, year-range + text searchable, plotted on the map). */
-    if(window._dashView==='events' && typeof window._renderEventsArchive==='function'){ window._renderEventsArchive(dash,q); return; }
-    const filtered=extendedDashDB.filter(i=>activeDashCategories.has(i.cat) && (!q ||
-      ((i.title.en+' '+(i.title.jp||'')+' '+(i.body.en||'')+' '+(i.body.jp||'')+' '+(i.badge||'')).toLowerCase().includes(q))));
-    /* Push features into WebGL source. Pins are mathematically placed by the GPU. */
-    dashFeatures=filtered.map(info=>({type:'Feature',id:info.id,geometry:{type:'Point',coordinates:info.loc},properties:{
-      fid:info.id, type:info.type, color:INFO_COLORS[info.type]||'#007aff',
-      title:info.title[currentLang]||info.title.en, body:info.body[currentLang]||info.body.en, layerRef:info.layerRef||''
-    }}));
-    /* Ensure pin layers exist NOW. Without this, on first tab-switch the source may not yet
-       have been created → pins appeared with a delay. */
-    if(map&&map.isStyleLoaded()) setupIntelLayers();
-    if(map&&map.getSource('dash-points')) map.getSource('dash-points').setData({type:'FeatureCollection',features:dashFeatures});
-    /* Sidebar cards */
-    let cards='<div class="dash-cards-container">';
-    filtered.forEach(info=>{
-      let specsHTML='';
-      if(info.specs){
-        const items=Object.entries(info.specs).map(([k,v])=>`<div class="spec-item"><span class="spec-label">${dict[k]||k}</span><span class="spec-value">${v[currentLang]||v.en||'—'}</span></div>`).join('');
-        if(items) specsHTML=`<div class="wiki-card-specs">${items}</div>`;
-      }
-      /* (#R23) imageless cards must NOT emit background-image:url('') and must NOT paint the dark ::before
-         gradient over the bare card — that overlay over the white card read as "うっすらグレーの四角いもの".
-         The wc-noimg class drops the gradient; the real image (+ its gradient) returns once it lazy-loads. */
-      const _cimg=info.img||'';
-      cards+=`<div class="wiki-card" id="card-${info.id}" onclick="flyToLoc(${info.loc[0]},${info.loc[1]})" onmouseenter="triggerLayerHover('${info.layerRef||''}',true); highlightDashMarker('${info.id}',true)" onmouseleave="triggerLayerHover('${info.layerRef||''}',false); highlightDashMarker('${info.id}',false)">
-        <div class="wiki-card-img${_cimg?'':' wc-noimg'}" data-type="${info.type||''}"${_cimg?` style="background-image:url('${_cimg}');"`:''}><span class="wiki-card-badge">${dashBadgeLabel(info.badge)}</span></div>
-        <div class="wiki-card-content"><h4 class="wiki-card-title">${info.title[currentLang]||info.title.en}</h4><p class="wiki-card-body">${info.body[currentLang]||info.body.en}</p>${specsHTML}<div class="wiki-card-footer"><a href="${IntMapSafe.html(IntMapSafe.url(info.wiki[currentLang]||info.wiki.en)||'#')}" target="_blank" rel="noopener" class="wiki-link" onclick="event.stopPropagation()">${dict.readWiki}</a></div></div></div>`;
-    });
-    cards+='</div>';
-    /* (#R20) top-level Places | Events switch, then the existing category nav */
-    const seg=`<div class="dash-nav"><button class="dash-nav-btn active" onclick="_setDashView('places')">${({en:'📍 Places',jp:'📍 場所',de:'📍 Orte',ru:'📍 Места',es:'📍 Lugares'})[currentLang]||'📍 Places'}</button><button class="dash-nav-btn" onclick="_setDashView('events')">${({en:'🗓 Events',jp:'🗓 出来事',de:'🗓 Ereignisse',ru:'🗓 События',es:'🗓 Eventos'})[currentLang]||'🗓 Events'}</button></div>`;
-    const nav=`<div class="dash-nav" id="dash-nav"><button class="dash-nav-btn ${activeDashCategories.has('mil')?'active':''}" onclick="toggleDashCat('mil')">${dict.dashCatMil}</button><button class="dash-nav-btn ${activeDashCategories.has('tech')?'active':''}" onclick="toggleDashCat('tech')">${dict.dashCatTech}</button><button class="dash-nav-btn ${activeDashCategories.has('maritime')?'active':''}" onclick="toggleDashCat('maritime')">${dict.dashCatMar}</button><button class="dash-nav-btn ${activeDashCategories.has('geo')?'active':''}" onclick="toggleDashCat('geo')">${dict.dashCatGeo}</button></div>`;
-    dash.innerHTML=seg+nav+cards;
-    /* Mouse wheel → horizontal scroll on the category nav */
-    const dnav=document.getElementById('dash-nav');
-    if(dnav){ dnav.addEventListener('wheel',(e)=>{ if(e.deltaY===0)return; e.preventDefault(); dnav.scrollLeft+=e.deltaY+e.deltaX; },{passive:false}); }
-    /* Lazy-fetch Wikipedia thumbnails for cards without an explicit image */
-    filtered.forEach(info=>{ if(!info.img) applyWikiImageBackground(info); });
-  }
 
   /* ===== Fetch news via CORS proxies ===== */
   const PROXIES=[ u=>`https://api.allorigins.win/raw?url=${encodeURIComponent(u)}`, u=>`https://corsproxy.io/?url=${encodeURIComponent(u)}`, u=>`https://api.codetabs.com/v1/proxy/?quest=${encodeURIComponent(u)}` ];
@@ -7115,48 +5762,6 @@ window.addEventListener('DOMContentLoaded', () => {
   /* #17 — open the azimuthal-equidistant viewer centerd on this pin (true distances/bearings from it). */
   window._azimuthalFromPin=(id)=>{ const p=userPins.find(x=>x.id===id); if(!p)return; if(window.ProjView) window.ProjView.open('azimuthal',[p.lng,p.lat]); };
 
-  /* Context menu */
-  function showContextMenu(point,lngLat){
-    const m=document.getElementById('ctx-menu'); const mc=document.getElementById('map-container').getBoundingClientRect();
-    const items=[
-      {h:`${t('ctxThisPoint')}: ${fmtLL(lngLat.lng,lngLat.lat)}`,head:true},
-      {label:`${currentLang==='jp'?'ここをAtlasに聞く':currentLang==='de'?'Atlas zu diesem Ort fragen':currentLang==='ru'?'Спросить Atlas об этом месте':currentLang==='es'?'Preguntar a Atlas sobre aquí':'Ask Atlas about here'}`, action:()=>{ try{ if(window.IntMapConsole&&window.IntMapConsole.askHere) window.IntMapConsole.askHere(lngLat); else if(window.IntMapConsole) window.IntMapConsole.open(); }catch(_){} }},
-      {label:`🧍 ${currentLang==='jp'?'ここのストリートビュー':currentLang==='de'?'Street View hier':currentLang==='ru'?'Просмотр улиц здесь':currentLang==='es'?'Street View aquí':'Street View here'}`, action:()=>{ try{ window.IntMapStreetView&&window.IntMapStreetView.open({lng:lngLat.lng,lat:lngLat.lat}); }catch(_){} }},
-      {label:`📍 ${t('ctxDropPin')}`, action:()=>{ const id=addPin(lngLat.lng,lngLat.lat); openPinPopup(id); }},
-      {label:`📏 ${t('ctxMeasureFrom')}`, action:()=>{ if(toolMode!=='measure') setTool('measure'); measurePoints=[[lngLat.lng,lngLat.lat]]; refreshTool(); updateToolPanel(); }},
-      {label:`⭕ ${currentLang==='jp'?'ここからの半径':currentLang==='de'?'Radius von hier':currentLang==='ru'?'Радиус отсюда':'Radius from here'}`, action:()=>{ try{ window._radiusFromPoint(lngLat.lng,lngLat.lat); }catch(_){} }},
-      {label:`💬 ${t('ctxPostHere')}`, action:()=>{ if(!requireLogin()) return; pendingPostLoc=[lngLat.lng,lngLat.lat]; communityAddArmed=false; openComposeModal(); }},
-      {divider:true},
-      /* (#R8c) Alt-projection viewer removed (MapLibre renders only Mercator/Globe). (#R9) "Copy link to
-         this view" removed per request — the live-permalink hash still restores a reload. */
-      {label:`📋 ${t('ctxCopy')}`, action:()=>{ try{ navigator.clipboard.writeText(`${lngLat.lat.toFixed(5)}, ${lngLat.lng.toFixed(5)}`); }catch(_){} }},
-      /* (#R40/#R42) Share the EXACT current state (position, zoom, projection, base map, layers, time-travel,
-         compare) as a link — opens the surfaced IntMapShare panel (link shown + copy + native share). */
-      {label:`🔗 ${currentLang==='jp'?'この表示を共有':currentLang==='de'?'Diese Ansicht teilen':currentLang==='ru'?'Поделиться этим видом':currentLang==='es'?'Compartir esta vista':'Share this view'}`, action:()=>{ try{ window.IntMapShare&&window.IntMapShare.open(); }catch(_){} }},
-      {label:`🌤 ${currentLang==='jp'?'ここの天気（最新）':currentLang==='de'?'Wetter hier (aktuell)':currentLang==='ru'?'Погода здесь (сейчас)':currentLang==='es'?'El tiempo aquí (ahora)':'Weather here (live)'}`, action:()=>{ try{ window.IntMapWeather&&window.IntMapWeather.open(lngLat); }catch(_){} }},
-      {label:`🛬 ${currentLang==='jp'?'滑走路検索（ここから）':currentLang==='de'?'Start-/Landebahn-Suche (von hier)':currentLang==='ru'?'Поиск ВПП (отсюда)':'Runway search (from here)'}`, action:()=>{ try{ window.RunwaySearch&&window.RunwaySearch.open(lngLat); }catch(_){} }},
-      {label:`📡 ${currentLang==='jp'?'見通し線解析（レーダー死角）':currentLang==='de'?'Sichtlinie (Radarschatten)':currentLang==='ru'?'Линия видимости (радиотень)':'Line of sight (radar shadow)'}`, action:()=>{ try{ window.IntMapLOS&&window.IntMapLOS.open(lngLat); }catch(_){} }},
-      {label:`🎯 ${currentLang==='jp'?'到達圏（車/徒歩/自転車）':currentLang==='de'?'Erreichbarkeit (Auto/Fuß/Rad)':currentLang==='ru'?'Зона доступности (авто/пешком/вело)':currentLang==='es'?'Área alcanzable (coche/pie/bici)':'Reachable area (drive/walk/cycle)'}`, action:()=>{ try{ window.IntMapIsochrone&&window.IntMapIsochrone.open(lngLat); }catch(_){} }},
-      /* (#R15c) Sea-route feature removed per request — repeatedly mis-routed (shallow endpoints / linear /
-         cut across land). The IntMapRoute engine stays defined but is no longer reachable from the UI. */
-      ...(userPins.length?[{label:`🗑 ${t('ctxClearPins')} (${userPins.length})`, action:clearAllPins}]:[])
-    ];
-    m.innerHTML=items.map(it=>{
-      if(it.divider) return `<div class="ctx-divider"></div>`;
-      if(it.head) return `<div class="ctx-head">${it.h}</div>`;
-      return `<button data-act="${items.indexOf(it)}">${it.label}</button>`;
-    }).join('');
-    m.querySelectorAll('button[data-act]').forEach(b=>{ b.onclick=()=>{ const i=+b.getAttribute('data-act'); items[i].action(); m.style.display='none'; }; });
-    m.style.display='block';
-    /* (#R17) On mobile the bottom sheet covers the lower map; clamp the menu into the VISIBLE area above it
-       (and cap its height so a long menu scrolls) — it was overflowing behind the sheet / off-screen. */
-    let availBottom=mc.height; try{ const mcEl=document.getElementById('map-container'); const cover=parseFloat(getComputedStyle(mcEl).getPropertyValue('--sheet-cover'))||0; const isM=window.matchMedia&&window.matchMedia('(max-width:768px)').matches; if(isM&&cover>0){ availBottom=mc.height-cover-8; m.style.maxHeight=Math.max(160,availBottom-56)+'px'; m.style.overflowY='auto'; } else { m.style.maxHeight=''; m.style.overflowY=''; } }catch(_){}
-    const rect=m.getBoundingClientRect();
-    let x=point.x, y=point.y;
-    if(x+rect.width>mc.width) x=mc.width-rect.width-8;
-    if(y+rect.height>availBottom) y=availBottom-rect.height-8;
-    m.style.left=Math.max(8,x)+'px'; m.style.top=Math.max(8,y)+'px';
-  }
   document.addEventListener('click',(e)=>{ const m=document.getElementById('ctx-menu'); if(m&&!m.contains(e.target)) m.style.display='none'; });
 
   /* ===================== GROUP 3: DATA LAYERS ===================== */
@@ -7321,14 +5926,6 @@ window.addEventListener('DOMContentLoaded', () => {
     if(!wrap||!thumb) return;
     if(src){ thumb.src=src; wrap.style.display='inline-block'; } else { thumb.removeAttribute('src'); wrap.style.display='none'; }
   }
-  function openImageLightbox(src){
-    const old=document.getElementById('img-lightbox'); if(old) old.remove();
-    const lb=document.createElement('div'); lb.id='img-lightbox';
-    const im=document.createElement('img'); im.src=src; lb.appendChild(im);
-    lb.onclick=()=>lb.remove();
-    document.addEventListener('keydown',function esc(e){ if(e.key==='Escape'){ lb.remove(); document.removeEventListener('keydown',esc); } });
-    document.body.appendChild(lb);
-  }
   function setupCommunityLayer(){
     if(!map||!map.isStyleLoaded()) return;
     if(!map.getSource('community-points')){
@@ -7396,46 +5993,6 @@ window.addEventListener('DOMContentLoaded', () => {
   /* Escape + auto-link URLs (body/comment text). */
   function linkify(s){ return escapeHtml(s||'').replace(/(https?:\/\/[^\s<]+)/g,'<a href="$1" target="_blank" rel="noopener" class="comm-link">$1</a>'); }
 
-  function renderCommunity(){
-    const cont=document.getElementById('community-feed');
-    if(map&&map.isStyleLoaded()) setupCommunityLayer();
-    const jp=currentLang==='jp';
-    const sortBtn=(k,lbl)=>`<button data-sort="${k}" class="${communitySort===k?'active':''}">${lbl}</button>`;
-    const catChip=(id,lbl,color)=>`<button class="comm-cat-chip ${commCatFilter===id?'active':''}" data-catf="${id}" style="--cc:${color}">${lbl}</button>`;
-    const loginHint = currentUser ? '' : `<div class="empty-msg" style="padding:10px 16px;">${jp?'投稿・コメント・投票するにはログインしてください。':'Log in to post, comment and vote.'}</div>`;
-    /* New post + Hot/New/Top are a STICKY BOTTOM bar, always visible while the feed scrolls (#27). */
-    cont.innerHTML=`<div class="comm-scroll" id="comm-scroll">
-        <div class="comm-filters">
-          <div class="comm-search"><span>🔎</span><input type="text" id="comm-search" placeholder="${t('commSearchPh')}" value="${escapeHtml(commSearch)}"></div>
-          <button class="comm-inview ${commInView?'active':''}" id="comm-inview" title="${jp?'地図の表示範囲内の投稿だけ':'Only posts in the current map view'}">🧭 ${t('commInView')}</button>
-        </div>
-        <div class="comm-cat-row">
-          ${catChip('all',t('commCatAll'),'var(--primary-color)')}
-          ${COMM_CATEGORIES.map(c=>catChip(c.id,c.emoji+' '+commCatLabel(c.id),c.color)).join('')}
-        </div>${loginHint}
-        <div id="comm-list"></div>
-      </div>
-      <div class="comm-toolbar comm-toolbar-bottom">
-        <button class="comm-add-btn" id="comm-add-btn">${t('commAdd')}</button>
-        <div class="comm-sort">${sortBtn('hot',t('commSortHot'))}${sortBtn('new',t('commSortNew'))}${sortBtn('top',t('commSortTop'))}</div>
-      </div>`;
-    /* Toolbar wiring (rebuilds list on change — search updates list only, so its input keeps focus). */
-    document.getElementById('comm-add-btn').onclick=()=>{
-      if(!requireLogin()) return;
-      /* (#R16) "コミュニティで投稿するときは、まず初めに場所を選ばせろ" — pick the location on the map FIRST.
-         Arm a one-shot map tap (the communityAddArmed handler opens the composer at the tapped point); on
-         mobile collapse the sheet so the map is reachable, and guide with a toast. */
-      pendingPostLoc=null; communityAddArmed=true;
-      try{ if(window.matchMedia&&window.matchMedia('(max-width:768px)').matches && window.__setDetent) window.__setDetent('peek',true); }catch(_){}   /* (#R107) 'mini' disabled → collapse to 'peek' (still frees the map) */
-      imToast(currentLang==='jp'?'📍 地図をタップして投稿する場所を選んでください':currentLang==='de'?'📍 Tippe auf die Karte, um den Ort des Beitrags zu wählen':currentLang==='ru'?'📍 Коснитесь карты, чтобы выбрать место публикации':currentLang==='es'?'📍 Toca el mapa para elegir dónde publicar':'📍 Tap the map to choose where to post');
-    };
-    cont.querySelectorAll('.comm-sort button').forEach(b=>b.onclick=()=>{ communitySort=b.dataset.sort; renderCommunity(); });
-    cont.querySelectorAll('.comm-cat-chip').forEach(b=>b.onclick=()=>{ commCatFilter=b.dataset.catf; renderCommunity(); });
-    document.getElementById('comm-inview').onclick=()=>{ commInView=!commInView; renderCommunity(); };
-    const si=document.getElementById('comm-search');
-    if(si) si.addEventListener('input',()=>{ commSearch=si.value; clearTimeout(renderCommunity._st); renderCommunity._st=setTimeout(renderCommList,160); });
-    renderCommList();
-  }
   /* Fills only #comm-list (so the search box above never loses focus while typing). */
   function renderCommList(){
     const list=document.getElementById('comm-list'); if(!list) return;
@@ -7509,61 +6066,6 @@ window.addEventListener('DOMContentLoaded', () => {
         ${canDel?`<button class="cdel-btn" data-cid="${c.id}">${t('commDelete')}</button>`:''}
       </div>
     </div>`;
-  }
-  const _findComment=(cid)=>{ for(const p of communityPosts){ const c=(p.comments||[]).find(x=>x.id===cid); if(c) return c; } return null; };
-  /* Per-card event wiring (run after every list render). */
-  function wireCommList(cont){
-    cont.querySelectorAll('.comm-post-loc').forEach(el=>el.onclick=()=>{ if(map) map.flyTo({center:[+el.dataset.lng,+el.dataset.lat],zoom:5,speed:1.2}); });
-    cont.querySelectorAll('.locate-btn').forEach(b=>b.onclick=()=>{ const p=communityPosts.find(p=>p.id===b.dataset.id); if(p&&map) map.flyTo({center:[p.lng,p.lat],zoom:5,speed:1.2}); });
-    cont.querySelectorAll('.cmt-toggle').forEach(b=>b.onclick=()=>{ const id=b.dataset.id; commCollapsed[id]=!commCollapsed[id]; const w=cont.querySelector(`[data-cwrap="${id}"]`); if(w) w.classList.toggle('collapsed',!!commCollapsed[id]); });
-    cont.querySelectorAll('.comm-post-img').forEach(im=>im.onclick=()=>openImageLightbox(im.src));
-    cont.querySelectorAll('.vote-btn').forEach(b=>b.onclick=async()=>{
-      if(!requireLogin()) return; const p=communityPosts.find(p=>p.id===b.dataset.id); if(!p) return;
-      try{ await cmVote(p.id,!p.voted); }catch(e){ imToast((e&&e.message)||'Vote failed'); return; } await loadCommunity();
-    });
-    cont.querySelectorAll('.edit-btn').forEach(b=>b.onclick=()=>{ const p=communityPosts.find(p=>p.id===b.dataset.id); if(p) openComposeModal(p); });
-    cont.querySelectorAll('.del-btn').forEach(b=>b.onclick=async()=>{
-      if(!confirm(currentLang==='jp'?'この投稿を削除しますか？':currentLang==='de'?'Diesen Beitrag löschen?':currentLang==='ru'?'Удалить эту публикацию?':currentLang==='es'?'¿Eliminar esta publicación?':'Delete this post?')) return;
-      try{ await cmDelete(b.dataset.id); }catch(e){ imToast((e&&e.message)||'Delete failed'); return; } await loadCommunity();
-    });
-    cont.querySelectorAll('.report-btn').forEach(b=>b.onclick=async()=>{
-      if(!requireLogin()) return;
-      if(!confirm(currentLang==='jp'?'この投稿を不適切として通報しますか？':currentLang==='de'?'Diesen Beitrag als unangemessen melden?':currentLang==='ru'?'Пожаловаться на эту публикацию?':currentLang==='es'?'¿Denunciar esta publicación como inapropiada?':'Report this post as inappropriate?')) return;
-      try{ await cmReport(b.dataset.id); imToast(currentLang==='jp'?'通報しました。ご協力ありがとうございます。':currentLang==='de'?'Gemeldet. Danke.':currentLang==='ru'?'Жалоба отправлена. Спасибо.':currentLang==='es'?'Denunciado. Gracias.':'Reported. Thank you.'); }catch(e){ imToast((e&&e.message)||'Report failed'); }
-    });
-    /* Add comment / reply */
-    const submitComment=async(b)=>{
-      if(!requireLogin()) return; const input=b.previousElementSibling, txt=input.value.trim(); if(!txt) return;
-      const pid=b.dataset.pid, parent=(replyingTo&&replyingTo.pid===pid)?replyingTo.cid:null;
-      input.value=''; replyingTo=null;
-      try{ await cmComment(pid,txt,parent); }catch(e){ imToast((e&&e.message)||'Comment failed'); return; } await loadCommunity();
-    };
-    cont.querySelectorAll('.comm-comment-add button').forEach(b=>b.onclick=()=>submitComment(b));
-    cont.querySelectorAll('.comm-comment-add input').forEach(inp=>inp.addEventListener('keydown',e=>{ if(e.key==='Enter') inp.nextElementSibling.click(); }));
-    /* Reply: focus this post's comment box and remember the parent comment. */
-    cont.querySelectorAll('.creply-btn').forEach(b=>b.onclick=()=>{
-      const pid=b.dataset.pid, cid=b.dataset.cid, c=_findComment(cid);
-      replyingTo={pid,cid};
-      const box=cont.querySelector(`.comm-comment-add input[data-pid="${pid}"]`);
-      if(box){ box.placeholder=(currentLang==='jp'?'返信: ':currentLang==='de'?'Antwort an ':currentLang==='ru'?'Ответ: ':currentLang==='es'?'Responder a ':'Reply to ')+(c?c.author:'')+' …'; box.focus(); }
-    });
-    /* Comment upvote */
-    cont.querySelectorAll('.cvote-btn').forEach(b=>b.onclick=async()=>{
-      if(!requireLogin()) return; const c=_findComment(b.dataset.cid); if(!c) return;
-      try{ await cmVoteComment(c.id,!c.voted); }catch(e){ imToast((e&&e.message)||'Vote failed'); return; } await loadCommunity();
-    });
-    /* Comment edit (inline prompt) */
-    cont.querySelectorAll('.cedit-btn').forEach(b=>b.onclick=async()=>{
-      const c=_findComment(b.dataset.cid); if(!c) return;
-      const v=prompt(currentLang==='jp'?'コメントを編集':currentLang==='de'?'Kommentar bearbeiten':currentLang==='ru'?'Изменить комментарий':currentLang==='es'?'Editar comentario':'Edit comment',c.text); if(v==null) return;
-      const nv=v.trim(); if(!nv||nv===c.text) return;
-      try{ await cmEditComment(c.id,nv); }catch(e){ imToast((e&&e.message)||'Edit failed'); return; } await loadCommunity();
-    });
-    /* Comment delete */
-    cont.querySelectorAll('.cdel-btn').forEach(b=>b.onclick=async()=>{
-      if(!confirm(currentLang==='jp'?'このコメントを削除しますか？':currentLang==='de'?'Diesen Kommentar löschen?':currentLang==='ru'?'Удалить этот комментарий?':currentLang==='es'?'¿Eliminar este comentario?':'Delete this comment?')) return;
-      try{ await cmDeleteComment(b.dataset.cid); }catch(e){ imToast((e&&e.message)||'Delete failed'); return; } await loadCommunity();
-    });
   }
   function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
   /* When add-mode is armed, map-click drops a community post pin and opens the compose modal */
@@ -7684,15 +6186,6 @@ window.addEventListener('DOMContentLoaded', () => {
   let currentUser = null;      /* {id,email,name,isAdmin} when logged in, else null */
   function imToast(msg){ try{ aiToast(msg); }catch(_){ try{ satToast(msg); }catch(__){ try{ alert(msg); }catch(___){} } } }
 
-  /* ---------- DATA: geo_pins -> geoRaw -> rebuildGeoIndex ---------- */
-  async function loadGeoFromSupabase(){
-    if(!DB) return;
-    const { data, error } = await DB.from('geo_pins').select('type,terms,name_en,name_jp,lng,lat').order('sort_order',{ascending:true});
-    if(error){ console.warn('[IntMap] geo_pins load failed:', error.message); return; }
-    const grouped={};
-    (data||[]).forEach(r=>{ (grouped[r.type]=grouped[r.type]||[]).push({ terms:r.terms||[], loc:[r.lng,r.lat], name:{en:r.name_en, jp:r.name_jp||r.name_en} }); });
-    geoRaw=grouped; rebuildGeoIndex();
-  }
   /* ---------- DATA: dashboard_cards -> extendedDashDB ---------- */
   /* 50 curated strategic-location cards (#info-cards). Bundled locally so the Information tab is
      rich even before/without Supabase; merged with any DB cards (deduped by English title).
@@ -7715,370 +6208,14 @@ window.addEventListener('DOMContentLoaded', () => {
     extendedDashDB=fromDB.concat(DEFAULT_DASH_CARDS.filter(c=>!have.has((c.title.en||'').toLowerCase())));
   }
 
-  /* ---------- AUTH ---------- */
-  /* (#R155) 5-language helper for the auth/account modals (they predate the i18n dict). */
-  function _authL(en,jp,de,ru,es){ return currentLang==='jp'?jp:currentLang==='de'?de:currentLang==='ru'?ru:currentLang==='es'?es:en; }
-  /* (#R155) Password strength — mirrors the SERVER floor (supabase/config.toml [auth]:
-     minimum_password_length=8, password_requirements="lower_upper_letters_digits"). Returns {ok,msg}. */
-  function _pwStrength(pw){ pw=String(pw||'');
-    if(pw.length<8) return {ok:false,msg:_authL('Password must be at least 8 characters.','パスワードは8文字以上にしてください。','Das Passwort muss mindestens 8 Zeichen lang sein.','Пароль должен содержать не менее 8 символов.','La contraseña debe tener al menos 8 caracteres.')};
-    if(!/[a-z]/.test(pw)||!/[A-Z]/.test(pw)||!/[0-9]/.test(pw)) return {ok:false,msg:_authL('Include lower- and upper-case letters and a number.','小文字・大文字・数字を含めてください。','Verwende Groß- und Kleinbuchstaben sowie eine Ziffer.','Используйте строчные и прописные буквы и цифру.','Incluye mayúsculas, minúsculas y un número.')};
-    return {ok:true,msg:''};
-  }
   /* (#R155) Have-I-Been-Pwned k-ANONYMITY breach check. Only the first 5 hex chars of the SHA-1
      are ever sent — the password/full hash never leaves the device. Returns the breach count
      (0 = not found). FAIL-OPEN on any error: the dashboard's server-side leaked-password
      protection is the backstop, so a HIBP outage never blocks a legitimate signup. */
-  async function _pwBreachCount(pw){ try{
-    if(!(window.crypto&&crypto.subtle&&crypto.subtle.digest)) return 0;
-    const buf=await crypto.subtle.digest('SHA-1', new TextEncoder().encode(String(pw||'')));
-    const hex=Array.from(new Uint8Array(buf)).map(b=>b.toString(16).padStart(2,'0')).join('').toUpperCase();
-    const r=await fetch('https://api.pwnedpasswords.com/range/'+hex.slice(0,5));
-    if(!r.ok) return 0;
-    const suffix=hex.slice(5), txt=await r.text();
-    for(const line of txt.split('\n')){ const p=line.trim().split(':'); if(p[0]===suffix) return parseInt(p[1],10)||1; }
-    return 0;
-  }catch(_){ return 0; } }
-  /* (#R155) Full new-password gate: strength THEN breach. Returns {ok,msg}. */
-  async function _pwValidateNew(pw){ const s=_pwStrength(pw); if(!s.ok) return s;
-    if(await _pwBreachCount(pw)>0) return {ok:false,msg:_authL('This password appears in a known data breach — please choose a different one.','このパスワードは既知の漏えいに含まれています。別のものを選んでください。','Dieses Passwort taucht in einem bekannten Datenleck auf — bitte wähle ein anderes.','Этот пароль встречался в известной утечке — выберите другой.','Esta contraseña apareció en una filtración conocida: elige otra.')};
-    return {ok:true,msg:''};
-  }
-  /* (#R155) Passkey capability: the SDK method exists AND the browser supports WebAuthn. */
-  function _passkeysAvailable(){ try{ return !!(DB&&DB.auth&&typeof DB.auth.signInWithPasskey==='function'&&window.PublicKeyCredential); }catch(_){ return false; } }
   /* (#R155) Render the signed-in user's passkeys into #acct-passkeys (management list).
      Defensive about the exact SDK return/param shape (Beta API) so a shape change degrades
      gracefully instead of throwing. */
-  async function _renderPasskeys(){ const box=document.getElementById('acct-passkeys'); if(!box) return;
-    const addBtn=document.getElementById('acct-add-passkey');
-    if(!_passkeysAvailable()||!(DB.auth.passkey&&typeof DB.auth.passkey.list==='function')){ box.innerHTML=''; if(addBtn) addBtn.style.display='none'; return; }
-    if(addBtn) addBtn.style.display='block';
-    box.innerHTML='<div style="font-size:12px;color:var(--text-muted);">'+escapeHtml(_authL('Loading passkeys…','パスキーを読み込み中…','Passkeys werden geladen…','Загрузка паскеев…','Cargando passkeys…'))+'</div>';
-    let list=[];
-    try{ const r=await DB.auth.passkey.list(); const d=(r&&r.data)||r; list=Array.isArray(d)?d:(d&&(d.passkeys||d.all||d.factors))||[]; }
-    catch(_){ box.innerHTML=''; return; }
-    if(!list.length){ box.innerHTML='<div style="font-size:12px;color:var(--text-muted);">'+escapeHtml(_authL('No passkeys yet.','パスキーはまだありません。','Noch keine Passkeys.','Паскеев пока нет.','Aún no hay passkeys.'))+'</div>'; return; }
-    box.innerHTML=list.map(pk=>{ const nm=escapeHtml(pk.friendly_name||pk.friendlyName||pk.name||'Passkey'), id=escapeHtml(String(pk.id||''));
-      return '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;background:var(--input-bg);border-radius:8px;padding:7px 10px;margin-bottom:6px;"><span style="font-size:12.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">'+nm+'</span><button data-pkdel="'+id+'" style="background:transparent;border:none;color:#ff3b30;font-size:12px;font-weight:600;cursor:pointer;flex:0 0 auto;">'+escapeHtml(_authL('Remove','削除','Entfernen','Удалить','Quitar'))+'</button></div>'; }).join('');
-    box.querySelectorAll('[data-pkdel]').forEach(b=>b.onclick=async()=>{ const id=b.getAttribute('data-pkdel');
-      if(!window.confirm(_authL('Remove this passkey?','このパスキーを削除しますか？','Diesen Passkey entfernen?','Удалить этот паскей?','¿Quitar este passkey?'))) return;
-      try{ await DB.auth.passkey.delete({id}); }catch(_){ try{ await DB.auth.passkey.delete({passkeyId:id}); }catch(__){} }
-      _renderPasskeys();
-    });
-  }
-  /* (#R155) Shared "set a new password" modal — used by the reset-link recovery flow AND the
-     account menu's Change-password button. Enforces the same strength + breach gate as signup. */
-  function _openSetPassword(isRecovery){
-    let d=document.getElementById('setpw-modal');
-    if(!d){ d=document.createElement('div'); d.id='setpw-modal';
-      d.style.cssText='position:fixed;inset:0;background:rgba(0,0,0,.55);display:none;align-items:center;justify-content:center;z-index:5300;padding:20px;';
-      d.innerHTML='<div style="background:var(--card-bg);color:var(--text-main);border-radius:16px;box-shadow:var(--shadow);padding:24px;width:100%;max-width:340px;box-sizing:border-box;">'
-        +'<h2 style="margin:0 0 12px;font-size:18px;">'+escapeHtml(_authL('Set a new password','新しいパスワードを設定','Neues Passwort festlegen','Задать новый пароль','Establecer nueva contraseña'))+'</h2>'
-        +'<input id="setpw-input" type="password" autocomplete="new-password" placeholder="'+escapeHtml(_authL('New password (min. 8, incl. a number)','新しいパスワード（8文字以上・数字を含む）','Neues Passwort (min. 8, mit Ziffer)','Новый пароль (мин. 8, с цифрой)','Nueva contraseña (mín. 8, con número)'))+'" style="width:100%;box-sizing:border-box;padding:10px;border-radius:8px;border:1px solid transparent;background:var(--input-bg);color:var(--text-main);margin-bottom:12px;">'
-        +'<button id="setpw-save" style="width:100%;background:var(--primary-color);color:#fff;border:none;padding:11px;border-radius:9px;font-weight:600;cursor:pointer;">'+escapeHtml(_authL('Save','保存','Speichern','Сохранить','Guardar'))+'</button>'
-        +'<p id="setpw-msg" style="margin:10px 0 0;color:var(--text-muted);font-size:12.5px;"></p>'
-        +'<button id="setpw-close" style="width:100%;background:transparent;border:none;color:var(--text-muted);margin-top:8px;padding:6px;cursor:pointer;font-size:13px;">'+escapeHtml(_authL('Cancel','キャンセル','Abbrechen','Отмена','Cancelar'))+'</button></div>';
-      document.body.appendChild(d);
-      d.onclick=e=>{ if(e.target===d) d.style.display='none'; };
-      document.getElementById('setpw-close').onclick=()=>{ d.style.display='none'; };
-      document.getElementById('setpw-save').onclick=async()=>{
-        const pw=document.getElementById('setpw-input').value, msg=document.getElementById('setpw-msg'), btn=document.getElementById('setpw-save');
-        btn.disabled=true; msg.textContent=_authL('Checking password…','パスワードを確認中…','Passwort wird geprüft…','Проверка пароля…','Comprobando contraseña…');
-        const chk=await _pwValidateNew(pw); if(!chk.ok){ msg.textContent=chk.msg; btn.disabled=false; return; }
-        msg.textContent=_authL('Saving…','保存中…','Speichere…','Сохранение…','Guardando…');
-        try{ const {error}=await DB.auth.updateUser({password:pw}); if(error) throw error;
-          msg.textContent=_authL('Password updated.','パスワードを更新しました。','Passwort aktualisiert.','Пароль обновлён.','Contraseña actualizada.');
-          setTimeout(()=>{ d.style.display='none'; }, 900);
-        }catch(e){ msg.textContent=_authL('Could not update the password.','パスワードを更新できませんでした。','Passwort konnte nicht aktualisiert werden.','Не удалось обновить пароль.','No se pudo actualizar la contraseña.'); }
-        finally{ btn.disabled=false; }
-      };
-    }
-    document.getElementById('setpw-input').value='';
-    document.getElementById('setpw-msg').textContent=isRecovery?_authL('Enter a new password to finish resetting your account.','アカウント再設定を完了するには新しいパスワードを入力してください。','Gib ein neues Passwort ein, um das Zurücksetzen abzuschließen.','Введите новый пароль, чтобы завершить сброс.','Introduce una nueva contraseña para terminar el restablecimiento.'):'';
-    d.style.display='flex';
-  }
   window._imOpenSetPassword=_openSetPassword;
-  function injectAuthUI(){
-    const settingsBtn=document.getElementById('btn-open-settings');
-    const acct=document.createElement('button');
-    acct.id='btn-account'; acct.className='btn-settings'; acct.style.marginRight='8px'; acct.textContent=(currentLang==='jp'?'ログイン':currentLang==='de'?'Anmelden':currentLang==='ru'?'Войти':currentLang==='es'?'Iniciar sesión':'Log in');
-    acct.onclick=()=>{ currentUser ? openAccountMenu() : openAuthModal(); };
-    if(settingsBtn&&settingsBtn.parentNode) settingsBtn.parentNode.insertBefore(acct,settingsBtn);
-    else document.body.appendChild(acct);
-    /* (#R122) enter Workspace (floating-window) mode from the Log in / Feedback / Settings row — desktop only. */
-    try{ const wsB=document.createElement('button'); wsB.id='btn-ws-enter'; wsB.className='btn-settings'; wsB.style.marginRight='8px';
-      const _wsL=()=>(currentLang==='jp'?'ワークスペース':currentLang==='de'?'Arbeitsbereich':currentLang==='ru'?'Рабочая область':currentLang==='es'?'Espacio':'Workspace');
-      wsB.title=_wsL(); wsB.setAttribute('aria-label',_wsL());
-      wsB.innerHTML='<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M9 9v11"/></svg>';
-      window.addEventListener('intmap-lang',()=>{ wsB.title=_wsL(); wsB.setAttribute('aria-label',_wsL()); });
-      wsB.onclick=()=>{ try{ if(window.IntMapWorkspace){ const act=window.IntMapWorkspace.active&&window.IntMapWorkspace.active(); if(act) window.IntMapWorkspace.close(); else window.IntMapWorkspace.open(); } }catch(_){} };
-      if(settingsBtn&&settingsBtn.parentNode) settingsBtn.parentNode.insertBefore(wsB,acct); else document.body.appendChild(wsB); }catch(_){}
-    /* (#R21) Header Support button RETIRED per request — support stays reachable from Settings
-       (the in-panel button) and from the feedback flow. */
-    /* (#R20) Feedback button in the header */
-    const fb=document.createElement('button');
-    fb.id='btn-feedback-hdr'; fb.className='btn-settings'; fb.style.marginRight='8px';
-    fb.textContent=(currentLang==='jp'?'フィードバック':currentLang==='de'?'Feedback':currentLang==='ru'?'Обратная связь':currentLang==='es'?'Comentarios':'Feedback');
-    window.addEventListener('intmap-lang',()=>{ fb.textContent=(currentLang==='jp'?'フィードバック':currentLang==='de'?'Feedback':currentLang==='ru'?'Обратная связь':currentLang==='es'?'Comentarios':'Feedback'); });
-    fb.onclick=()=>{ try{ window._openFeedback&&window._openFeedback(); }catch(_){} };
-    if(settingsBtn&&settingsBtn.parentNode) settingsBtn.parentNode.insertBefore(fb,settingsBtn);
-    else document.body.appendChild(fb);
-
-    const m=document.createElement('div'); m.id='auth-modal';
-    m.style.cssText='position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;z-index:5000;padding:20px;';
-    const inStyle='width:100%;box-sizing:border-box;padding:10px;border-radius:8px;border:1px solid transparent;background:var(--input-bg);color:var(--text-main);margin-bottom:10px;';
-    const oaStyle='width:100%;box-sizing:border-box;display:flex;align-items:center;justify-content:center;gap:8px;padding:10px;border-radius:9px;border:1px solid rgba(128,128,128,0.25);background:var(--card-bg);color:var(--text-main);font-weight:600;font-size:13.5px;cursor:pointer;margin-bottom:8px;';
-    m.innerHTML=`<div style="background:var(--card-bg);color:var(--text-main);border-radius:16px;box-shadow:var(--shadow);padding:24px;width:100%;max-width:360px;box-sizing:border-box;max-height:92vh;overflow-y:auto;">
-      <h2 style="margin:0 0 4px;font-size:19px;">IntMap account</h2>
-      <p id="am-sub" style="margin:0 0 16px;color:var(--text-muted);font-size:13px;line-height:1.5;">Log in or create an account to use AI features and sync your settings, widgets, favorites and avatar across devices.</p>
-      <div style="display:flex;background:var(--input-bg);border-radius:10px;padding:3px;margin-bottom:14px;">
-        <button id="am-tab-login" style="flex:1;border:none;background:var(--card-bg);color:var(--text-main);padding:8px;border-radius:8px;font-weight:600;cursor:pointer;">Log In</button>
-        <button id="am-tab-signup" style="flex:1;border:none;background:transparent;color:var(--text-muted);padding:8px;border-radius:8px;font-weight:600;cursor:pointer;">Sign Up</button>
-      </div>
-      <button id="am-oauth-google" style="${oaStyle}"><svg width="17" height="17" viewBox="0 0 48 48" style="flex:0 0 auto;"><path fill="#4285F4" d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"/><path fill="#34A853" d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"/><path fill="#FBBC05" d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34C2.85 17.09 2 20.45 2 24s.85 6.91 2.34 9.88l7.35-5.7z"/><path fill="#EA4335" d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"/></svg> Continue with Google</button>
-      <div style="display:flex;align-items:center;gap:10px;margin:12px 0 14px;color:var(--text-muted);font-size:12px;"><div style="flex:1;height:1px;background:rgba(128,128,128,0.2);"></div>or<div style="flex:1;height:1px;background:rgba(128,128,128,0.2);"></div></div>
-      <input id="am-name" type="text" placeholder="Display name" autocomplete="nickname" maxlength="40" style="${inStyle}display:none;">
-      <input id="am-email" type="email" placeholder="you@example.com" autocomplete="username" style="${inStyle}">
-      <input id="am-pass" type="password" placeholder="Password" autocomplete="current-password" style="${inStyle}margin-bottom:8px;">
-      <div id="am-forgot-row" style="text-align:right;margin:-2px 0 12px;"><a id="am-forgot" href="#" style="color:var(--text-muted);font-size:12px;text-decoration:none;">${_authL('Forgot password?','パスワードをお忘れですか？','Passwort vergessen?','Забыли пароль?','¿Olvidaste tu contraseña?')}</a></div>
-      <button id="am-submit" style="width:100%;background:var(--primary-color);color:#fff;border:none;padding:11px;border-radius:9px;font-weight:600;font-size:14px;cursor:pointer;">Log In</button>
-      <button id="am-passkey" style="width:100%;background:var(--card-bg);color:var(--text-main);border:1px solid rgba(128,128,128,0.25);padding:10px;border-radius:9px;font-weight:600;font-size:13.5px;cursor:pointer;margin-top:8px;display:none;">${_authL('Sign in with a passkey','パスキーでログイン','Mit Passkey anmelden','Войти по паскею','Iniciar sesión con passkey')}</button>
-      <p id="am-msg" style="margin:12px 0 0;color:var(--text-muted);font-size:12.5px;line-height:1.5;"></p>
-      <button id="am-close" style="width:100%;background:transparent;border:none;color:var(--text-muted);margin-top:8px;padding:6px;cursor:pointer;font-size:13px;">Close</button>
-    </div>`;
-    document.body.appendChild(m);
-    let amMode='login';
-    function setTab(mode){ amMode=mode;
-      /* (#R122) dark mode: the SELECTED segment is a solid white pill with black text (high contrast) */
-      const dk=document.documentElement.getAttribute('data-theme')==='dark';
-      const selBg=dk?'#fff':'var(--card-bg)', selFg=dk?'#111':'var(--text-main)';
-      $am('am-tab-login').style.background = mode==='login'?selBg:'transparent';
-      $am('am-tab-login').style.color = mode==='login'?selFg:'var(--text-muted)';
-      $am('am-tab-signup').style.background = mode==='signup'?selBg:'transparent';
-      $am('am-tab-signup').style.color = mode==='signup'?selFg:'var(--text-muted)';
-      $am('am-name').style.display = mode==='signup'?'block':'none';
-      $am('am-pass').setAttribute('autocomplete', mode==='signup'?'new-password':'current-password');
-      $am('am-submit').textContent = mode==='login'?'Log In':'Create account';
-      $am('am-pass').placeholder = mode==='signup'?_authL('Password (min. 8 chars, incl. a number)','パスワード（8文字以上・数字を含む）','Passwort (min. 8 Zeichen, mit Ziffer)','Пароль (мин. 8 символов, с цифрой)','Contraseña (mín. 8, con un número)'):_authL('Password','パスワード','Passwort','Пароль','Contraseña');
-      /* (#R155) passkey sign-in + forgot-password only make sense on the LOGIN tab. */
-      try{ $am('am-passkey').style.display=(mode==='login'&&_passkeysAvailable())?'block':'none'; }catch(_){}
-      try{ $am('am-forgot-row').style.display=mode==='login'?'block':'none'; }catch(_){}
-      $am('am-msg').textContent='';
-    }
-    function $am(id){ return document.getElementById(id); }
-    $am('am-tab-login').onclick=()=>setTab('login');
-    $am('am-tab-signup').onclick=()=>setTab('signup');
-    try{ setTab('login'); }catch(_){}   /* (#R122) normalize the initial segment colours for the current theme */
-    $am('am-close').onclick=()=>{ m.style.display='none'; };
-    m.onclick=(e)=>{ if(e.target===m) m.style.display='none'; };
-    $am('am-submit').onclick=async()=>{
-      const email=$am('am-email').value.trim(), password=$am('am-pass').value, name=$am('am-name').value.trim(), msg=$am('am-msg');
-      if(!email||!password){ msg.textContent=_authL('Enter email and password.','メールアドレスとパスワードを入力してください。','Gib E-Mail und Passwort ein.','Введите e-mail и пароль.','Introduce el correo y la contraseña.'); return; }
-      $am('am-submit').disabled=true;
-      try{
-        if(amMode==='signup'){
-          if(!name){ msg.textContent=_authL('Choose a display name (shown on your community posts).','表示名を入力してください（コミュニティ投稿に表示されます）。','Wähle einen Anzeigenamen (in Community-Beiträgen sichtbar).','Выберите отображаемое имя (видно в постах сообщества).','Elige un nombre visible (aparece en tus publicaciones).'); return; }
-          /* (#R155) strength (mirrors the server floor) THEN a HIBP breach check before we submit. */
-          msg.textContent=_authL('Checking password…','パスワードを確認中…','Passwort wird geprüft…','Проверка пароля…','Comprobando contraseña…');
-          const chk=await _pwValidateNew(password); if(!chk.ok){ msg.textContent=chk.msg; return; }
-          msg.textContent=_authL('Working…','処理中…','Wird verarbeitet…','Обработка…','Procesando…');
-          /* display_name is stored in user metadata; the profile row picks it up on first login */
-          const {error}=await DB.auth.signUp({email,password,options:{data:{display_name:name}}});
-          /* (#R155) ENUMERATION-SAFE: whether the email is new OR already registered, show the SAME
-             neutral message so signup can't be used to probe which emails have accounts. */
-          if(error && !/already|exist|registered/i.test(error.message||'')) throw error;
-          msg.textContent=_authL('Check your email — if this address is new, we sent a confirmation link. Then log in.','メールをご確認ください。新規の場合は確認リンクを送信しました。その後ログインしてください。','Prüfe deine E-Mail — falls neu, haben wir einen Bestätigungslink gesendet. Dann anmelden.','Проверьте почту — если адрес новый, мы отправили ссылку для подтверждения. Затем войдите.','Revisa tu correo: si es nuevo, enviamos un enlace de confirmación. Luego inicia sesión.'); setTab('login');
-        } else {
-          const {data,error}=await DB.auth.signInWithPassword({email,password});
-          /* (#R155) ENUMERATION-SAFE: Supabase already returns a generic "Invalid login credentials";
-             surface a single localized generic message and never reveal whether the email exists. */
-          if(error){ msg.textContent=_authL('Invalid email or password.','メールアドレスまたはパスワードが正しくありません。','E-Mail oder Passwort ist falsch.','Неверный e-mail или пароль.','Correo o contraseña incorrectos.'); return; }
-          m.style.display='none';
-          try{ recordLogin(data&&data.user&&data.user.id); }catch(_){}   /* (#R27) genuine login → count for the 3rd-login feedback nudge */
-        }
-      }catch(e){ msg.textContent=_authL('Something went wrong. Please try again.','エラーが発生しました。もう一度お試しください。','Etwas ist schiefgelaufen. Bitte erneut versuchen.','Что-то пошло не так. Повторите попытку.','Algo salió mal. Inténtalo de nuevo.'); }
-      finally{ $am('am-submit').disabled=false; }
-    };
-    /* (#R155) Passkey sign-in (WebAuthn, discoverable credential — no email needed). */
-    $am('am-passkey').onclick=async()=>{
-      const msg=$am('am-msg');
-      if(!_passkeysAvailable()){ msg.textContent=_authL('Passkeys aren\'t available on this device.','この端末ではパスキーを利用できません。','Passkeys sind auf diesem Gerät nicht verfügbar.','Паскеи недоступны на этом устройстве.','Los passkeys no están disponibles en este dispositivo.'); return; }
-      $am('am-passkey').disabled=true; msg.textContent=_authL('Waiting for your passkey…','パスキーを待機中…','Warte auf deinen Passkey…','Ожидание паскея…','Esperando tu passkey…');
-      try{ const {data,error}=await DB.auth.signInWithPasskey(); if(error) throw error;
-        m.style.display='none'; try{ recordLogin(data&&data.user&&data.user.id); }catch(_){}
-      }catch(e){ msg.textContent=_authL('Passkey sign-in failed or was cancelled.','パスキーのログインに失敗またはキャンセルされました。','Passkey-Anmeldung fehlgeschlagen oder abgebrochen.','Вход по паскею не удался или отменён.','El inicio con passkey falló o se canceló.'); }
-      finally{ $am('am-passkey').disabled=false; }
-    };
-    /* (#R155) Forgot password → email a reset link. Enumeration-safe: identical message regardless. */
-    $am('am-forgot').onclick=async(e)=>{ e.preventDefault(); const msg=$am('am-msg');
-      const email=$am('am-email').value.trim();
-      if(!email){ msg.textContent=_authL('Enter your email above, then tap “Forgot password?”.','上のメール欄を入力してから「パスワードをお忘れですか？」を押してください。','Gib oben deine E-Mail ein und tippe dann auf „Passwort vergessen?“.','Введите e-mail выше, затем нажмите «Забыли пароль?».','Introduce tu correo arriba y pulsa «¿Olvidaste tu contraseña?».'); return; }
-      const redirectTo=(location.protocol==='file:')?location.href:(location.origin+location.pathname);
-      try{ await DB.auth.resetPasswordForEmail(email,{redirectTo}); }catch(_){}
-      msg.textContent=_authL('If an account exists for that email, we\'ve sent a password-reset link.','そのメールアドレスのアカウントが存在する場合、再設定リンクを送信しました。','Falls ein Konto zu dieser E-Mail existiert, haben wir einen Link zum Zurücksetzen gesendet.','Если аккаунт с этим адресом существует, мы отправили ссылку для сброса пароля.','Si existe una cuenta con ese correo, enviamos un enlace para restablecer la contraseña.');
-    };
-    /* OAuth (Google / Apple). NOTE: each provider must be ENABLED in the Supabase dashboard
-       (Authentication → Providers) with this site added as a redirect URL, or it errors. */
-    async function oauth(provider){ const msg=$am('am-msg'); msg.textContent='Redirecting…';
-      /* Use a CLEAN redirect target (origin + path, no query/hash). It must be listed verbatim in
-         Supabase → Auth → URL Configuration → Redirect URLs, or the provider bounces back without a
-         session (the "logged in via Google but not actually logged in" symptom, #33). file:// can't
-         do OAuth at all — must be served over http(s). */
-      const redirectTo=(location.protocol==='file:') ? location.href : (location.origin+location.pathname);
-      try{ const {error}=await DB.auth.signInWithOAuth({ provider, options:{ redirectTo } }); if(error) throw error; }
-      catch(e){ msg.textContent='Error: '+((e&&e.message)||e); } }
-    $am('am-oauth-google').onclick=()=>oauth('google');
-    window.__amSetTab=setTab;
-  }
-  function openAuthModal(contextMsg){ const m=document.getElementById('auth-modal'); if(!m) return; if(window.__amSetTab) window.__amSetTab('login');
-    try{ const sub=document.getElementById('am-sub');
-      if(sub){ if(contextMsg){ sub.dataset.ctx='1'; sub.textContent=contextMsg; }
-        else if(sub.dataset.ctx){ delete sub.dataset.ctx; sub.textContent=(currentLang==='jp'?'ログイン／新規登録で、AI機能・設定/ウィジェット/お気に入り/アイコンの端末間同期が使えます。':currentLang==='de'?'Melde dich an oder registriere dich für KI-Funktionen und die Synchronisierung von Einstellungen, Widgets, Favoriten und Avatar über Geräte hinweg.':currentLang==='ru'?'Войдите или создайте аккаунт: ИИ-функции и синхронизация настроек, виджетов, избранного и аватара между устройствами.':currentLang==='es'?'Inicia sesión o crea una cuenta para usar la IA y sincronizar ajustes, widgets, favoritos y avatar entre dispositivos.':'Log in or create an account to use AI features and sync your settings, widgets, favorites and avatar across devices.'); } }
-    }catch(_){}
-    m.style.display='flex'; }
-  function openAccountMenu(){
-    if(!currentUser) return openAuthModal();
-    let m=document.getElementById('acct-modal');
-    if(!m){
-      m=document.createElement('div'); m.id='acct-modal';
-      m.style.cssText='position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;z-index:5000;padding:20px;';
-      const secBtn='width:100%;background:var(--input-bg);color:var(--text-main);border:none;padding:10px;border-radius:9px;font-weight:600;font-size:13px;cursor:pointer;margin-bottom:8px;text-align:left;';   /* (#R155) security-section buttons */
-      m.innerHTML=`<div style="background:var(--card-bg);color:var(--text-main);border-radius:16px;box-shadow:var(--shadow);padding:24px;width:100%;max-width:360px;box-sizing:border-box;max-height:90vh;overflow-y:auto;">
-        <h2 style="margin:0 0 4px;font-size:19px;">${currentLang==='jp'?'プロフィール':currentLang==='de'?'Dein Profil':currentLang==='ru'?'Ваш профиль':currentLang==='es'?'Tu perfil':'Your profile'}</h2>
-        <p id="acct-email" style="margin:0 0 10px;color:var(--text-muted);font-size:13px;"></p>
-        <div class="acct-avatar-wrap"><div class="acct-avatar" id="acct-avatar-preview"></div>
-          <div style="flex:1;"><div style="font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;margin-bottom:4px;">${currentLang==='jp'?'アイコン':currentLang==='de'?'Icon':currentLang==='ru'?'Значок':currentLang==='es'?'Icono':'Icon'}</div>
-          <div class="acct-avatar-pick" id="acct-avatar-pick"></div>
-          <label class="compose-img-btn" for="acct-avatar-file" style="padding:6px 11px;font-size:12px;margin-top:2px;">🖼 ${currentLang==='jp'?'画像をアップロード':currentLang==='de'?'Bild hochladen':currentLang==='ru'?'Загрузить изображение':currentLang==='es'?'Subir imagen':'Upload image'}</label>
-          <input type="file" id="acct-avatar-file" accept="image/*" style="display:none;"></div></div>
-        <div id="acct-pro" style="margin:0 0 16px;font-size:13px;"></div>
-        <label style="font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;">${currentLang==='jp'?'表示名':currentLang==='de'?'Anzeigename':currentLang==='ru'?'Отображаемое имя':currentLang==='es'?'Nombre visible':'Display name'}</label>
-        <input id="acct-name" type="text" maxlength="40" style="width:100%;box-sizing:border-box;padding:10px;border-radius:8px;border:1px solid transparent;background:var(--input-bg);color:var(--text-main);margin:6px 0 12px;">
-        <label style="font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;">${currentLang==='jp'?'自己紹介（他のユーザーに公開）':currentLang==='de'?'Bio (öffentlich)':currentLang==='ru'?'О себе (публично)':currentLang==='es'?'Biografía (pública)':'Bio (public)'}</label>
-        <textarea id="acct-bio" maxlength="280" rows="3" style="width:100%;box-sizing:border-box;padding:10px;border-radius:8px;border:1px solid transparent;background:var(--input-bg);color:var(--text-main);margin:6px 0 14px;resize:vertical;font-family:inherit;font-size:13px;"></textarea>
-        <button id="acct-save" style="width:100%;background:var(--primary-color);color:#fff;border:none;padding:11px;border-radius:9px;font-weight:600;font-size:14px;cursor:pointer;">${currentLang==='jp'?'保存':currentLang==='de'?'Profil speichern':currentLang==='ru'?'Сохранить профиль':currentLang==='es'?'Guardar perfil':'Save profile'}</button>
-        <p id="acct-msg" style="margin:10px 0 0;color:var(--text-muted);font-size:12.5px;"></p>
-        <div style="margin-top:16px;border-top:1px solid rgba(128,128,128,0.18);padding-top:14px;">
-          <div style="font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;margin-bottom:9px;">${_authL('Security','セキュリティ','Sicherheit','Безопасность','Seguridad')}</div>
-          <div id="acct-passkeys" style="margin-bottom:8px;"></div>
-          <button id="acct-add-passkey" style="${secBtn}display:none;">${_authL('Add a passkey','パスキーを追加','Passkey hinzufügen','Добавить паскей','Añadir passkey')}</button>
-          <button id="acct-change-email" style="${secBtn}">${_authL('Change email','メールアドレスを変更','E-Mail ändern','Изменить e-mail','Cambiar correo')}</button>
-          <button id="acct-change-pw" style="${secBtn}">${_authL('Change password','パスワードを変更','Passwort ändern','Изменить пароль','Cambiar contraseña')}</button>
-          <button id="acct-logout-all" style="${secBtn}margin-bottom:0;">${_authL('Log out on all devices','すべての端末からログアウト','Auf allen Geräten abmelden','Выйти на всех устройствах','Cerrar sesión en todos')}</button>
-        </div>
-        <button id="acct-logout" style="width:100%;background:var(--input-bg);color:var(--info-mil);border:none;padding:10px;border-radius:9px;font-weight:600;font-size:13px;cursor:pointer;margin-top:12px;">${currentLang==='jp'?'ログアウト':currentLang==='de'?'Abmelden':currentLang==='ru'?'Выйти':currentLang==='es'?'Cerrar sesión':'Log out'}</button>
-        <button id="acct-delete" style="width:100%;background:transparent;color:#ff3b30;border:1px solid rgba(255,59,48,0.4);padding:9px;border-radius:9px;font-weight:600;font-size:12.5px;cursor:pointer;margin-top:8px;">${_authL('Delete account','アカウントを削除','Konto löschen','Удалить аккаунт','Eliminar cuenta')}</button>
-        <button id="acct-close" style="width:100%;background:transparent;border:none;color:var(--text-muted);margin-top:6px;padding:6px;cursor:pointer;font-size:13px;">${currentLang==='jp'?'閉じる':currentLang==='de'?'Schließen':currentLang==='ru'?'Закрыть':currentLang==='es'?'Cerrar':'Close'}</button>
-      </div>`;
-      document.body.appendChild(m);
-      /* Avatar picker (#28): emoji + color, stored locally (and used as the account-button icon). */
-      const AV_EMOJI=['👤','🌍','🛰️','⚓','✈️','🛡️','📡','⛰️','🗺️','🔭','📰','🏛️','🦅','🐻','🐉','🌐'];
-      const pick=document.getElementById('acct-avatar-pick');
-      pick.innerHTML=AV_EMOJI.map(e=>`<button class="acct-emoji" data-e="${e}">${e}</button>`).join('');
-      pick.querySelectorAll('.acct-emoji').forEach(b=>b.onclick=()=>{ window.imSetAvatarImg(''); window.imSetAvatar(b.dataset.e); pick.querySelectorAll('.acct-emoji').forEach(x=>x.classList.toggle('sel',x===b)); const pv=document.getElementById('acct-avatar-preview'); pv.style.backgroundImage=''; pv.textContent=b.dataset.e; });
-      /* Upload a custom avatar image (#28) — compressed, stored locally + pushed to the profile if the column exists. */
-      const af=document.getElementById('acct-avatar-file');
-      if(af) af.onchange=async()=>{ const f=af.files&&af.files[0]; af.value=''; if(!f) return; try{
-        /* Crop to a square first (#12), then store the cropped 256² image. */
-        const data=await window.imCropImage(f); if(!data) return;
-        window.imSetAvatarImg(data); const pv=document.getElementById('acct-avatar-preview'); pv.style.backgroundImage=`url('${data}')`; pv.textContent='';
-        document.querySelectorAll('#acct-avatar-pick .acct-emoji').forEach(x=>x.classList.remove('sel'));
-        try{ await DB.from('profiles').update({avatar_url:data}).eq('id',currentUser.id); }catch(_){}
-      }catch(_){ imToast(currentLang==='jp'?'画像を読み込めませんでした':currentLang==='de'?'Bild konnte nicht geladen werden':currentLang==='ru'?'Не удалось загрузить изображение':currentLang==='es'?'No se pudo cargar la imagen':'Could not load image'); } };
-      m.onclick=(e)=>{ if(e.target===m) m.style.display='none'; };
-      document.getElementById('acct-close').onclick=()=>{ m.style.display='none'; };
-      document.getElementById('acct-logout').onclick=()=>{
-        /* (#R33) Confirm before logging out. */
-        if(!window.confirm(currentLang==='jp'?'ログアウトしますか？':currentLang==='de'?'Vom Konto abmelden?':currentLang==='ru'?'Выйти из аккаунта?':currentLang==='es'?'¿Cerrar la sesión?':'Log out of your account?')) return;
-        /* Instant: clear local state + UI right away, revoke the session in the background. */
-        m.style.display='none';
-        currentUser=null; bookmarks=[];
-        try{ updateAccountButton(); }catch(_){}
-        try{ if(typeof renderUI==='function') renderUI(); }catch(_){}
-        try{ window.refreshProUI&&window.refreshProUI(); }catch(_){}
-        try{ DB.auth.signOut(); }catch(_){}   /* onAuthStateChange will reconcile favorites/community */
-        try{ imToast(currentLang==='jp'?'ログアウトしました':currentLang==='de'?'Abgemeldet':currentLang==='ru'?'Вы вышли из аккаунта':currentLang==='es'?'Sesión cerrada':'Logged out'); }catch(_){}
-      };
-      document.getElementById('acct-save').onclick=async()=>{
-        const name=document.getElementById('acct-name').value.trim(), msg=document.getElementById('acct-msg');
-        const bio=(document.getElementById('acct-bio')||{}).value||'';
-        if(!name){ msg.textContent=currentLang==='jp'?'表示名を入力してください。':currentLang==='de'?'Anzeigename darf nicht leer sein.':currentLang==='ru'?'Имя не может быть пустым.':currentLang==='es'?'El nombre no puede estar vacío.':'Display name cannot be empty.'; return; }
-        const btn=document.getElementById('acct-save'); btn.disabled=true; msg.textContent=currentLang==='jp'?'保存中…':currentLang==='de'?'Speichere…':currentLang==='ru'?'Сохранение…':currentLang==='es'?'Guardando…':'Saving…';
-        try{
-          const {error}=await DB.from('profiles').update({display_name:name}).eq('id',currentUser.id); if(error) throw error;
-          try{ await DB.auth.updateUser({data:{display_name:name}}); }catch(_){}
-          /* bio + avatar_url are best-effort (columns may not exist yet — see supabase_profiles_extra.sql) */
-          try{ await DB.from('profiles').update({bio:bio.trim()}).eq('id',currentUser.id); }catch(_){}
-          try{ localStorage.setItem('intmap_bio',bio.trim()); }catch(_){}
-          currentUser.name=name; currentUser.bio=bio.trim(); updateAccountButton(); msg.textContent=currentLang==='jp'?'保存しました。':currentLang==='de'?'Gespeichert.':currentLang==='ru'?'Сохранено.':currentLang==='es'?'Guardado.':'Saved.';
-          if(currentMode==='community') loadCommunity();
-          setTimeout(()=>{ m.style.display='none'; }, 600);
-        }catch(e){ msg.textContent='Error: '+((e&&e.message)||e); }
-        finally{ btn.disabled=false; }
-      };
-      /* ---- (#R155) Security section: passkeys / change email / change password / logout-all / delete ---- */
-      const _addPk=document.getElementById('acct-add-passkey');
-      if(_addPk) _addPk.onclick=async()=>{ const msg=document.getElementById('acct-msg');
-        if(!_passkeysAvailable()||typeof DB.auth.registerPasskey!=='function'){ msg.textContent=_authL('Passkeys aren\'t available on this device.','この端末ではパスキーを利用できません。','Passkeys sind auf diesem Gerät nicht verfügbar.','Паскеи недоступны на этом устройстве.','Los passkeys no están disponibles en este dispositivo.'); return; }
-        msg.textContent=_authL('Follow your device prompt to create a passkey…','端末の指示に従ってパスキーを作成してください…','Folge der Geräteaufforderung, um einen Passkey zu erstellen…','Следуйте подсказке устройства, чтобы создать паскей…','Sigue la indicación de tu dispositivo para crear un passkey…');
-        try{ const {error}=await DB.auth.registerPasskey(); if(error) throw error; msg.textContent=_authL('Passkey added.','パスキーを追加しました。','Passkey hinzugefügt.','Паскей добавлен.','Passkey añadido.'); _renderPasskeys(); }
-        catch(e){ msg.textContent=_authL('Could not add a passkey (or it was cancelled).','パスキーを追加できませんでした（またはキャンセルされました）。','Passkey konnte nicht hinzugefügt werden (oder abgebrochen).','Не удалось добавить паскей (или отменено).','No se pudo añadir el passkey (o se canceló).'); }
-      };
-      document.getElementById('acct-change-email').onclick=async()=>{ const msg=document.getElementById('acct-msg');
-        const ne=window.prompt(_authL('New email address:','新しいメールアドレス：','Neue E-Mail-Adresse:','Новый e-mail:','Nuevo correo:')); if(ne==null) return;
-        if(!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(ne.trim())){ msg.textContent=_authL('That doesn\'t look like an email.','メールアドレスの形式ではありません。','Das sieht nicht wie eine E-Mail aus.','Это не похоже на e-mail.','Eso no parece un correo.'); return; }
-        msg.textContent=_authL('Sending confirmation…','確認メールを送信中…','Bestätigung wird gesendet…','Отправка подтверждения…','Enviando confirmación…');
-        try{ const {error}=await DB.auth.updateUser({email:ne.trim()}); if(error) throw error;
-          msg.textContent=_authL('Confirm the change from the link sent to your new email (and, if asked, your current one).','新しいメールに届いたリンクから変更を確認してください（求められた場合は現在のメールも）。','Bestätige die Änderung über den Link an deine neue E-Mail (und ggf. deine aktuelle).','Подтвердите изменение по ссылке на новый e-mail (и, если попросят, на текущий).','Confirma el cambio desde el enlace enviado a tu nuevo correo (y al actual si se solicita).');
-        }catch(e){ msg.textContent=_authL('Could not change the email.','メールアドレスを変更できませんでした。','E-Mail konnte nicht geändert werden.','Не удалось изменить e-mail.','No se pudo cambiar el correo.'); }
-      };
-      document.getElementById('acct-change-pw').onclick=()=>_openSetPassword(false);
-      document.getElementById('acct-logout-all').onclick=async()=>{
-        if(!window.confirm(_authL('Log out on ALL devices? You\'ll need to sign in again everywhere.','すべての端末からログアウトしますか？各端末で再度ログインが必要になります。','Auf ALLEN Geräten abmelden? Du musst dich überall neu anmelden.','Выйти на ВСЕХ устройствах? Потребуется войти заново везде.','¿Cerrar sesión en TODOS los dispositivos? Tendrás que volver a iniciar sesión.'))) return;
-        m.style.display='none'; currentUser=null; bookmarks=[];
-        try{ updateAccountButton(); }catch(_){}
-        try{ if(typeof renderUI==='function') renderUI(); }catch(_){}
-        try{ window.refreshProUI&&window.refreshProUI(); }catch(_){}
-        try{ await DB.auth.signOut({scope:'global'}); }catch(_){ try{ await DB.auth.signOut(); }catch(__){} }
-        try{ imToast(_authL('Logged out on all devices','すべての端末からログアウトしました','Auf allen Geräten abgemeldet','Выход выполнен на всех устройствах','Sesión cerrada en todos los dispositivos')); }catch(_){}
-      };
-      document.getElementById('acct-delete').onclick=async()=>{ const msg=document.getElementById('acct-msg');
-        const typed=window.prompt(_authL('This PERMANENTLY deletes your account and all your data — it cannot be undone. Type your email to confirm:','これはアカウントと全データを完全に削除します（取り消せません）。確認のためメールアドレスを入力：','Dies löscht dein Konto und alle Daten DAUERHAFT — nicht umkehrbar. Gib zur Bestätigung deine E-Mail ein:','Это НАВСЕГДА удалит аккаунт и все данные — отменить нельзя. Введите e-mail для подтверждения:','Esto elimina PERMANENTEMENTE tu cuenta y todos tus datos, sin vuelta atrás. Escribe tu correo para confirmar:'));
-        if(typed==null) return;
-        if((typed||'').trim().toLowerCase()!==String(currentUser.email||'').toLowerCase()){ msg.textContent=_authL('That didn\'t match your email — cancelled.','メールアドレスが一致しません。キャンセルしました。','Stimmt nicht mit deiner E-Mail überein — abgebrochen.','Не совпадает с вашим e-mail — отменено.','No coincide con tu correo — cancelado.'); return; }
-        msg.textContent=_authL('Deleting your account…','アカウントを削除中…','Konto wird gelöscht…','Удаление аккаунта…','Eliminando tu cuenta…');
-        try{
-          const sres=await DB.auth.getSession(); const session=sres&&sres.data&&sres.data.session;
-          const r=await fetch(window.SUPABASE_URL+'/functions/v1/delete-account',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+((session&&session.access_token)||''),'apikey':window.SUPABASE_ANON_KEY},body:JSON.stringify({confirm:'DELETE'})});
-          const j=await r.json().catch(()=>({}));
-          if(!r.ok||!j.ok) throw new Error(j.message||'delete failed');
-          try{ await DB.auth.signOut(); }catch(_){}
-          currentUser=null; bookmarks=[];
-          try{ Object.keys(localStorage).forEach(k=>{ if(/^(intmap_|sb-)/.test(k)) localStorage.removeItem(k); }); }catch(_){}
-          try{ updateAccountButton(); if(typeof renderUI==='function') renderUI(); }catch(_){}
-          m.style.display='none';
-          try{ imToast(_authL('Your account has been deleted.','アカウントを削除しました。','Dein Konto wurde gelöscht.','Ваш аккаунт удалён.','Tu cuenta ha sido eliminada.')); }catch(_){}
-        }catch(e){ msg.textContent=_authL('Could not delete the account. Please try again or contact support.','アカウントを削除できませんでした。もう一度試すかサポートへご連絡ください。','Konto konnte nicht gelöscht werden. Bitte erneut versuchen oder Support kontaktieren.','Не удалось удалить аккаунт. Повторите попытку или обратитесь в поддержку.','No se pudo eliminar la cuenta. Inténtalo de nuevo o contacta soporte.'); }
-      };
-    }
-    document.getElementById('acct-email').textContent=currentUser.email;
-    try{ _renderPasskeys(); }catch(_){}
-    document.getElementById('acct-name').value=currentUser.name||'';
-    document.getElementById('acct-msg').textContent='';
-    /* avatar preview + current selection */
-    { const av=window.imGetAvatar(), img=window.imGetAvatarImg(); const prev=document.getElementById('acct-avatar-preview');
-      if(prev){ if(img){ prev.style.backgroundImage=`url('${img}')`; prev.textContent=''; } else { prev.style.backgroundImage=''; prev.textContent=av; prev.style.background='hsl('+(window.imAvatarHue())+',58%,46%)'; } }
-      document.querySelectorAll('#acct-avatar-pick .acct-emoji').forEach(b=>b.classList.toggle('sel',!img&&b.dataset.e===av)); }
-    { const bioEl=document.getElementById('acct-bio'); if(bioEl){ let b=currentUser.bio; if(b==null){ try{ b=localStorage.getItem('intmap_bio')||''; }catch(_){ b=''; } } bioEl.value=b||''; } }
-    /* (#R10) Pro status / upgrade row removed — the app is fully free, no plan indicator. Admin still
-       shown for moderators. */
-    const proRow=document.getElementById('acct-pro');
-    if(proRow){
-      if(currentUser && currentUser.isAdmin){ proRow.style.display=''; proRow.innerHTML=`<span style="color:var(--text-muted);font-weight:600;font-size:12px;">· admin</span>`; }
-      else { proRow.style.display='none'; proRow.innerHTML=''; }
-    }
-    m.style.display='flex';
-  }
   /* Account avatar (#28) — chosen emoji icon, persisted locally. */
   window.imGetAvatar=function(){ try{ return localStorage.getItem('intmap_avatar')||'👤'; }catch(_){ return '👤'; } };
   window.imGetAvatarImg=function(){ try{ return localStorage.getItem('intmap_avatar_img')||''; }catch(_){ return ''; } };
@@ -8116,59 +6253,7 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   window.imViewProfile=imViewProfile;
   document.addEventListener('click',e=>{ const a=e.target.closest&&e.target.closest('.comm-author-link'); if(a && !(e.target.closest&&e.target.closest('.comm-post-loc'))){ e.preventDefault(); imViewProfile(a.getAttribute('data-uid'),a.getAttribute('data-author')); } });
-  async function refreshCurrentUser(sessionArg){
-    if(!DB){ currentUser=null; return; }
-    /* Accept a session passed in from onAuthStateChange so we don't re-enter getSession() while the
-       auth lock is held (that re-entry is the supabase-js v2 deadlock behind "logged in but the UI
-       never updates", #14). Only call getSession() when invoked standalone (sessionArg===undefined). */
-    let session=sessionArg;
-    if(session===undefined){ try{ const r=await DB.auth.getSession(); session=(r&&r.data)?r.data.session:null; }catch(_){ session=null; } }
-    if(!session){ currentUser=null; updateAccountButton(); return; }
-    const meta=session.user.user_metadata||{};
-    let isAdmin=false, isPro=false, name='';
-    try{
-      /* try to read is_pro too; if that column doesn't exist yet, fall back to the basic select */
-      let r=await DB.from('profiles').select('display_name,is_admin,is_pro').eq('id',session.user.id).maybeSingle();
-      if(r.error) r=await DB.from('profiles').select('display_name,is_admin').eq('id',session.user.id).maybeSingle();
-      const prof=r.data;
-      if(prof){ isAdmin=!!prof.is_admin; isPro=!!prof.is_pro; if(prof.display_name) name=prof.display_name; }
-      /* First login after email/OAuth signup: copy the chosen name (or OAuth name) into the profile */
-      if(!name){ const want=meta.display_name||meta.full_name||meta.name||''; if(want){ try{ await DB.from('profiles').update({display_name:want}).eq('id',session.user.id); name=want; }catch(_){} } }
-    }catch(_){}
-    /* (#R33) PRIVACY: never derive the public name from the email (its local part would expose part of the
-       address in community posts). Fall back to a neutral handle from the user id instead. */
-    if(!name) name='User-'+String(session.user.id||'').replace(/[^a-z0-9]/gi,'').slice(0,5);
-    currentUser={ id:session.user.id, email:session.user.email, name, isAdmin, isPro:isPro||isAdmin }; updateAccountButton();
-    /* (#R35) Persist the developer flag the moment the OWNER account logs in, so "unlimited AI" is recognised
-       SYNCHRONOUSLY everywhere afterward — even before currentUser repopulates on the next load. This is why
-       the Settings usage graph "wasn't reflecting unlimited": aiRenderSettings could run before the async
-       email arrived. Persist + re-render now. */
-    try{ if(/2ppzc4kk6r@privaterelay\.appleid\.com/i.test(currentUser.email||'')) localStorage.setItem('intmap_dev','1'); }catch(_){}
-    try{ window.aiRenderSettings&&window.aiRenderSettings(); }catch(_){}
-    try{ window.refreshProUI&&window.refreshProUI(); }catch(_){}
-    try{ window._syncPrefsDown&&window._syncPrefsDown(); }catch(_){}   /* (#R20) pull the account's saved settings/presets/widgets */
-  }
 
-  /* ---------- FAVORITES (★ saved articles) ---------- */
-  async function loadFavorites(){
-    if(!currentUser||!DB) return;
-    const {data,error}=await DB.from('favorites').select('article_link');
-    if(error){ console.warn('[IntMap] favorites load:', error.message); return; }
-    let cloud=(data||[]).map(r=>r.article_link);
-    /* one-time merge of any favorites saved as a guest before logging in */
-    let local=[]; try{ local=JSON.parse(localStorage.getItem('intmap_bookmarks'))||[]; }catch(_){}
-    const toAdd=local.filter(l=>!cloud.includes(l));
-    if(toAdd.length){ try{ await DB.from('favorites').insert(toAdd.map(l=>({user_id:currentUser.id,article_link:l}))); cloud=cloud.concat(toAdd); }catch(_){}
-      try{ localStorage.removeItem('intmap_bookmarks'); }catch(_){} }
-    bookmarks=cloud;
-  }
-  async function toggleFavorite(link,title){
-    if(!currentUser){ openAuthModal(); return false; }
-    const has=bookmarks.includes(link);
-    if(has){ bookmarks=bookmarks.filter(b=>b!==link); await DB.from('favorites').delete().eq('user_id',currentUser.id).eq('article_link',link); }
-    else { bookmarks.push(link); await DB.from('favorites').insert({ user_id:currentUser.id, article_link:link, article_title:title||null }); }
-    return !has;
-  }
 
   /* ---------- COMMUNITY (cloud) ---------- */
   function requireLogin(){ if(!currentUser){ openAuthModal(); return false; } return true; }
@@ -8233,44 +6318,7 @@ window.addEventListener('DOMContentLoaded', () => {
     if(commCaps&&commCaps.edited) patch.edited_at=new Date().toISOString();
     const {error}=await DB.from('community_posts').update(patch).eq('id',id); if(error) throw error;
   }
-  async function cmComment(postId,text,parentId){
-    const row={ post_id:postId, user_id:currentUser.id, author_name:currentUser.name, body:text };
-    if(parentId && commCaps&&commCaps.threads) row.parent_id=parentId;
-    let {error}=await DB.from('community_comments').insert(row);
-    if(error && row.parent_id){ delete row.parent_id; ({error}=await DB.from('community_comments').insert(row)); }
-    if(error) throw error;
-  }
-  async function cmEditComment(id,text){
-    const patch={ body:text };
-    if(commCaps&&commCaps.edited) patch.edited_at=new Date().toISOString();
-    const {error}=await DB.from('community_comments').update(patch).eq('id',id); if(error) throw error;
-  }
-  async function cmDeleteComment(id){ const {error}=await DB.from('community_comments').delete().eq('id',id); if(error) throw error; }
-  async function cmVoteComment(id,on){
-    if(on){ const {error}=await DB.from('community_comment_votes').insert({ comment_id:id, user_id:currentUser.id }); if(error && error.code!=='23505') throw error; }
-    else { const {error}=await DB.from('community_comment_votes').delete().eq('comment_id',id).eq('user_id',currentUser.id); if(error) throw error; }
-  }
-  async function cmVote(postId,on){
-    if(on){ const {error}=await DB.from('community_votes').insert({ post_id:postId, user_id:currentUser.id }); if(error && error.code!=='23505') throw error; }
-    else { const {error}=await DB.from('community_votes').delete().eq('post_id',postId).eq('user_id',currentUser.id); if(error) throw error; }
-  }
-  async function cmDelete(postId){ const {error}=await DB.from('community_posts').delete().eq('id',postId); if(error) throw error; }
-  async function cmReport(postId){ const {error}=await DB.from('community_reports').insert({ post_id:postId, user_id:currentUser.id }); if(error && error.code!=='23505') throw error; }
 
-  /* ---------- REALTIME (live auto-reflect) ---------- */
-  function subscribeRealtime(){
-    if(!DB||!DB.channel) return;
-    try{
-      DB.channel('intmap-public')
-        .on('postgres_changes',{event:'*',schema:'public',table:'geo_pins'},        ()=>loadGeoFromSupabase().then(()=>{ try{ if(globalData&&globalData.length) renderUI(); }catch(_){} }))
-        .on('postgres_changes',{event:'*',schema:'public',table:'dashboard_cards'}, ()=>loadDashFromSupabase().then(()=>{ try{ if(currentMode==='info') renderDashboard(); }catch(_){} }))
-        .on('postgres_changes',{event:'*',schema:'public',table:'community_posts'},    ()=>loadCommunity())
-        .on('postgres_changes',{event:'*',schema:'public',table:'community_comments'}, ()=>{ if(currentMode==='community') loadCommunity(); })
-        .on('postgres_changes',{event:'*',schema:'public',table:'community_votes'},    ()=>{ if(currentMode==='community') loadCommunity(); })
-        .on('postgres_changes',{event:'*',schema:'public',table:'current_news'},       ()=>{ try{ if(window.__IM_USE_SERVER_NEWS!==false && !activeSearchQuery&&!newsDate&&newsLangMode!=='multi') loadNewsFromSupabase(); }catch(_){} })   /* (#R40) gated off while the server feed is temporarily disabled */
-        .subscribe();
-    }catch(e){ console.warn('[IntMap] realtime subscribe failed:', e&&e.message); }
-  }
 
   /* (#R27) Count a genuine, user-initiated login (email submit success OR an OAuth return — NOT a
      session restore on reload, NOT a token refresh) and, on the user's 3rd login, show the feedback
@@ -8289,72 +6337,6 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   window.recordLogin=recordLogin;
 
-  /* ---------- BOOT ---------- */
-  async function bootSupabase(){
-    if(!DB){ console.warn('[IntMap] Supabase unavailable — load supabase.js / supabase-config.js. Running with empty data.'); return; }
-    injectAuthUI();
-    /* Register the auth listener FIRST so the SIGNED_IN event fired while supabase parses the OAuth
-       token out of the redirect URL is never missed (a cause of "logged in but not logged in", #33). */
-    DB.auth.onAuthStateChange((event,session)=>{
-      /* (#R7-login) IMMEDIATE, synchronous, lock-safe reflection: the instant Supabase parses the
-         Google OAuth token out of the redirect URL it fires here. Update the account button RIGHT NOW
-         from the event's own session (no Supabase calls — those would re-enter the held auth lock and
-         deadlock, #14), so the UI shows "logged in" without waiting for the profile fetch or a reload. */
-      try{
-        /* (#R155) The user followed a "reset password" email link → prompt for a new password. */
-        if(event==='PASSWORD_RECOVERY'){ try{ const am=document.getElementById('auth-modal'); if(am) am.style.display='none'; }catch(_){} try{ _openSetPassword(true); }catch(_){} }
-        if(session&&session.user){
-          if(!currentUser||currentUser.id!==session.user.id){
-            const m=session.user.user_metadata||{};
-            currentUser={ id:session.user.id, email:session.user.email||'', name:(m.display_name||m.full_name||m.name||('User-'+String(session.user.id||'').replace(/[^a-z0-9]/gi,'').slice(0,5))), isAdmin:false, isPro:false };
-          }
-          try{ updateAccountButton(); }catch(_){}
-          try{ const am=document.getElementById('auth-modal'); if(am && am.style.display!=='none') am.style.display='none'; }catch(_){}
-        } else if(event==='SIGNED_OUT'){ currentUser=null; try{ updateAccountButton(); }catch(_){} }
-      }catch(_){}
-      /* Then the heavier enrich (profile name / admin / pro, favorites, tab re-render) deferred a tick
-         so the auth lock is released first. */
-      setTimeout(async()=>{
-        await refreshCurrentUser(session||null); await loadFavorites();
-        try{ if(currentMode==='news'||currentMode==='saved') startNews(); }catch(_){}
-        try{ if(currentMode==='community') loadCommunity(); }catch(_){}
-        try{ const am=document.getElementById('auth-modal'); if(currentUser && am && am.style.display!=='none') am.style.display='none'; }catch(_){}   /* close the login modal once signed in */
-        try{ renderUI(); }catch(_){}            /* reflect the new auth state in the active tab immediately */
-        /* Pro entitlement may have changed → re-check satellite provider access */
-        try{ if(currentMapType==='sat'){ const cur=satProviderById(satState.providerId); if(cur&&cur.tier==='pro'&&!satHasKey(cur)) satRevertToFallback(); else satRenderController(); } }catch(_){}
-        try{ if(currentUser) aiFetchUsage(); }catch(_){}   /* (#R27) refresh today's AI-quota for the signed-in user */
-      },0);
-    });
-    await refreshCurrentUser();
-    /* OAuth implicit-flow tokens land in the URL hash and are parsed asynchronously; if the very
-       first getSession ran a hair too early, re-check a couple of times so the session is picked up
-       without needing a manual reload (#33). */
-    if(!currentUser && /[#&?](access_token|code|refresh_token)=/.test(location.href)){
-      /* (#R8) Poll long enough to cover a slow PKCE code-exchange round-trip — the implicit-flow hash
-         parse is near-instant, but a ?code= exchange needs a network hop to Supabase. Reflect each tick. */
-      for(let i=0;i<16 && !currentUser;i++){ await new Promise(r=>setTimeout(r,400)); try{ await refreshCurrentUser(); }catch(_){} if(currentUser){ try{ updateAccountButton(); renderUI(); }catch(_){} } }
-      try{ if(currentUser){ await loadFavorites(); renderUI(); } }catch(_){}
-      try{ if(currentUser){ recordLogin(); aiFetchUsage(); } }catch(_){}   /* (#R27) an OAuth return is a genuine login */
-      /* (#R8) Only scrub the token AFTER a session is in hand. Scrubbing while the exchange is still
-         pending throws away the code and forces a manual reload — the exact "戻ると未ログイン" symptom. */
-      try{ if(currentUser && (location.protocol==='http:'||location.protocol==='https:')) history.replaceState(null,'',location.origin+location.pathname); }catch(_){}
-    }
-    /* (#R8) Safety nets so login reflects the instant the user returns from Google — no manual reload.
-       focus + visibilitychange cover a tab switch; pageshow covers a BFCACHE restore (back button from
-       Google, where focus/visibilitychange often DON'T fire — the missing case behind "戻ると未ログイン");
-       storage covers the session being written by another tab or the Supabase auth helper. */
-    let _authRecheck=0;
-    const _recheckAuth=(force)=>{ if(!force && _authRecheck && Date.now()-_authRecheck<1200) return; _authRecheck=Date.now();
-      setTimeout(async()=>{ try{ const had=!!currentUser; await refreshCurrentUser(); if(!!currentUser!==had){ try{ updateAccountButton(); renderUI(); }catch(_){} if(currentUser) try{ await loadFavorites(); }catch(_){} } }catch(_){} },0); };
-    window.addEventListener('focus',()=>_recheckAuth());
-    document.addEventListener('visibilitychange',()=>{ if(document.visibilityState==='visible') _recheckAuth(); });
-    window.addEventListener('pageshow',(e)=>{ _recheckAuth(!!(e&&e.persisted)); });
-    window.addEventListener('storage',(e)=>{ if(e&&e.key&&/sb-|supabase|auth/i.test(e.key)) _recheckAuth(true); });
-    await Promise.all([ loadGeoFromSupabase(), loadDashFromSupabase(), loadFavorites() ]);
-    try{ renderUI(); }catch(_){}          /* re-render the active tab now data + favorites are in */
-    try{ loadCommunity(); }catch(_){}      /* prime the community map pins */
-    subscribeRealtime();
-  }
 
   /* =====================================================================
    *  ROUND 3 — settings persistence, scrollbars, translucent sidebar,

--- a/js/auth-ui.js
+++ b/js/auth-ui.js
@@ -1,0 +1,522 @@
+/* ============================================================================
+ *  IntMap · Account, authentication & Supabase boot  (#R168)
+ * ----------------------------------------------------------------------------
+ *  Everything account-shaped: the auth modal, the account menu, password strength / breach
+ *  checking, passkeys, the set-password flow, the favourites loader, the realtime subscription
+ *  and bootSupabase(). currentUser is the single source of truth and stays declared in
+ *  index.html — this module writes it through the host setter.
+ *
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure: the only edit is that free
+ *  references to closure variables became HOST.<member> reads (Architecture.md §3.1). The
+ *  extraction was done by script and reversed byte-for-byte against the original text.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.authUi=function(map,HOST){
+  /* ---------- DATA: geo_pins -> geoRaw -> rebuildGeoIndex ---------- */
+  async function loadGeoFromSupabase(){
+    if(!HOST.DB) return;
+    const { data, error } = await HOST.DB.from('geo_pins').select('type,terms,name_en,name_jp,lng,lat').order('sort_order',{ascending:true});
+    if(error){ console.warn('[IntMap] geo_pins load failed:', error.message); return; }
+    const grouped={};
+    (data||[]).forEach(r=>{ (grouped[r.type]=grouped[r.type]||[]).push({ terms:r.terms||[], loc:[r.lng,r.lat], name:{en:r.name_en, jp:r.name_jp||r.name_en} }); });
+    HOST.geoRaw=grouped; HOST.rebuildGeoIndex();
+  }
+
+  /* ---------- AUTH ---------- */
+  /* (#R155) 5-language helper for the auth/account modals (they predate the i18n dict). */
+  function _authL(en,jp,de,ru,es){ return HOST.lang==='jp'?jp:HOST.lang==='de'?de:HOST.lang==='ru'?ru:HOST.lang==='es'?es:en; }
+
+  /* (#R155) Password strength — mirrors the SERVER floor (supabase/config.toml [auth]:
+     minimum_password_length=8, password_requirements="lower_upper_letters_digits"). Returns {ok,msg}. */
+  function _pwStrength(pw){ pw=String(pw||'');
+    if(pw.length<8) return {ok:false,msg:_authL('Password must be at least 8 characters.','パスワードは8文字以上にしてください。','Das Passwort muss mindestens 8 Zeichen lang sein.','Пароль должен содержать не менее 8 символов.','La contraseña debe tener al menos 8 caracteres.')};
+    if(!/[a-z]/.test(pw)||!/[A-Z]/.test(pw)||!/[0-9]/.test(pw)) return {ok:false,msg:_authL('Include lower- and upper-case letters and a number.','小文字・大文字・数字を含めてください。','Verwende Groß- und Kleinbuchstaben sowie eine Ziffer.','Используйте строчные и прописные буквы и цифру.','Incluye mayúsculas, minúsculas y un número.')};
+    return {ok:true,msg:''};
+  }
+
+  async function _pwBreachCount(pw){ try{
+    if(!(window.crypto&&crypto.subtle&&crypto.subtle.digest)) return 0;
+    const buf=await crypto.subtle.digest('SHA-1', new TextEncoder().encode(String(pw||'')));
+    const hex=Array.from(new Uint8Array(buf)).map(b=>b.toString(16).padStart(2,'0')).join('').toUpperCase();
+    const r=await fetch('https://api.pwnedpasswords.com/range/'+hex.slice(0,5));
+    if(!r.ok) return 0;
+    const suffix=hex.slice(5), txt=await r.text();
+    for(const line of txt.split('\n')){ const p=line.trim().split(':'); if(p[0]===suffix) return parseInt(p[1],10)||1; }
+    return 0;
+  }catch(_){ return 0; } }
+
+  /* (#R155) Full new-password gate: strength THEN breach. Returns {ok,msg}. */
+  async function _pwValidateNew(pw){ const s=_pwStrength(pw); if(!s.ok) return s;
+    if(await _pwBreachCount(pw)>0) return {ok:false,msg:_authL('This password appears in a known data breach — please choose a different one.','このパスワードは既知の漏えいに含まれています。別のものを選んでください。','Dieses Passwort taucht in einem bekannten Datenleck auf — bitte wähle ein anderes.','Этот пароль встречался в известной утечке — выберите другой.','Esta contraseña apareció en una filtración conocida: elige otra.')};
+    return {ok:true,msg:''};
+  }
+
+  /* (#R155) Passkey capability: the SDK method exists AND the browser supports WebAuthn. */
+  function _passkeysAvailable(){ try{ return !!(HOST.DB&&HOST.DB.auth&&typeof HOST.DB.auth.signInWithPasskey==='function'&&window.PublicKeyCredential); }catch(_){ return false; } }
+
+  async function _renderPasskeys(){ const box=document.getElementById('acct-passkeys'); if(!box) return;
+    const addBtn=document.getElementById('acct-add-passkey');
+    if(!_passkeysAvailable()||!(HOST.DB.auth.passkey&&typeof HOST.DB.auth.passkey.list==='function')){ box.innerHTML=''; if(addBtn) addBtn.style.display='none'; return; }
+    if(addBtn) addBtn.style.display='block';
+    box.innerHTML='<div style="font-size:12px;color:var(--text-muted);">'+HOST.escapeHtml(_authL('Loading passkeys…','パスキーを読み込み中…','Passkeys werden geladen…','Загрузка паскеев…','Cargando passkeys…'))+'</div>';
+    let list=[];
+    try{ const r=await HOST.DB.auth.passkey.list(); const d=(r&&r.data)||r; list=Array.isArray(d)?d:(d&&(d.passkeys||d.all||d.factors))||[]; }
+    catch(_){ box.innerHTML=''; return; }
+    if(!list.length){ box.innerHTML='<div style="font-size:12px;color:var(--text-muted);">'+HOST.escapeHtml(_authL('No passkeys yet.','パスキーはまだありません。','Noch keine Passkeys.','Паскеев пока нет.','Aún no hay passkeys.'))+'</div>'; return; }
+    box.innerHTML=list.map(pk=>{ const nm=HOST.escapeHtml(pk.friendly_name||pk.friendlyName||pk.name||'Passkey'), id=HOST.escapeHtml(String(pk.id||''));
+      return '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;background:var(--input-bg);border-radius:8px;padding:7px 10px;margin-bottom:6px;"><span style="font-size:12.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">'+nm+'</span><button data-pkdel="'+id+'" style="background:transparent;border:none;color:#ff3b30;font-size:12px;font-weight:600;cursor:pointer;flex:0 0 auto;">'+HOST.escapeHtml(_authL('Remove','削除','Entfernen','Удалить','Quitar'))+'</button></div>'; }).join('');
+    box.querySelectorAll('[data-pkdel]').forEach(b=>b.onclick=async()=>{ const id=b.getAttribute('data-pkdel');
+      if(!window.confirm(_authL('Remove this passkey?','このパスキーを削除しますか？','Diesen Passkey entfernen?','Удалить этот паскей?','¿Quitar este passkey?'))) return;
+      try{ await HOST.DB.auth.passkey.delete({id}); }catch(_){ try{ await HOST.DB.auth.passkey.delete({passkeyId:id}); }catch(__){} }
+      _renderPasskeys();
+    });
+  }
+
+  /* (#R155) Shared "set a new password" modal — used by the reset-link recovery flow AND the
+     account menu's Change-password button. Enforces the same strength + breach gate as signup. */
+  function _openSetPassword(isRecovery){
+    let d=document.getElementById('setpw-modal');
+    if(!d){ d=document.createElement('div'); d.id='setpw-modal';
+      d.style.cssText='position:fixed;inset:0;background:rgba(0,0,0,.55);display:none;align-items:center;justify-content:center;z-index:5300;padding:20px;';
+      d.innerHTML='<div style="background:var(--card-bg);color:var(--text-main);border-radius:16px;box-shadow:var(--shadow);padding:24px;width:100%;max-width:340px;box-sizing:border-box;">'
+        +'<h2 style="margin:0 0 12px;font-size:18px;">'+HOST.escapeHtml(_authL('Set a new password','新しいパスワードを設定','Neues Passwort festlegen','Задать новый пароль','Establecer nueva contraseña'))+'</h2>'
+        +'<input id="setpw-input" type="password" autocomplete="new-password" placeholder="'+HOST.escapeHtml(_authL('New password (min. 8, incl. a number)','新しいパスワード（8文字以上・数字を含む）','Neues Passwort (min. 8, mit Ziffer)','Новый пароль (мин. 8, с цифрой)','Nueva contraseña (mín. 8, con número)'))+'" style="width:100%;box-sizing:border-box;padding:10px;border-radius:8px;border:1px solid transparent;background:var(--input-bg);color:var(--text-main);margin-bottom:12px;">'
+        +'<button id="setpw-save" style="width:100%;background:var(--primary-color);color:#fff;border:none;padding:11px;border-radius:9px;font-weight:600;cursor:pointer;">'+HOST.escapeHtml(_authL('Save','保存','Speichern','Сохранить','Guardar'))+'</button>'
+        +'<p id="setpw-msg" style="margin:10px 0 0;color:var(--text-muted);font-size:12.5px;"></p>'
+        +'<button id="setpw-close" style="width:100%;background:transparent;border:none;color:var(--text-muted);margin-top:8px;padding:6px;cursor:pointer;font-size:13px;">'+HOST.escapeHtml(_authL('Cancel','キャンセル','Abbrechen','Отмена','Cancelar'))+'</button></div>';
+      document.body.appendChild(d);
+      d.onclick=e=>{ if(e.target===d) d.style.display='none'; };
+      document.getElementById('setpw-close').onclick=()=>{ d.style.display='none'; };
+      document.getElementById('setpw-save').onclick=async()=>{
+        const pw=document.getElementById('setpw-input').value, msg=document.getElementById('setpw-msg'), btn=document.getElementById('setpw-save');
+        btn.disabled=true; msg.textContent=_authL('Checking password…','パスワードを確認中…','Passwort wird geprüft…','Проверка пароля…','Comprobando contraseña…');
+        const chk=await _pwValidateNew(pw); if(!chk.ok){ msg.textContent=chk.msg; btn.disabled=false; return; }
+        msg.textContent=_authL('Saving…','保存中…','Speichere…','Сохранение…','Guardando…');
+        try{ const {error}=await HOST.DB.auth.updateUser({password:pw}); if(error) throw error;
+          msg.textContent=_authL('Password updated.','パスワードを更新しました。','Passwort aktualisiert.','Пароль обновлён.','Contraseña actualizada.');
+          setTimeout(()=>{ d.style.display='none'; }, 900);
+        }catch(e){ msg.textContent=_authL('Could not update the password.','パスワードを更新できませんでした。','Passwort konnte nicht aktualisiert werden.','Не удалось обновить пароль.','No se pudo actualizar la contraseña.'); }
+        finally{ btn.disabled=false; }
+      };
+    }
+    document.getElementById('setpw-input').value='';
+    document.getElementById('setpw-msg').textContent=isRecovery?_authL('Enter a new password to finish resetting your account.','アカウント再設定を完了するには新しいパスワードを入力してください。','Gib ein neues Passwort ein, um das Zurücksetzen abzuschließen.','Введите новый пароль, чтобы завершить сброс.','Introduce una nueva contraseña para terminar el restablecimiento.'):'';
+    d.style.display='flex';
+  }
+
+  function injectAuthUI(){
+    const settingsBtn=document.getElementById('btn-open-settings');
+    const acct=document.createElement('button');
+    acct.id='btn-account'; acct.className='btn-settings'; acct.style.marginRight='8px'; acct.textContent=(HOST.lang==='jp'?'ログイン':HOST.lang==='de'?'Anmelden':HOST.lang==='ru'?'Войти':HOST.lang==='es'?'Iniciar sesión':'Log in');
+    acct.onclick=()=>{ HOST.user ? openAccountMenu() : openAuthModal(); };
+    if(settingsBtn&&settingsBtn.parentNode) settingsBtn.parentNode.insertBefore(acct,settingsBtn);
+    else document.body.appendChild(acct);
+    /* (#R122) enter Workspace (floating-window) mode from the Log in / Feedback / Settings row — desktop only. */
+    try{ const wsB=document.createElement('button'); wsB.id='btn-ws-enter'; wsB.className='btn-settings'; wsB.style.marginRight='8px';
+      const _wsL=()=>(HOST.lang==='jp'?'ワークスペース':HOST.lang==='de'?'Arbeitsbereich':HOST.lang==='ru'?'Рабочая область':HOST.lang==='es'?'Espacio':'Workspace');
+      wsB.title=_wsL(); wsB.setAttribute('aria-label',_wsL());
+      wsB.innerHTML='<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M9 9v11"/></svg>';
+      window.addEventListener('intmap-lang',()=>{ wsB.title=_wsL(); wsB.setAttribute('aria-label',_wsL()); });
+      wsB.onclick=()=>{ try{ if(window.IntMapWorkspace){ const act=window.IntMapWorkspace.active&&window.IntMapWorkspace.active(); if(act) window.IntMapWorkspace.close(); else window.IntMapWorkspace.open(); } }catch(_){} };
+      if(settingsBtn&&settingsBtn.parentNode) settingsBtn.parentNode.insertBefore(wsB,acct); else document.body.appendChild(wsB); }catch(_){}
+    /* (#R21) Header Support button RETIRED per request — support stays reachable from Settings
+       (the in-panel button) and from the feedback flow. */
+    /* (#R20) Feedback button in the header */
+    const fb=document.createElement('button');
+    fb.id='btn-feedback-hdr'; fb.className='btn-settings'; fb.style.marginRight='8px';
+    fb.textContent=(HOST.lang==='jp'?'フィードバック':HOST.lang==='de'?'Feedback':HOST.lang==='ru'?'Обратная связь':HOST.lang==='es'?'Comentarios':'Feedback');
+    window.addEventListener('intmap-lang',()=>{ fb.textContent=(HOST.lang==='jp'?'フィードバック':HOST.lang==='de'?'Feedback':HOST.lang==='ru'?'Обратная связь':HOST.lang==='es'?'Comentarios':'Feedback'); });
+    fb.onclick=()=>{ try{ window._openFeedback&&window._openFeedback(); }catch(_){} };
+    if(settingsBtn&&settingsBtn.parentNode) settingsBtn.parentNode.insertBefore(fb,settingsBtn);
+    else document.body.appendChild(fb);
+
+    const m=document.createElement('div'); m.id='auth-modal';
+    m.style.cssText='position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;z-index:5000;padding:20px;';
+    const inStyle='width:100%;box-sizing:border-box;padding:10px;border-radius:8px;border:1px solid transparent;background:var(--input-bg);color:var(--text-main);margin-bottom:10px;';
+    const oaStyle='width:100%;box-sizing:border-box;display:flex;align-items:center;justify-content:center;gap:8px;padding:10px;border-radius:9px;border:1px solid rgba(128,128,128,0.25);background:var(--card-bg);color:var(--text-main);font-weight:600;font-size:13.5px;cursor:pointer;margin-bottom:8px;';
+    m.innerHTML=`<div style="background:var(--card-bg);color:var(--text-main);border-radius:16px;box-shadow:var(--shadow);padding:24px;width:100%;max-width:360px;box-sizing:border-box;max-height:92vh;overflow-y:auto;">
+      <h2 style="margin:0 0 4px;font-size:19px;">IntMap account</h2>
+      <p id="am-sub" style="margin:0 0 16px;color:var(--text-muted);font-size:13px;line-height:1.5;">Log in or create an account to use AI features and sync your settings, widgets, favorites and avatar across devices.</p>
+      <div style="display:flex;background:var(--input-bg);border-radius:10px;padding:3px;margin-bottom:14px;">
+        <button id="am-tab-login" style="flex:1;border:none;background:var(--card-bg);color:var(--text-main);padding:8px;border-radius:8px;font-weight:600;cursor:pointer;">Log In</button>
+        <button id="am-tab-signup" style="flex:1;border:none;background:transparent;color:var(--text-muted);padding:8px;border-radius:8px;font-weight:600;cursor:pointer;">Sign Up</button>
+      </div>
+      <button id="am-oauth-google" style="${oaStyle}"><svg width="17" height="17" viewBox="0 0 48 48" style="flex:0 0 auto;"><path fill="#4285F4" d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"/><path fill="#34A853" d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"/><path fill="#FBBC05" d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34C2.85 17.09 2 20.45 2 24s.85 6.91 2.34 9.88l7.35-5.7z"/><path fill="#EA4335" d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"/></svg> Continue with Google</button>
+      <div style="display:flex;align-items:center;gap:10px;margin:12px 0 14px;color:var(--text-muted);font-size:12px;"><div style="flex:1;height:1px;background:rgba(128,128,128,0.2);"></div>or<div style="flex:1;height:1px;background:rgba(128,128,128,0.2);"></div></div>
+      <input id="am-name" type="text" placeholder="Display name" autocomplete="nickname" maxlength="40" style="${inStyle}display:none;">
+      <input id="am-email" type="email" placeholder="you@example.com" autocomplete="username" style="${inStyle}">
+      <input id="am-pass" type="password" placeholder="Password" autocomplete="current-password" style="${inStyle}margin-bottom:8px;">
+      <div id="am-forgot-row" style="text-align:right;margin:-2px 0 12px;"><a id="am-forgot" href="#" style="color:var(--text-muted);font-size:12px;text-decoration:none;">${_authL('Forgot password?','パスワードをお忘れですか？','Passwort vergessen?','Забыли пароль?','¿Olvidaste tu contraseña?')}</a></div>
+      <button id="am-submit" style="width:100%;background:var(--primary-color);color:#fff;border:none;padding:11px;border-radius:9px;font-weight:600;font-size:14px;cursor:pointer;">Log In</button>
+      <button id="am-passkey" style="width:100%;background:var(--card-bg);color:var(--text-main);border:1px solid rgba(128,128,128,0.25);padding:10px;border-radius:9px;font-weight:600;font-size:13.5px;cursor:pointer;margin-top:8px;display:none;">${_authL('Sign in with a passkey','パスキーでログイン','Mit Passkey anmelden','Войти по паскею','Iniciar sesión con passkey')}</button>
+      <p id="am-msg" style="margin:12px 0 0;color:var(--text-muted);font-size:12.5px;line-height:1.5;"></p>
+      <button id="am-close" style="width:100%;background:transparent;border:none;color:var(--text-muted);margin-top:8px;padding:6px;cursor:pointer;font-size:13px;">Close</button>
+    </div>`;
+    document.body.appendChild(m);
+    let amMode='login';
+    function setTab(mode){ amMode=mode;
+      /* (#R122) dark mode: the SELECTED segment is a solid white pill with black text (high contrast) */
+      const dk=document.documentElement.getAttribute('data-theme')==='dark';
+      const selBg=dk?'#fff':'var(--card-bg)', selFg=dk?'#111':'var(--text-main)';
+      $am('am-tab-login').style.background = mode==='login'?selBg:'transparent';
+      $am('am-tab-login').style.color = mode==='login'?selFg:'var(--text-muted)';
+      $am('am-tab-signup').style.background = mode==='signup'?selBg:'transparent';
+      $am('am-tab-signup').style.color = mode==='signup'?selFg:'var(--text-muted)';
+      $am('am-name').style.display = mode==='signup'?'block':'none';
+      $am('am-pass').setAttribute('autocomplete', mode==='signup'?'new-password':'current-password');
+      $am('am-submit').textContent = mode==='login'?'Log In':'Create account';
+      $am('am-pass').placeholder = mode==='signup'?_authL('Password (min. 8 chars, incl. a number)','パスワード（8文字以上・数字を含む）','Passwort (min. 8 Zeichen, mit Ziffer)','Пароль (мин. 8 символов, с цифрой)','Contraseña (mín. 8, con un número)'):_authL('Password','パスワード','Passwort','Пароль','Contraseña');
+      /* (#R155) passkey sign-in + forgot-password only make sense on the LOGIN tab. */
+      try{ $am('am-passkey').style.display=(mode==='login'&&_passkeysAvailable())?'block':'none'; }catch(_){}
+      try{ $am('am-forgot-row').style.display=mode==='login'?'block':'none'; }catch(_){}
+      $am('am-msg').textContent='';
+    }
+    function $am(id){ return document.getElementById(id); }
+    $am('am-tab-login').onclick=()=>setTab('login');
+    $am('am-tab-signup').onclick=()=>setTab('signup');
+    try{ setTab('login'); }catch(_){}   /* (#R122) normalize the initial segment colours for the current theme */
+    $am('am-close').onclick=()=>{ m.style.display='none'; };
+    m.onclick=(e)=>{ if(e.target===m) m.style.display='none'; };
+    $am('am-submit').onclick=async()=>{
+      const email=$am('am-email').value.trim(), password=$am('am-pass').value, name=$am('am-name').value.trim(), msg=$am('am-msg');
+      if(!email||!password){ msg.textContent=_authL('Enter email and password.','メールアドレスとパスワードを入力してください。','Gib E-Mail und Passwort ein.','Введите e-mail и пароль.','Introduce el correo y la contraseña.'); return; }
+      $am('am-submit').disabled=true;
+      try{
+        if(amMode==='signup'){
+          if(!name){ msg.textContent=_authL('Choose a display name (shown on your community posts).','表示名を入力してください（コミュニティ投稿に表示されます）。','Wähle einen Anzeigenamen (in Community-Beiträgen sichtbar).','Выберите отображаемое имя (видно в постах сообщества).','Elige un nombre visible (aparece en tus publicaciones).'); return; }
+          /* (#R155) strength (mirrors the server floor) THEN a HIBP breach check before we submit. */
+          msg.textContent=_authL('Checking password…','パスワードを確認中…','Passwort wird geprüft…','Проверка пароля…','Comprobando contraseña…');
+          const chk=await _pwValidateNew(password); if(!chk.ok){ msg.textContent=chk.msg; return; }
+          msg.textContent=_authL('Working…','処理中…','Wird verarbeitet…','Обработка…','Procesando…');
+          /* display_name is stored in user metadata; the profile row picks it up on first login */
+          const {error}=await HOST.DB.auth.signUp({email,password,options:{data:{display_name:name}}});
+          /* (#R155) ENUMERATION-SAFE: whether the email is new OR already registered, show the SAME
+             neutral message so signup can't be used to probe which emails have accounts. */
+          if(error && !/already|exist|registered/i.test(error.message||'')) throw error;
+          msg.textContent=_authL('Check your email — if this address is new, we sent a confirmation link. Then log in.','メールをご確認ください。新規の場合は確認リンクを送信しました。その後ログインしてください。','Prüfe deine E-Mail — falls neu, haben wir einen Bestätigungslink gesendet. Dann anmelden.','Проверьте почту — если адрес новый, мы отправили ссылку для подтверждения. Затем войдите.','Revisa tu correo: si es nuevo, enviamos un enlace de confirmación. Luego inicia sesión.'); setTab('login');
+        } else {
+          const {data,error}=await HOST.DB.auth.signInWithPassword({email,password});
+          /* (#R155) ENUMERATION-SAFE: Supabase already returns a generic "Invalid login credentials";
+             surface a single localized generic message and never reveal whether the email exists. */
+          if(error){ msg.textContent=_authL('Invalid email or password.','メールアドレスまたはパスワードが正しくありません。','E-Mail oder Passwort ist falsch.','Неверный e-mail или пароль.','Correo o contraseña incorrectos.'); return; }
+          m.style.display='none';
+          try{ HOST.recordLogin(data&&data.user&&data.user.id); }catch(_){}   /* (#R27) genuine login → count for the 3rd-login feedback nudge */
+        }
+      }catch(e){ msg.textContent=_authL('Something went wrong. Please try again.','エラーが発生しました。もう一度お試しください。','Etwas ist schiefgelaufen. Bitte erneut versuchen.','Что-то пошло не так. Повторите попытку.','Algo salió mal. Inténtalo de nuevo.'); }
+      finally{ $am('am-submit').disabled=false; }
+    };
+    /* (#R155) Passkey sign-in (WebAuthn, discoverable credential — no email needed). */
+    $am('am-passkey').onclick=async()=>{
+      const msg=$am('am-msg');
+      if(!_passkeysAvailable()){ msg.textContent=_authL('Passkeys aren\'t available on this device.','この端末ではパスキーを利用できません。','Passkeys sind auf diesem Gerät nicht verfügbar.','Паскеи недоступны на этом устройстве.','Los passkeys no están disponibles en este dispositivo.'); return; }
+      $am('am-passkey').disabled=true; msg.textContent=_authL('Waiting for your passkey…','パスキーを待機中…','Warte auf deinen Passkey…','Ожидание паскея…','Esperando tu passkey…');
+      try{ const {data,error}=await HOST.DB.auth.signInWithPasskey(); if(error) throw error;
+        m.style.display='none'; try{ HOST.recordLogin(data&&data.user&&data.user.id); }catch(_){}
+      }catch(e){ msg.textContent=_authL('Passkey sign-in failed or was cancelled.','パスキーのログインに失敗またはキャンセルされました。','Passkey-Anmeldung fehlgeschlagen oder abgebrochen.','Вход по паскею не удался или отменён.','El inicio con passkey falló o se canceló.'); }
+      finally{ $am('am-passkey').disabled=false; }
+    };
+    /* (#R155) Forgot password → email a reset link. Enumeration-safe: identical message regardless. */
+    $am('am-forgot').onclick=async(e)=>{ e.preventDefault(); const msg=$am('am-msg');
+      const email=$am('am-email').value.trim();
+      if(!email){ msg.textContent=_authL('Enter your email above, then tap “Forgot password?”.','上のメール欄を入力してから「パスワードをお忘れですか？」を押してください。','Gib oben deine E-Mail ein und tippe dann auf „Passwort vergessen?“.','Введите e-mail выше, затем нажмите «Забыли пароль?».','Introduce tu correo arriba y pulsa «¿Olvidaste tu contraseña?».'); return; }
+      const redirectTo=(location.protocol==='file:')?location.href:(location.origin+location.pathname);
+      try{ await HOST.DB.auth.resetPasswordForEmail(email,{redirectTo}); }catch(_){}
+      msg.textContent=_authL('If an account exists for that email, we\'ve sent a password-reset link.','そのメールアドレスのアカウントが存在する場合、再設定リンクを送信しました。','Falls ein Konto zu dieser E-Mail existiert, haben wir einen Link zum Zurücksetzen gesendet.','Если аккаунт с этим адресом существует, мы отправили ссылку для сброса пароля.','Si existe una cuenta con ese correo, enviamos un enlace para restablecer la contraseña.');
+    };
+    /* OAuth (Google / Apple). NOTE: each provider must be ENABLED in the Supabase dashboard
+       (Authentication → Providers) with this site added as a redirect URL, or it errors. */
+    async function oauth(provider){ const msg=$am('am-msg'); msg.textContent='Redirecting…';
+      /* Use a CLEAN redirect target (origin + path, no query/hash). It must be listed verbatim in
+         Supabase → Auth → URL Configuration → Redirect URLs, or the provider bounces back without a
+         session (the "logged in via Google but not actually logged in" symptom, #33). file:// can't
+         do OAuth at all — must be served over http(s). */
+      const redirectTo=(location.protocol==='file:') ? location.href : (location.origin+location.pathname);
+      try{ const {error}=await HOST.DB.auth.signInWithOAuth({ provider, options:{ redirectTo } }); if(error) throw error; }
+      catch(e){ msg.textContent='Error: '+((e&&e.message)||e); } }
+    $am('am-oauth-google').onclick=()=>oauth('google');
+    window.__amSetTab=setTab;
+  }
+
+  function openAuthModal(contextMsg){ const m=document.getElementById('auth-modal'); if(!m) return; if(window.__amSetTab) window.__amSetTab('login');
+    try{ const sub=document.getElementById('am-sub');
+      if(sub){ if(contextMsg){ sub.dataset.ctx='1'; sub.textContent=contextMsg; }
+        else if(sub.dataset.ctx){ delete sub.dataset.ctx; sub.textContent=(HOST.lang==='jp'?'ログイン／新規登録で、AI機能・設定/ウィジェット/お気に入り/アイコンの端末間同期が使えます。':HOST.lang==='de'?'Melde dich an oder registriere dich für KI-Funktionen und die Synchronisierung von Einstellungen, Widgets, Favoriten und Avatar über Geräte hinweg.':HOST.lang==='ru'?'Войдите или создайте аккаунт: ИИ-функции и синхронизация настроек, виджетов, избранного и аватара между устройствами.':HOST.lang==='es'?'Inicia sesión o crea una cuenta para usar la IA y sincronizar ajustes, widgets, favoritos y avatar entre dispositivos.':'Log in or create an account to use AI features and sync your settings, widgets, favorites and avatar across devices.'); } }
+    }catch(_){}
+    m.style.display='flex'; }
+
+  function openAccountMenu(){
+    if(!HOST.user) return openAuthModal();
+    let m=document.getElementById('acct-modal');
+    if(!m){
+      m=document.createElement('div'); m.id='acct-modal';
+      m.style.cssText='position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;z-index:5000;padding:20px;';
+      const secBtn='width:100%;background:var(--input-bg);color:var(--text-main);border:none;padding:10px;border-radius:9px;font-weight:600;font-size:13px;cursor:pointer;margin-bottom:8px;text-align:left;';   /* (#R155) security-section buttons */
+      m.innerHTML=`<div style="background:var(--card-bg);color:var(--text-main);border-radius:16px;box-shadow:var(--shadow);padding:24px;width:100%;max-width:360px;box-sizing:border-box;max-height:90vh;overflow-y:auto;">
+        <h2 style="margin:0 0 4px;font-size:19px;">${HOST.lang==='jp'?'プロフィール':HOST.lang==='de'?'Dein Profil':HOST.lang==='ru'?'Ваш профиль':HOST.lang==='es'?'Tu perfil':'Your profile'}</h2>
+        <p id="acct-email" style="margin:0 0 10px;color:var(--text-muted);font-size:13px;"></p>
+        <div class="acct-avatar-wrap"><div class="acct-avatar" id="acct-avatar-preview"></div>
+          <div style="flex:1;"><div style="font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;margin-bottom:4px;">${HOST.lang==='jp'?'アイコン':HOST.lang==='de'?'Icon':HOST.lang==='ru'?'Значок':HOST.lang==='es'?'Icono':'Icon'}</div>
+          <div class="acct-avatar-pick" id="acct-avatar-pick"></div>
+          <label class="compose-img-btn" for="acct-avatar-file" style="padding:6px 11px;font-size:12px;margin-top:2px;">🖼 ${HOST.lang==='jp'?'画像をアップロード':HOST.lang==='de'?'Bild hochladen':HOST.lang==='ru'?'Загрузить изображение':HOST.lang==='es'?'Subir imagen':'Upload image'}</label>
+          <input type="file" id="acct-avatar-file" accept="image/*" style="display:none;"></div></div>
+        <div id="acct-pro" style="margin:0 0 16px;font-size:13px;"></div>
+        <label style="font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;">${HOST.lang==='jp'?'表示名':HOST.lang==='de'?'Anzeigename':HOST.lang==='ru'?'Отображаемое имя':HOST.lang==='es'?'Nombre visible':'Display name'}</label>
+        <input id="acct-name" type="text" maxlength="40" style="width:100%;box-sizing:border-box;padding:10px;border-radius:8px;border:1px solid transparent;background:var(--input-bg);color:var(--text-main);margin:6px 0 12px;">
+        <label style="font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;">${HOST.lang==='jp'?'自己紹介（他のユーザーに公開）':HOST.lang==='de'?'Bio (öffentlich)':HOST.lang==='ru'?'О себе (публично)':HOST.lang==='es'?'Biografía (pública)':'Bio (public)'}</label>
+        <textarea id="acct-bio" maxlength="280" rows="3" style="width:100%;box-sizing:border-box;padding:10px;border-radius:8px;border:1px solid transparent;background:var(--input-bg);color:var(--text-main);margin:6px 0 14px;resize:vertical;font-family:inherit;font-size:13px;"></textarea>
+        <button id="acct-save" style="width:100%;background:var(--primary-color);color:#fff;border:none;padding:11px;border-radius:9px;font-weight:600;font-size:14px;cursor:pointer;">${HOST.lang==='jp'?'保存':HOST.lang==='de'?'Profil speichern':HOST.lang==='ru'?'Сохранить профиль':HOST.lang==='es'?'Guardar perfil':'Save profile'}</button>
+        <p id="acct-msg" style="margin:10px 0 0;color:var(--text-muted);font-size:12.5px;"></p>
+        <div style="margin-top:16px;border-top:1px solid rgba(128,128,128,0.18);padding-top:14px;">
+          <div style="font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.4px;margin-bottom:9px;">${_authL('Security','セキュリティ','Sicherheit','Безопасность','Seguridad')}</div>
+          <div id="acct-passkeys" style="margin-bottom:8px;"></div>
+          <button id="acct-add-passkey" style="${secBtn}display:none;">${_authL('Add a passkey','パスキーを追加','Passkey hinzufügen','Добавить паскей','Añadir passkey')}</button>
+          <button id="acct-change-email" style="${secBtn}">${_authL('Change email','メールアドレスを変更','E-Mail ändern','Изменить e-mail','Cambiar correo')}</button>
+          <button id="acct-change-pw" style="${secBtn}">${_authL('Change password','パスワードを変更','Passwort ändern','Изменить пароль','Cambiar contraseña')}</button>
+          <button id="acct-logout-all" style="${secBtn}margin-bottom:0;">${_authL('Log out on all devices','すべての端末からログアウト','Auf allen Geräten abmelden','Выйти на всех устройствах','Cerrar sesión en todos')}</button>
+        </div>
+        <button id="acct-logout" style="width:100%;background:var(--input-bg);color:var(--info-mil);border:none;padding:10px;border-radius:9px;font-weight:600;font-size:13px;cursor:pointer;margin-top:12px;">${HOST.lang==='jp'?'ログアウト':HOST.lang==='de'?'Abmelden':HOST.lang==='ru'?'Выйти':HOST.lang==='es'?'Cerrar sesión':'Log out'}</button>
+        <button id="acct-delete" style="width:100%;background:transparent;color:#ff3b30;border:1px solid rgba(255,59,48,0.4);padding:9px;border-radius:9px;font-weight:600;font-size:12.5px;cursor:pointer;margin-top:8px;">${_authL('Delete account','アカウントを削除','Konto löschen','Удалить аккаунт','Eliminar cuenta')}</button>
+        <button id="acct-close" style="width:100%;background:transparent;border:none;color:var(--text-muted);margin-top:6px;padding:6px;cursor:pointer;font-size:13px;">${HOST.lang==='jp'?'閉じる':HOST.lang==='de'?'Schließen':HOST.lang==='ru'?'Закрыть':HOST.lang==='es'?'Cerrar':'Close'}</button>
+      </div>`;
+      document.body.appendChild(m);
+      /* Avatar picker (#28): emoji + color, stored locally (and used as the account-button icon). */
+      const AV_EMOJI=['👤','🌍','🛰️','⚓','✈️','🛡️','📡','⛰️','🗺️','🔭','📰','🏛️','🦅','🐻','🐉','🌐'];
+      const pick=document.getElementById('acct-avatar-pick');
+      pick.innerHTML=AV_EMOJI.map(e=>`<button class="acct-emoji" data-e="${e}">${e}</button>`).join('');
+      pick.querySelectorAll('.acct-emoji').forEach(b=>b.onclick=()=>{ window.imSetAvatarImg(''); window.imSetAvatar(b.dataset.e); pick.querySelectorAll('.acct-emoji').forEach(x=>x.classList.toggle('sel',x===b)); const pv=document.getElementById('acct-avatar-preview'); pv.style.backgroundImage=''; pv.textContent=b.dataset.e; });
+      /* Upload a custom avatar image (#28) — compressed, stored locally + pushed to the profile if the column exists. */
+      const af=document.getElementById('acct-avatar-file');
+      if(af) af.onchange=async()=>{ const f=af.files&&af.files[0]; af.value=''; if(!f) return; try{
+        /* Crop to a square first (#12), then store the cropped 256² image. */
+        const data=await window.imCropImage(f); if(!data) return;
+        window.imSetAvatarImg(data); const pv=document.getElementById('acct-avatar-preview'); pv.style.backgroundImage=`url('${data}')`; pv.textContent='';
+        document.querySelectorAll('#acct-avatar-pick .acct-emoji').forEach(x=>x.classList.remove('sel'));
+        try{ await HOST.DB.from('profiles').update({avatar_url:data}).eq('id',HOST.user.id); }catch(_){}
+      }catch(_){ HOST.imToast(HOST.lang==='jp'?'画像を読み込めませんでした':HOST.lang==='de'?'Bild konnte nicht geladen werden':HOST.lang==='ru'?'Не удалось загрузить изображение':HOST.lang==='es'?'No se pudo cargar la imagen':'Could not load image'); } };
+      m.onclick=(e)=>{ if(e.target===m) m.style.display='none'; };
+      document.getElementById('acct-close').onclick=()=>{ m.style.display='none'; };
+      document.getElementById('acct-logout').onclick=()=>{
+        /* (#R33) Confirm before logging out. */
+        if(!window.confirm(HOST.lang==='jp'?'ログアウトしますか？':HOST.lang==='de'?'Vom Konto abmelden?':HOST.lang==='ru'?'Выйти из аккаунта?':HOST.lang==='es'?'¿Cerrar la sesión?':'Log out of your account?')) return;
+        /* Instant: clear local state + UI right away, revoke the session in the background. */
+        m.style.display='none';
+        HOST.user=null; HOST.bookmarks=[];
+        try{ HOST.updateAccountButton(); }catch(_){}
+        try{ if(typeof HOST.renderUI==='function') HOST.renderUI(); }catch(_){}
+        try{ window.refreshProUI&&window.refreshProUI(); }catch(_){}
+        try{ HOST.DB.auth.signOut(); }catch(_){}   /* onAuthStateChange will reconcile favorites/community */
+        try{ HOST.imToast(HOST.lang==='jp'?'ログアウトしました':HOST.lang==='de'?'Abgemeldet':HOST.lang==='ru'?'Вы вышли из аккаунта':HOST.lang==='es'?'Sesión cerrada':'Logged out'); }catch(_){}
+      };
+      document.getElementById('acct-save').onclick=async()=>{
+        const name=document.getElementById('acct-name').value.trim(), msg=document.getElementById('acct-msg');
+        const bio=(document.getElementById('acct-bio')||{}).value||'';
+        if(!name){ msg.textContent=HOST.lang==='jp'?'表示名を入力してください。':HOST.lang==='de'?'Anzeigename darf nicht leer sein.':HOST.lang==='ru'?'Имя не может быть пустым.':HOST.lang==='es'?'El nombre no puede estar vacío.':'Display name cannot be empty.'; return; }
+        const btn=document.getElementById('acct-save'); btn.disabled=true; msg.textContent=HOST.lang==='jp'?'保存中…':HOST.lang==='de'?'Speichere…':HOST.lang==='ru'?'Сохранение…':HOST.lang==='es'?'Guardando…':'Saving…';
+        try{
+          const {error}=await HOST.DB.from('profiles').update({display_name:name}).eq('id',HOST.user.id); if(error) throw error;
+          try{ await HOST.DB.auth.updateUser({data:{display_name:name}}); }catch(_){}
+          /* bio + avatar_url are best-effort (columns may not exist yet — see supabase_profiles_extra.sql) */
+          try{ await HOST.DB.from('profiles').update({bio:bio.trim()}).eq('id',HOST.user.id); }catch(_){}
+          try{ localStorage.setItem('intmap_bio',bio.trim()); }catch(_){}
+          HOST.user.name=name; HOST.user.bio=bio.trim(); HOST.updateAccountButton(); msg.textContent=HOST.lang==='jp'?'保存しました。':HOST.lang==='de'?'Gespeichert.':HOST.lang==='ru'?'Сохранено.':HOST.lang==='es'?'Guardado.':'Saved.';
+          if(HOST.mode==='community') HOST.loadCommunity();
+          setTimeout(()=>{ m.style.display='none'; }, 600);
+        }catch(e){ msg.textContent='Error: '+((e&&e.message)||e); }
+        finally{ btn.disabled=false; }
+      };
+      /* ---- (#R155) Security section: passkeys / change email / change password / logout-all / delete ---- */
+      const _addPk=document.getElementById('acct-add-passkey');
+      if(_addPk) _addPk.onclick=async()=>{ const msg=document.getElementById('acct-msg');
+        if(!_passkeysAvailable()||typeof HOST.DB.auth.registerPasskey!=='function'){ msg.textContent=_authL('Passkeys aren\'t available on this device.','この端末ではパスキーを利用できません。','Passkeys sind auf diesem Gerät nicht verfügbar.','Паскеи недоступны на этом устройстве.','Los passkeys no están disponibles en este dispositivo.'); return; }
+        msg.textContent=_authL('Follow your device prompt to create a passkey…','端末の指示に従ってパスキーを作成してください…','Folge der Geräteaufforderung, um einen Passkey zu erstellen…','Следуйте подсказке устройства, чтобы создать паскей…','Sigue la indicación de tu dispositivo para crear un passkey…');
+        try{ const {error}=await HOST.DB.auth.registerPasskey(); if(error) throw error; msg.textContent=_authL('Passkey added.','パスキーを追加しました。','Passkey hinzugefügt.','Паскей добавлен.','Passkey añadido.'); _renderPasskeys(); }
+        catch(e){ msg.textContent=_authL('Could not add a passkey (or it was cancelled).','パスキーを追加できませんでした（またはキャンセルされました）。','Passkey konnte nicht hinzugefügt werden (oder abgebrochen).','Не удалось добавить паскей (или отменено).','No se pudo añadir el passkey (o se canceló).'); }
+      };
+      document.getElementById('acct-change-email').onclick=async()=>{ const msg=document.getElementById('acct-msg');
+        const ne=window.prompt(_authL('New email address:','新しいメールアドレス：','Neue E-Mail-Adresse:','Новый e-mail:','Nuevo correo:')); if(ne==null) return;
+        if(!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(ne.trim())){ msg.textContent=_authL('That doesn\'t look like an email.','メールアドレスの形式ではありません。','Das sieht nicht wie eine E-Mail aus.','Это не похоже на e-mail.','Eso no parece un correo.'); return; }
+        msg.textContent=_authL('Sending confirmation…','確認メールを送信中…','Bestätigung wird gesendet…','Отправка подтверждения…','Enviando confirmación…');
+        try{ const {error}=await HOST.DB.auth.updateUser({email:ne.trim()}); if(error) throw error;
+          msg.textContent=_authL('Confirm the change from the link sent to your new email (and, if asked, your current one).','新しいメールに届いたリンクから変更を確認してください（求められた場合は現在のメールも）。','Bestätige die Änderung über den Link an deine neue E-Mail (und ggf. deine aktuelle).','Подтвердите изменение по ссылке на новый e-mail (и, если попросят, на текущий).','Confirma el cambio desde el enlace enviado a tu nuevo correo (y al actual si se solicita).');
+        }catch(e){ msg.textContent=_authL('Could not change the email.','メールアドレスを変更できませんでした。','E-Mail konnte nicht geändert werden.','Не удалось изменить e-mail.','No se pudo cambiar el correo.'); }
+      };
+      document.getElementById('acct-change-pw').onclick=()=>_openSetPassword(false);
+      document.getElementById('acct-logout-all').onclick=async()=>{
+        if(!window.confirm(_authL('Log out on ALL devices? You\'ll need to sign in again everywhere.','すべての端末からログアウトしますか？各端末で再度ログインが必要になります。','Auf ALLEN Geräten abmelden? Du musst dich überall neu anmelden.','Выйти на ВСЕХ устройствах? Потребуется войти заново везде.','¿Cerrar sesión en TODOS los dispositivos? Tendrás que volver a iniciar sesión.'))) return;
+        m.style.display='none'; HOST.user=null; HOST.bookmarks=[];
+        try{ HOST.updateAccountButton(); }catch(_){}
+        try{ if(typeof HOST.renderUI==='function') HOST.renderUI(); }catch(_){}
+        try{ window.refreshProUI&&window.refreshProUI(); }catch(_){}
+        try{ await HOST.DB.auth.signOut({scope:'global'}); }catch(_){ try{ await HOST.DB.auth.signOut(); }catch(__){} }
+        try{ HOST.imToast(_authL('Logged out on all devices','すべての端末からログアウトしました','Auf allen Geräten abgemeldet','Выход выполнен на всех устройствах','Sesión cerrada en todos los dispositivos')); }catch(_){}
+      };
+      document.getElementById('acct-delete').onclick=async()=>{ const msg=document.getElementById('acct-msg');
+        const typed=window.prompt(_authL('This PERMANENTLY deletes your account and all your data — it cannot be undone. Type your email to confirm:','これはアカウントと全データを完全に削除します（取り消せません）。確認のためメールアドレスを入力：','Dies löscht dein Konto und alle Daten DAUERHAFT — nicht umkehrbar. Gib zur Bestätigung deine E-Mail ein:','Это НАВСЕГДА удалит аккаунт и все данные — отменить нельзя. Введите e-mail для подтверждения:','Esto elimina PERMANENTEMENTE tu cuenta y todos tus datos, sin vuelta atrás. Escribe tu correo para confirmar:'));
+        if(typed==null) return;
+        if((typed||'').trim().toLowerCase()!==String(HOST.user.email||'').toLowerCase()){ msg.textContent=_authL('That didn\'t match your email — cancelled.','メールアドレスが一致しません。キャンセルしました。','Stimmt nicht mit deiner E-Mail überein — abgebrochen.','Не совпадает с вашим e-mail — отменено.','No coincide con tu correo — cancelado.'); return; }
+        msg.textContent=_authL('Deleting your account…','アカウントを削除中…','Konto wird gelöscht…','Удаление аккаунта…','Eliminando tu cuenta…');
+        try{
+          const sres=await HOST.DB.auth.getSession(); const session=sres&&sres.data&&sres.data.session;
+          const r=await fetch(window.SUPABASE_URL+'/functions/v1/delete-account',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+((session&&session.access_token)||''),'apikey':window.SUPABASE_ANON_KEY},body:JSON.stringify({confirm:'DELETE'})});
+          const j=await r.json().catch(()=>({}));
+          if(!r.ok||!j.ok) throw new Error(j.message||'delete failed');
+          try{ await HOST.DB.auth.signOut(); }catch(_){}
+          HOST.user=null; HOST.bookmarks=[];
+          try{ Object.keys(localStorage).forEach(k=>{ if(/^(intmap_|sb-)/.test(k)) localStorage.removeItem(k); }); }catch(_){}
+          try{ HOST.updateAccountButton(); if(typeof HOST.renderUI==='function') HOST.renderUI(); }catch(_){}
+          m.style.display='none';
+          try{ HOST.imToast(_authL('Your account has been deleted.','アカウントを削除しました。','Dein Konto wurde gelöscht.','Ваш аккаунт удалён.','Tu cuenta ha sido eliminada.')); }catch(_){}
+        }catch(e){ msg.textContent=_authL('Could not delete the account. Please try again or contact support.','アカウントを削除できませんでした。もう一度試すかサポートへご連絡ください。','Konto konnte nicht gelöscht werden. Bitte erneut versuchen oder Support kontaktieren.','Не удалось удалить аккаунт. Повторите попытку или обратитесь в поддержку.','No se pudo eliminar la cuenta. Inténtalo de nuevo o contacta soporte.'); }
+      };
+    }
+    document.getElementById('acct-email').textContent=HOST.user.email;
+    try{ _renderPasskeys(); }catch(_){}
+    document.getElementById('acct-name').value=HOST.user.name||'';
+    document.getElementById('acct-msg').textContent='';
+    /* avatar preview + current selection */
+    { const av=window.imGetAvatar(), img=window.imGetAvatarImg(); const prev=document.getElementById('acct-avatar-preview');
+      if(prev){ if(img){ prev.style.backgroundImage=`url('${img}')`; prev.textContent=''; } else { prev.style.backgroundImage=''; prev.textContent=av; prev.style.background='hsl('+(window.imAvatarHue())+',58%,46%)'; } }
+      document.querySelectorAll('#acct-avatar-pick .acct-emoji').forEach(b=>b.classList.toggle('sel',!img&&b.dataset.e===av)); }
+    { const bioEl=document.getElementById('acct-bio'); if(bioEl){ let b=HOST.user.bio; if(b==null){ try{ b=localStorage.getItem('intmap_bio')||''; }catch(_){ b=''; } } bioEl.value=b||''; } }
+    /* (#R10) Pro status / upgrade row removed — the app is fully free, no plan indicator. Admin still
+       shown for moderators. */
+    const proRow=document.getElementById('acct-pro');
+    if(proRow){
+      if(HOST.user && HOST.user.isAdmin){ proRow.style.display=''; proRow.innerHTML=`<span style="color:var(--text-muted);font-weight:600;font-size:12px;">· admin</span>`; }
+      else { proRow.style.display='none'; proRow.innerHTML=''; }
+    }
+    m.style.display='flex';
+  }
+
+  async function refreshCurrentUser(sessionArg){
+    if(!HOST.DB){ HOST.user=null; return; }
+    /* Accept a session passed in from onAuthStateChange so we don't re-enter getSession() while the
+       auth lock is held (that re-entry is the supabase-js v2 deadlock behind "logged in but the UI
+       never updates", #14). Only call getSession() when invoked standalone (sessionArg===undefined). */
+    let session=sessionArg;
+    if(session===undefined){ try{ const r=await HOST.DB.auth.getSession(); session=(r&&r.data)?r.data.session:null; }catch(_){ session=null; } }
+    if(!session){ HOST.user=null; HOST.updateAccountButton(); return; }
+    const meta=session.user.user_metadata||{};
+    let isAdmin=false, isPro=false, name='';
+    try{
+      /* try to read is_pro too; if that column doesn't exist yet, fall back to the basic select */
+      let r=await HOST.DB.from('profiles').select('display_name,is_admin,is_pro').eq('id',session.user.id).maybeSingle();
+      if(r.error) r=await HOST.DB.from('profiles').select('display_name,is_admin').eq('id',session.user.id).maybeSingle();
+      const prof=r.data;
+      if(prof){ isAdmin=!!prof.is_admin; isPro=!!prof.is_pro; if(prof.display_name) name=prof.display_name; }
+      /* First login after email/OAuth signup: copy the chosen name (or OAuth name) into the profile */
+      if(!name){ const want=meta.display_name||meta.full_name||meta.name||''; if(want){ try{ await HOST.DB.from('profiles').update({display_name:want}).eq('id',session.user.id); name=want; }catch(_){} } }
+    }catch(_){}
+    /* (#R33) PRIVACY: never derive the public name from the email (its local part would expose part of the
+       address in community posts). Fall back to a neutral handle from the user id instead. */
+    if(!name) name='User-'+String(session.user.id||'').replace(/[^a-z0-9]/gi,'').slice(0,5);
+    HOST.user={ id:session.user.id, email:session.user.email, name, isAdmin, isPro:isPro||isAdmin }; HOST.updateAccountButton();
+    /* (#R35) Persist the developer flag the moment the OWNER account logs in, so "unlimited AI" is recognised
+       SYNCHRONOUSLY everywhere afterward — even before currentUser repopulates on the next load. This is why
+       the Settings usage graph "wasn't reflecting unlimited": aiRenderSettings could run before the async
+       email arrived. Persist + re-render now. */
+    try{ if(/2ppzc4kk6r@privaterelay\.appleid\.com/i.test(HOST.user.email||'')) localStorage.setItem('intmap_dev','1'); }catch(_){}
+    try{ window.aiRenderSettings&&window.aiRenderSettings(); }catch(_){}
+    try{ window.refreshProUI&&window.refreshProUI(); }catch(_){}
+    try{ window._syncPrefsDown&&window._syncPrefsDown(); }catch(_){}   /* (#R20) pull the account's saved settings/presets/widgets */
+  }
+
+  /* ---------- FAVORITES (★ saved articles) ---------- */
+  async function loadFavorites(){
+    if(!HOST.user||!HOST.DB) return;
+    const {data,error}=await HOST.DB.from('favorites').select('article_link');
+    if(error){ console.warn('[IntMap] favorites load:', error.message); return; }
+    let cloud=(data||[]).map(r=>r.article_link);
+    /* one-time merge of any favorites saved as a guest before logging in */
+    let local=[]; try{ local=JSON.parse(localStorage.getItem('intmap_bookmarks'))||[]; }catch(_){}
+    const toAdd=local.filter(l=>!cloud.includes(l));
+    if(toAdd.length){ try{ await HOST.DB.from('favorites').insert(toAdd.map(l=>({user_id:HOST.user.id,article_link:l}))); cloud=cloud.concat(toAdd); }catch(_){}
+      try{ localStorage.removeItem('intmap_bookmarks'); }catch(_){} }
+    HOST.bookmarks=cloud;
+  }
+
+  /* ---------- REALTIME (live auto-reflect) ---------- */
+  function subscribeRealtime(){
+    if(!HOST.DB||!HOST.DB.channel) return;
+    try{
+      HOST.DB.channel('intmap-public')
+        .on('postgres_changes',{event:'*',schema:'public',table:'geo_pins'},        ()=>loadGeoFromSupabase().then(()=>{ try{ if(HOST.globalData&&HOST.globalData.length) HOST.renderUI(); }catch(_){} }))
+        .on('postgres_changes',{event:'*',schema:'public',table:'dashboard_cards'}, ()=>HOST.loadDashFromSupabase().then(()=>{ try{ if(HOST.mode==='info') HOST.renderDashboard(); }catch(_){} }))
+        .on('postgres_changes',{event:'*',schema:'public',table:'community_posts'},    ()=>HOST.loadCommunity())
+        .on('postgres_changes',{event:'*',schema:'public',table:'community_comments'}, ()=>{ if(HOST.mode==='community') HOST.loadCommunity(); })
+        .on('postgres_changes',{event:'*',schema:'public',table:'community_votes'},    ()=>{ if(HOST.mode==='community') HOST.loadCommunity(); })
+        .on('postgres_changes',{event:'*',schema:'public',table:'current_news'},       ()=>{ try{ if(window.__IM_USE_SERVER_NEWS!==false && !HOST.activeSearchQuery&&!HOST.newsDate&&HOST.newsLangMode!=='multi') HOST.loadNewsFromSupabase(); }catch(_){} })   /* (#R40) gated off while the server feed is temporarily disabled */
+        .subscribe();
+    }catch(e){ console.warn('[IntMap] realtime subscribe failed:', e&&e.message); }
+  }
+
+  /* ---------- BOOT ---------- */
+  async function bootSupabase(){
+    if(!HOST.DB){ console.warn('[IntMap] Supabase unavailable — load supabase.js / supabase-config.js. Running with empty data.'); return; }
+    injectAuthUI();
+    /* Register the auth listener FIRST so the SIGNED_IN event fired while supabase parses the OAuth
+       token out of the redirect URL is never missed (a cause of "logged in but not logged in", #33). */
+    HOST.DB.auth.onAuthStateChange((event,session)=>{
+      /* (#R7-login) IMMEDIATE, synchronous, lock-safe reflection: the instant Supabase parses the
+         Google OAuth token out of the redirect URL it fires here. Update the account button RIGHT NOW
+         from the event's own session (no Supabase calls — those would re-enter the held auth lock and
+         deadlock, #14), so the UI shows "logged in" without waiting for the profile fetch or a reload. */
+      try{
+        /* (#R155) The user followed a "reset password" email link → prompt for a new password. */
+        if(event==='PASSWORD_RECOVERY'){ try{ const am=document.getElementById('auth-modal'); if(am) am.style.display='none'; }catch(_){} try{ _openSetPassword(true); }catch(_){} }
+        if(session&&session.user){
+          if(!HOST.user||HOST.user.id!==session.user.id){
+            const m=session.user.user_metadata||{};
+            HOST.user={ id:session.user.id, email:session.user.email||'', name:(m.display_name||m.full_name||m.name||('User-'+String(session.user.id||'').replace(/[^a-z0-9]/gi,'').slice(0,5))), isAdmin:false, isPro:false };
+          }
+          try{ HOST.updateAccountButton(); }catch(_){}
+          try{ const am=document.getElementById('auth-modal'); if(am && am.style.display!=='none') am.style.display='none'; }catch(_){}
+        } else if(event==='SIGNED_OUT'){ HOST.user=null; try{ HOST.updateAccountButton(); }catch(_){} }
+      }catch(_){}
+      /* Then the heavier enrich (profile name / admin / pro, favorites, tab re-render) deferred a tick
+         so the auth lock is released first. */
+      setTimeout(async()=>{
+        await refreshCurrentUser(session||null); await loadFavorites();
+        try{ if(HOST.mode==='news'||HOST.mode==='saved') HOST.startNews(); }catch(_){}
+        try{ if(HOST.mode==='community') HOST.loadCommunity(); }catch(_){}
+        try{ const am=document.getElementById('auth-modal'); if(HOST.user && am && am.style.display!=='none') am.style.display='none'; }catch(_){}   /* close the login modal once signed in */
+        try{ HOST.renderUI(); }catch(_){}            /* reflect the new auth state in the active tab immediately */
+        /* Pro entitlement may have changed → re-check satellite provider access */
+        try{ if(HOST.mapType==='sat'){ const cur=HOST.satProviderById(HOST.satState.providerId); if(cur&&cur.tier==='pro'&&!HOST.satHasKey(cur)) HOST.satRevertToFallback(); else HOST.satRenderController(); } }catch(_){}
+        try{ if(HOST.user) HOST.aiFetchUsage(); }catch(_){}   /* (#R27) refresh today's AI-quota for the signed-in user */
+      },0);
+    });
+    await refreshCurrentUser();
+    /* OAuth implicit-flow tokens land in the URL hash and are parsed asynchronously; if the very
+       first getSession ran a hair too early, re-check a couple of times so the session is picked up
+       without needing a manual reload (#33). */
+    if(!HOST.user && /[#&?](access_token|code|refresh_token)=/.test(location.href)){
+      /* (#R8) Poll long enough to cover a slow PKCE code-exchange round-trip — the implicit-flow hash
+         parse is near-instant, but a ?code= exchange needs a network hop to Supabase. Reflect each tick. */
+      for(let i=0;i<16 && !HOST.user;i++){ await new Promise(r=>setTimeout(r,400)); try{ await refreshCurrentUser(); }catch(_){} if(HOST.user){ try{ HOST.updateAccountButton(); HOST.renderUI(); }catch(_){} } }
+      try{ if(HOST.user){ await loadFavorites(); HOST.renderUI(); } }catch(_){}
+      try{ if(HOST.user){ HOST.recordLogin(); HOST.aiFetchUsage(); } }catch(_){}   /* (#R27) an OAuth return is a genuine login */
+      /* (#R8) Only scrub the token AFTER a session is in hand. Scrubbing while the exchange is still
+         pending throws away the code and forces a manual reload — the exact "戻ると未ログイン" symptom. */
+      try{ if(HOST.user && (location.protocol==='http:'||location.protocol==='https:')) history.replaceState(null,'',location.origin+location.pathname); }catch(_){}
+    }
+    /* (#R8) Safety nets so login reflects the instant the user returns from Google — no manual reload.
+       focus + visibilitychange cover a tab switch; pageshow covers a BFCACHE restore (back button from
+       Google, where focus/visibilitychange often DON'T fire — the missing case behind "戻ると未ログイン");
+       storage covers the session being written by another tab or the Supabase auth helper. */
+    let _authRecheck=0;
+    const _recheckAuth=(force)=>{ if(!force && _authRecheck && Date.now()-_authRecheck<1200) return; _authRecheck=Date.now();
+      setTimeout(async()=>{ try{ const had=!!HOST.user; await refreshCurrentUser(); if(!!HOST.user!==had){ try{ HOST.updateAccountButton(); HOST.renderUI(); }catch(_){} if(HOST.user) try{ await loadFavorites(); }catch(_){} } }catch(_){} },0); };
+    window.addEventListener('focus',()=>_recheckAuth());
+    document.addEventListener('visibilitychange',()=>{ if(document.visibilityState==='visible') _recheckAuth(); });
+    window.addEventListener('pageshow',(e)=>{ _recheckAuth(!!(e&&e.persisted)); });
+    window.addEventListener('storage',(e)=>{ if(e&&e.key&&/sb-|supabase|auth/i.test(e.key)) _recheckAuth(true); });
+    await Promise.all([ loadGeoFromSupabase(), HOST.loadDashFromSupabase(), loadFavorites() ]);
+    try{ HOST.renderUI(); }catch(_){}          /* re-render the active tab now data + favorites are in */
+    try{ HOST.loadCommunity(); }catch(_){}      /* prime the community map pins */
+    subscribeRealtime();
+  }
+
+  /* The names index.html still calls: it keeps a hoisted shim for each (#R168). */
+  return { bootSupabase, _openSetPassword, openAuthModal };
+};

--- a/js/community.js
+++ b/js/community.js
@@ -1,0 +1,153 @@
+/* ============================================================================
+ *  IntMap · Community feed  (#R168)
+ * ----------------------------------------------------------------------------
+ *  The community feed renderer and its list wiring, plus the comment/vote/report mutations.
+ *  The filter and compose state it drives stays declared in index.html and is written through
+ *  the host, so index.html and this module always read the same live values.
+ *
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure: the only edit is that free
+ *  references to closure variables became HOST.<member> reads (Architecture.md §3.1). The
+ *  extraction was done by script and reversed byte-for-byte against the original text.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.community=function(map,HOST){
+  function openImageLightbox(src){
+    const old=document.getElementById('img-lightbox'); if(old) old.remove();
+    const lb=document.createElement('div'); lb.id='img-lightbox';
+    const im=document.createElement('img'); im.src=src; lb.appendChild(im);
+    lb.onclick=()=>lb.remove();
+    document.addEventListener('keydown',function esc(e){ if(e.key==='Escape'){ lb.remove(); document.removeEventListener('keydown',esc); } });
+    document.body.appendChild(lb);
+  }
+
+  function renderCommunity(){
+    const cont=document.getElementById('community-feed');
+    if(map&&map.isStyleLoaded()) HOST.setupCommunityLayer();
+    const jp=HOST.lang==='jp';
+    const sortBtn=(k,lbl)=>`<button data-sort="${k}" class="${HOST.communitySort===k?'active':''}">${lbl}</button>`;
+    const catChip=(id,lbl,color)=>`<button class="comm-cat-chip ${HOST.commCatFilter===id?'active':''}" data-catf="${id}" style="--cc:${color}">${lbl}</button>`;
+    const loginHint = HOST.user ? '' : `<div class="empty-msg" style="padding:10px 16px;">${jp?'投稿・コメント・投票するにはログインしてください。':'Log in to post, comment and vote.'}</div>`;
+    /* New post + Hot/New/Top are a STICKY BOTTOM bar, always visible while the feed scrolls (#27). */
+    cont.innerHTML=`<div class="comm-scroll" id="comm-scroll">
+        <div class="comm-filters">
+          <div class="comm-search"><span>🔎</span><input type="text" id="comm-search" placeholder="${HOST.t('commSearchPh')}" value="${HOST.escapeHtml(HOST.commSearch)}"></div>
+          <button class="comm-inview ${HOST.commInView?'active':''}" id="comm-inview" title="${jp?'地図の表示範囲内の投稿だけ':'Only posts in the current map view'}">🧭 ${HOST.t('commInView')}</button>
+        </div>
+        <div class="comm-cat-row">
+          ${catChip('all',HOST.t('commCatAll'),'var(--primary-color)')}
+          ${HOST.COMM_CATEGORIES.map(c=>catChip(c.id,c.emoji+' '+HOST.commCatLabel(c.id),c.color)).join('')}
+        </div>${loginHint}
+        <div id="comm-list"></div>
+      </div>
+      <div class="comm-toolbar comm-toolbar-bottom">
+        <button class="comm-add-btn" id="comm-add-btn">${HOST.t('commAdd')}</button>
+        <div class="comm-sort">${sortBtn('hot',HOST.t('commSortHot'))}${sortBtn('new',HOST.t('commSortNew'))}${sortBtn('top',HOST.t('commSortTop'))}</div>
+      </div>`;
+    /* Toolbar wiring (rebuilds list on change — search updates list only, so its input keeps focus). */
+    document.getElementById('comm-add-btn').onclick=()=>{
+      if(!HOST.requireLogin()) return;
+      /* (#R16) "コミュニティで投稿するときは、まず初めに場所を選ばせろ" — pick the location on the map FIRST.
+         Arm a one-shot map tap (the communityAddArmed handler opens the composer at the tapped point); on
+         mobile collapse the sheet so the map is reachable, and guide with a toast. */
+      HOST.pendingPostLoc=null; HOST.communityAddArmed=true;
+      try{ if(window.matchMedia&&window.matchMedia('(max-width:768px)').matches && window.__setDetent) window.__setDetent('peek',true); }catch(_){}   /* (#R107) 'mini' disabled → collapse to 'peek' (still frees the map) */
+      HOST.imToast(HOST.lang==='jp'?'📍 地図をタップして投稿する場所を選んでください':HOST.lang==='de'?'📍 Tippe auf die Karte, um den Ort des Beitrags zu wählen':HOST.lang==='ru'?'📍 Коснитесь карты, чтобы выбрать место публикации':HOST.lang==='es'?'📍 Toca el mapa para elegir dónde publicar':'📍 Tap the map to choose where to post');
+    };
+    cont.querySelectorAll('.comm-sort button').forEach(b=>b.onclick=()=>{ HOST.communitySort=b.dataset.sort; renderCommunity(); });
+    cont.querySelectorAll('.comm-cat-chip').forEach(b=>b.onclick=()=>{ HOST.commCatFilter=b.dataset.catf; renderCommunity(); });
+    document.getElementById('comm-inview').onclick=()=>{ HOST.commInView=!HOST.commInView; renderCommunity(); };
+    const si=document.getElementById('comm-search');
+    if(si) si.addEventListener('input',()=>{ HOST.commSearch=si.value; clearTimeout(renderCommunity._st); renderCommunity._st=setTimeout(HOST.renderCommList,160); });
+    HOST.renderCommList();
+  }
+
+  const _findComment=(cid)=>{ for(const p of HOST.communityPosts){ const c=(p.comments||[]).find(x=>x.id===cid); if(c) return c; } return null; };
+
+  /* Per-card event wiring (run after every list render). */
+  function wireCommList(cont){
+    cont.querySelectorAll('.comm-post-loc').forEach(el=>el.onclick=()=>{ if(map) map.flyTo({center:[+el.dataset.lng,+el.dataset.lat],zoom:5,speed:1.2}); });
+    cont.querySelectorAll('.locate-btn').forEach(b=>b.onclick=()=>{ const p=HOST.communityPosts.find(p=>p.id===b.dataset.id); if(p&&map) map.flyTo({center:[p.lng,p.lat],zoom:5,speed:1.2}); });
+    cont.querySelectorAll('.cmt-toggle').forEach(b=>b.onclick=()=>{ const id=b.dataset.id; HOST.commCollapsed[id]=!HOST.commCollapsed[id]; const w=cont.querySelector(`[data-cwrap="${id}"]`); if(w) w.classList.toggle('collapsed',!!HOST.commCollapsed[id]); });
+    cont.querySelectorAll('.comm-post-img').forEach(im=>im.onclick=()=>openImageLightbox(im.src));
+    cont.querySelectorAll('.vote-btn').forEach(b=>b.onclick=async()=>{
+      if(!HOST.requireLogin()) return; const p=HOST.communityPosts.find(p=>p.id===b.dataset.id); if(!p) return;
+      try{ await cmVote(p.id,!p.voted); }catch(e){ HOST.imToast((e&&e.message)||'Vote failed'); return; } await HOST.loadCommunity();
+    });
+    cont.querySelectorAll('.edit-btn').forEach(b=>b.onclick=()=>{ const p=HOST.communityPosts.find(p=>p.id===b.dataset.id); if(p) HOST.openComposeModal(p); });
+    cont.querySelectorAll('.del-btn').forEach(b=>b.onclick=async()=>{
+      if(!confirm(HOST.lang==='jp'?'この投稿を削除しますか？':HOST.lang==='de'?'Diesen Beitrag löschen?':HOST.lang==='ru'?'Удалить эту публикацию?':HOST.lang==='es'?'¿Eliminar esta publicación?':'Delete this post?')) return;
+      try{ await cmDelete(b.dataset.id); }catch(e){ HOST.imToast((e&&e.message)||'Delete failed'); return; } await HOST.loadCommunity();
+    });
+    cont.querySelectorAll('.report-btn').forEach(b=>b.onclick=async()=>{
+      if(!HOST.requireLogin()) return;
+      if(!confirm(HOST.lang==='jp'?'この投稿を不適切として通報しますか？':HOST.lang==='de'?'Diesen Beitrag als unangemessen melden?':HOST.lang==='ru'?'Пожаловаться на эту публикацию?':HOST.lang==='es'?'¿Denunciar esta publicación como inapropiada?':'Report this post as inappropriate?')) return;
+      try{ await cmReport(b.dataset.id); HOST.imToast(HOST.lang==='jp'?'通報しました。ご協力ありがとうございます。':HOST.lang==='de'?'Gemeldet. Danke.':HOST.lang==='ru'?'Жалоба отправлена. Спасибо.':HOST.lang==='es'?'Denunciado. Gracias.':'Reported. Thank you.'); }catch(e){ HOST.imToast((e&&e.message)||'Report failed'); }
+    });
+    /* Add comment / reply */
+    const submitComment=async(b)=>{
+      if(!HOST.requireLogin()) return; const input=b.previousElementSibling, txt=input.value.trim(); if(!txt) return;
+      const pid=b.dataset.pid, parent=(HOST.replyingTo&&HOST.replyingTo.pid===pid)?HOST.replyingTo.cid:null;
+      input.value=''; HOST.replyingTo=null;
+      try{ await cmComment(pid,txt,parent); }catch(e){ HOST.imToast((e&&e.message)||'Comment failed'); return; } await HOST.loadCommunity();
+    };
+    cont.querySelectorAll('.comm-comment-add button').forEach(b=>b.onclick=()=>submitComment(b));
+    cont.querySelectorAll('.comm-comment-add input').forEach(inp=>inp.addEventListener('keydown',e=>{ if(e.key==='Enter') inp.nextElementSibling.click(); }));
+    /* Reply: focus this post's comment box and remember the parent comment. */
+    cont.querySelectorAll('.creply-btn').forEach(b=>b.onclick=()=>{
+      const pid=b.dataset.pid, cid=b.dataset.cid, c=_findComment(cid);
+      HOST.replyingTo={pid,cid};
+      const box=cont.querySelector(`.comm-comment-add input[data-pid="${pid}"]`);
+      if(box){ box.placeholder=(HOST.lang==='jp'?'返信: ':HOST.lang==='de'?'Antwort an ':HOST.lang==='ru'?'Ответ: ':HOST.lang==='es'?'Responder a ':'Reply to ')+(c?c.author:'')+' …'; box.focus(); }
+    });
+    /* Comment upvote */
+    cont.querySelectorAll('.cvote-btn').forEach(b=>b.onclick=async()=>{
+      if(!HOST.requireLogin()) return; const c=_findComment(b.dataset.cid); if(!c) return;
+      try{ await cmVoteComment(c.id,!c.voted); }catch(e){ HOST.imToast((e&&e.message)||'Vote failed'); return; } await HOST.loadCommunity();
+    });
+    /* Comment edit (inline prompt) */
+    cont.querySelectorAll('.cedit-btn').forEach(b=>b.onclick=async()=>{
+      const c=_findComment(b.dataset.cid); if(!c) return;
+      const v=prompt(HOST.lang==='jp'?'コメントを編集':HOST.lang==='de'?'Kommentar bearbeiten':HOST.lang==='ru'?'Изменить комментарий':HOST.lang==='es'?'Editar comentario':'Edit comment',c.text); if(v==null) return;
+      const nv=v.trim(); if(!nv||nv===c.text) return;
+      try{ await cmEditComment(c.id,nv); }catch(e){ HOST.imToast((e&&e.message)||'Edit failed'); return; } await HOST.loadCommunity();
+    });
+    /* Comment delete */
+    cont.querySelectorAll('.cdel-btn').forEach(b=>b.onclick=async()=>{
+      if(!confirm(HOST.lang==='jp'?'このコメントを削除しますか？':HOST.lang==='de'?'Diesen Kommentar löschen?':HOST.lang==='ru'?'Удалить этот комментарий?':HOST.lang==='es'?'¿Eliminar este comentario?':'Delete this comment?')) return;
+      try{ await cmDeleteComment(b.dataset.cid); }catch(e){ HOST.imToast((e&&e.message)||'Delete failed'); return; } await HOST.loadCommunity();
+    });
+  }
+
+  async function cmComment(postId,text,parentId){
+    const row={ post_id:postId, user_id:HOST.user.id, author_name:HOST.user.name, body:text };
+    if(parentId && HOST.commCaps&&HOST.commCaps.threads) row.parent_id=parentId;
+    let {error}=await HOST.DB.from('community_comments').insert(row);
+    if(error && row.parent_id){ delete row.parent_id; ({error}=await HOST.DB.from('community_comments').insert(row)); }
+    if(error) throw error;
+  }
+
+  async function cmEditComment(id,text){
+    const patch={ body:text };
+    if(HOST.commCaps&&HOST.commCaps.edited) patch.edited_at=new Date().toISOString();
+    const {error}=await HOST.DB.from('community_comments').update(patch).eq('id',id); if(error) throw error;
+  }
+
+  async function cmDeleteComment(id){ const {error}=await HOST.DB.from('community_comments').delete().eq('id',id); if(error) throw error; }
+
+  async function cmVoteComment(id,on){
+    if(on){ const {error}=await HOST.DB.from('community_comment_votes').insert({ comment_id:id, user_id:HOST.user.id }); if(error && error.code!=='23505') throw error; }
+    else { const {error}=await HOST.DB.from('community_comment_votes').delete().eq('comment_id',id).eq('user_id',HOST.user.id); if(error) throw error; }
+  }
+
+  async function cmVote(postId,on){
+    if(on){ const {error}=await HOST.DB.from('community_votes').insert({ post_id:postId, user_id:HOST.user.id }); if(error && error.code!=='23505') throw error; }
+    else { const {error}=await HOST.DB.from('community_votes').delete().eq('post_id',postId).eq('user_id',HOST.user.id); if(error) throw error; }
+  }
+
+  async function cmDelete(postId){ const {error}=await HOST.DB.from('community_posts').delete().eq('id',postId); if(error) throw error; }
+
+  async function cmReport(postId){ const {error}=await HOST.DB.from('community_reports').insert({ post_id:postId, user_id:HOST.user.id }); if(error && error.code!=='23505') throw error; }
+
+  /* The names index.html still calls: it keeps a hoisted shim for each (#R168). */
+  return { renderCommunity, wireCommList };
+};

--- a/js/companies-ui.js
+++ b/js/companies-ui.js
@@ -1,0 +1,443 @@
+/* ============================================================================
+ *  IntMap · Companies tab, compare view & dashboard  (#R168)
+ * ----------------------------------------------------------------------------
+ *  The Companies subject: the company list and detail card, the multi-company compare sheet
+ *  (bar / table / CSV / time series) and the legacy dashboard renderer. Thirty-six statements,
+ *  all of them declarations — the compare view carries its own state, cache and palette.
+ *
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure: the only edit is that free
+ *  references to closure variables became HOST.<member> reads (Architecture.md §3.1). The
+ *  extraction was done by script and reversed byte-for-byte against the original text.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.companiesUi=function(map,HOST){
+  /* =============================================================================
+   * WEBGL PIN INFRASTRUCTURE — pins are rendered as native MapLibre circle layers
+   * on the WebGL canvas. The map projection math runs on the GPU at the exact
+   * lng/lat, so pins CANNOT drift relative to the map at any zoom or projection.
+   * The hover tooltip is a single shared DOM element positioned by mouse pixel.
+   * ============================================================================= */
+  const INFO_COLORS={ choke:'#ff9500', mil:'#ff3b30', tech:'#007aff', space:'#af52de', energy:'#34c759', hub:'#5856d6', maritime:'#30b0c7' };
+
+  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
+  const {CO_SECTORS,CO_CC}=window.IntMapTables;
+
+  /* (#R145) Companies compare view state — mirrors the Countries #scp-view (Bar / Time-series / Table, metric picker). */
+  let _coCmpMode='bar', _coCmpMetOpen=false, _coCmpMet=new Set(['mcap','rev','ni','emp']), _coCmpTsFrom=null, _coCmpTsTo=null, _coCmpCss=0, _coCmpSort={key:null,dir:-1};
+
+  let _coCmpTsMetric='mcap';
+
+  const _CO_CMP_METS=['mcap','rev','ni','emp','pe','price'];
+
+  const _coCmpMetLbl=k=>{ const m={mcap:HOST._coL('Market cap','時価総額','Marktkap.','Капитализация','Cap. bursátil'),rev:HOST._coL('Revenue','売上高','Umsatz','Выручка','Ingresos'),ni:HOST._coL('Net income','純利益','Nettogewinn','Чистая прибыль','Beneficio neto'),emp:HOST._coL('Employees','従業員数','Mitarbeiter','Сотрудники','Empleados'),pe:HOST._coL('P/E ratio','株価収益率 (P/E)','KGV','P/E','P/E'),price:HOST._coL('Share price','株価','Aktienkurs','Цена акции','Precio acción')}; return m[k]||k; };
+
+  const _CO_CMP_PAL=['#0a84ff','#ff9f0a','#30d158','#ff375f','#bf5af2','#64d2ff','#ffd60a','#ac8e68'];
+
+  function _coWireTime(){ if(HOST._coTimeWired||!(window.IntMapTime&&window.IntMapTime.on)) return; HOST._coTimeWired=true;
+    const _apply=hy=>{ try{ IntMapCompanies.setYear(hy, ()=>{ if(document.getElementById('co-cmp-view')){ try{ HOST.showCoCompare([...HOST.coCompareSet]); }catch(_){} } else if(HOST.mode==='info'||document.body.classList.contains('ws-mode')){ try{ renderCompanies(); }catch(_){} } }); }catch(_){} };
+    window.IntMapTime.on(e=>{ clearTimeout(HOST._coTimeDeb); HOST._coTimeDeb=setTimeout(()=>{
+      const cur=new Date().getFullYear(); const y=(e&&e.year!=null)?e.year:null; _apply(((e&&e.isLive)||y==null||y>=cur)?null:y);
+    }, 320); });
+    /* (#R142) initial sync: if the map was ALREADY time-travelled before Companies was first opened, the subscription
+       above would miss that past event — reflect the current clock now so the ranking opens on the historical year. */
+    try{ const cur=new Date().getFullYear(); const y=window.IntMapTime.year(); if(!window.IntMapTime.isLive()&&y!=null&&y<cur) _apply(y); }catch(_){}
+  }
+
+  let _coCmpTsGen=0;
+
+  function _coCmpEnsureCss(){ if(_coCmpCss) return; _coCmpCss=1; const st=document.createElement('style');
+    st.textContent='#co-cmp-view{container-type:inline-size;}'
+      +'#co-cmp-view .scp-stickhead{position:sticky;top:0;z-index:8;background:var(--panel-bg,var(--glass-fill));display:flex;flex-direction:column;gap:6px;margin:0 0 6px;padding:8px 0 6px;}'
+      +'#co-cmp-view .scp-back{display:inline-flex;align-items:center;gap:6px;border:1px solid rgba(0,0,0,0.12);border-radius:10px;background:#fff;color:#111;padding:3px 12px 3px 9px;font-size:12px;font-weight:600;cursor:pointer;flex:0 0 auto;}'
+      +'#co-cmp-view .scp-back:hover{background:#f2f2f4;}'
+      +'#co-cmp-view .scp-cmptitle{font-weight:700;font-size:13px;line-height:1.15;}'
+      +'#co-cmp-view .scp-cmpsub{font-weight:500;font-size:10.5px;color:var(--text-muted);}'
+      +'#co-cmp-view .scp-ctrlrow{display:flex;align-items:center;gap:5px;flex-wrap:wrap;}'
+      +'#co-cmp-view .scp-modes{display:inline-flex;border:1px solid rgba(128,128,128,0.3);border-radius:10px;overflow:hidden;align-self:center;}'
+      +'#co-cmp-view .scp-modes button{border:none;background:transparent;color:var(--text-muted);font-size:13.5px;font-weight:600;padding:5px 9px;cursor:pointer;}'
+      +'#co-cmp-view .scp-modes button + button{border-left:1px solid rgba(128,128,128,0.35);}'
+      +'[data-theme="dark"] #co-cmp-view .scp-modes button + button{border-left-color:rgba(255,255,255,0.6);}'
+      +'#co-cmp-view .scp-modes button.on{background:var(--primary-color);color:#fff;}'
+      +'[data-theme="dark"] #co-cmp-view .scp-modes,[data-theme="dark"] #co-cmp-view .scp-mtog:not(.open){border-color:rgba(255,255,255,0.85);}'
+      +'#co-cmp-view .scp-mtog{display:inline-flex;align-items:center;gap:4px;border:1px solid rgba(128,128,128,0.3);background:var(--input-bg);color:var(--text-main);border-radius:10px;font-size:13.5px;font-weight:600;padding:5px 9px;cursor:pointer;align-self:center;white-space:nowrap;}'
+      +'#co-cmp-view .scp-mtog .scp-mcount{font-weight:500;color:var(--text-muted);font-variant-numeric:tabular-nums;}'
+      +'#co-cmp-view .scp-mtog.open{background:var(--primary-color);border-color:var(--primary-color);color:#fff;}'
+      +'#co-cmp-view .scp-mtog.open .scp-mcount{color:rgba(255,255,255,0.85);}'
+      +'#co-cmp-view .scp-metrics{display:flex;flex-wrap:wrap;gap:5px;margin:2px 0;}'
+      +'#co-cmp-view .scp-m{font-size:11px;padding:4px 9px;border-radius:999px;border:1px solid rgba(128,128,128,0.28);background:transparent;color:var(--text-muted);cursor:pointer;}'
+      +'#co-cmp-view .scp-m.on{background:var(--primary-color);border-color:var(--primary-color);color:#fff;font-weight:600;}'
+      +'[data-theme="dark"] #co-cmp-view .scp-m{border-color:rgba(255,255,255,0.85);}'
+      +'#co-cmp-view .scp-add{height:34px;padding:0 12px;border-radius:10px;border:1px solid rgba(128,128,128,0.3);background:var(--card-bg);color:var(--text-main);font-size:12.5px;outline:none;width:100%;box-sizing:border-box;}'
+      +'#co-cmp-view #co-cmp-list{display:none;position:absolute;left:0;right:0;top:38px;max-height:230px;overflow-y:auto;background:var(--popup-bg);border:1px solid var(--glass-border,rgba(128,128,128,0.3));border-radius:12px;box-shadow:var(--shadow);z-index:40;padding:4px;}'
+      +'#co-cmp-view #co-cmp-list .scp-cr{display:flex;align-items:center;gap:8px;padding:6px 10px;border-radius:8px;cursor:pointer;font-size:12.5px;color:var(--text-main);}'
+      +'#co-cmp-view #co-cmp-list .scp-cr:hover{background:var(--input-bg);}'
+      +'#co-cmp-view .scp-chip{display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:999px;font-size:12px;font-weight:600;background:var(--input-bg);color:var(--text-main);border:1.5px solid transparent;}'   /* (#R152) match the canonical Countries .scp-chip (was missing the transparent border) */
+      +'#co-cmp-view .scp-chip .scp-x{cursor:pointer;color:var(--text-muted);font-weight:700;padding:0 2px;} #co-cmp-view .scp-chip .scp-x:hover{color:#ff453a;}'
+      +'#co-cmp-view .scp-dot{width:9px;height:9px;border-radius:50%;flex:0 0 auto;}'
+      +'#co-cmp-view .scp-sec{margin:12px 0 4px;font-weight:700;font-size:13px;color:var(--text-main);}'
+      +'#co-cmp-view .scp-bars{display:flex;flex-direction:column;gap:5px;margin:4px 0 10px;}'
+      +'#co-cmp-view .scp-brow{display:flex;align-items:center;gap:8px;font-size:12px;}'
+      +'#co-cmp-view .scp-bnm{flex:0 0 116px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-main);}'
+      +'#co-cmp-view .scp-btrack{flex:1;height:14px;border-radius:7px;background:var(--input-bg);overflow:hidden;position:relative;}'
+      +'#co-cmp-view .scp-bfill{position:absolute;top:0;bottom:0;border-radius:4px;}'
+      +'#co-cmp-view .scp-zline{position:absolute;top:-1px;bottom:-1px;width:1.5px;background:var(--text-muted);opacity:0.6;z-index:1;}'
+      +'#co-cmp-view .scp-bval{flex:0 0 104px;font-size:11.5px;white-space:nowrap;text-align:right;font-variant-numeric:tabular-nums;}'
+      +'#co-cmp-view .scp-tblwrap{overflow-x:auto;-webkit-overflow-scrolling:touch;}'
+      +'#co-cmp-view .scp-tbl{width:100%;border-collapse:collapse;font-size:11.5px;margin:4px 0 6px;}'
+      +'#co-cmp-view .scp-tbl td,#co-cmp-view .scp-tbl th{padding:4px 7px;text-align:right;border-bottom:1px solid rgba(128,128,128,0.12);white-space:nowrap;}'
+      +'#co-cmp-view .scp-tbl th{color:var(--text-muted);font-weight:600;}'
+      +'#co-cmp-view .scp-tbl td:first-child,#co-cmp-view .scp-tbl th:first-child{text-align:left;}'
+      +'#co-cmp-view .scp-ttools{display:flex;align-items:center;gap:7px;flex-wrap:wrap;margin:2px 0 8px;}'
+      +'#co-cmp-view .scp-ttools button{height:28px;border-radius:8px;border:1px solid rgba(128,128,128,0.3);background:var(--input-bg);color:var(--text-main);font-size:11.5px;padding:0 10px;cursor:pointer;}'
+      +'#co-cmp-view .scp-ttools button:hover{border-color:var(--primary-color);color:var(--primary-color);}'
+      +'#co-cmp-view .scp-tsrange{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin:0 0 8px;padding:6px 8px;background:var(--input-bg);border:1px solid rgba(128,128,128,0.2);border-radius:9px;font-size:12px;}'
+      +'#co-cmp-view .scp-tsrange select{background:var(--card-bg);color:var(--text-main);border:1px solid rgba(128,128,128,0.25);border-radius:7px;font-size:12px;padding:4px 6px;cursor:pointer;outline:none;}'
+      +'#co-cmp-view .scp-tsrange .scp-tsl{color:var(--text-muted);font-weight:600;}'
+      +'#co-cmp-view .co-ts-note{font-size:10.5px;color:var(--text-muted);margin:2px 0 8px;line-height:1.4;}'
+      +'#co-cmp-view .co-ts-wrap svg{width:100%;height:150px;display:block;}'
+      +'#co-cmp-view .scp-tsmsel{display:inline-flex;gap:4px;margin-left:auto;}'   /* (#R153) TS metric toggle pushed to the right of the year range */
+      +'#co-cmp-view .scp-tsm{background:var(--card-bg);color:var(--text-muted);border:1px solid rgba(128,128,128,0.25);border-radius:7px;font-size:11.5px;font-weight:600;padding:4px 9px;cursor:pointer;}'
+      +'#co-cmp-view .scp-tsm.on{background:var(--primary-color);color:#fff;border-color:var(--primary-color);}'
+      +'#co-cmp-view .co-ts-chart{position:relative;}'
+      +'#co-cmp-view .co-ts-ax{position:absolute;left:4px;font-size:9.5px;color:var(--text-muted);pointer-events:none;font-variant-numeric:tabular-nums;}'
+      +'#co-cmp-view .co-ts-axhi{top:2px;} #co-cmp-view .co-ts-axlo{bottom:2px;}'
+      +'#co-cmp-view .co-ts-cursor{position:absolute;top:0;bottom:0;width:1px;background:var(--text-muted);opacity:0.5;display:none;pointer-events:none;}'
+      +'#co-cmp-view .co-ts-tip{position:absolute;top:2px;display:none;pointer-events:none;background:var(--card-bg);border:1px solid rgba(128,128,128,0.28);border-radius:8px;box-shadow:var(--shadow);padding:5px 8px;font-size:11px;z-index:5;min-width:120px;}'
+      +'#co-cmp-view .co-ts-tth{font-weight:700;margin-bottom:2px;white-space:nowrap;}'
+      +'#co-cmp-view .co-ts-ttr{display:flex;align-items:center;gap:5px;line-height:1.5;white-space:nowrap;} #co-cmp-view .co-ts-ttr b{margin-left:auto;font-variant-numeric:tabular-nums;}'
+      +'#co-cmp-view .co-ts-ttd{width:8px;height:8px;border-radius:50%;flex:0 0 auto;} #co-cmp-view .co-ts-ttn{overflow:hidden;text-overflow:ellipsis;max-width:120px;}';
+    document.head.appendChild(st); }
+
+  function _coCmpRender(cos){ const root=document.getElementById('co-cmp-view'); if(!root) return;
+    const hy=IntMapCompanies.histYear&&IntMapCompanies.histYear();
+    const modes=[['bar',HOST._coL('Bar chart','棒グラフ','Balken','Столбцы','Barras')],['ts',HOST._coL('Time-series','時系列','Zeitreihe','Динамика','Series')],['table',HOST._coL('Table','表','Tabelle','Таблица','Tabla')]];
+    let h='<div class="scp-stickhead"><div style="display:flex;align-items:center;gap:8px;">'
+      +'<button class="scp-back" data-cmpback="1"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="M15 5l-7 7 7 7"/></svg>'+HOST._coL('Back','戻る','Zurück','Назад','Atrás')+'</button>'
+      +'<div><div class="scp-cmptitle">'+HOST._coL('Compare companies','企業を比較','Unternehmen vergleichen','Сравнение компаний','Comparar empresas')+'</div><div class="scp-cmpsub">'+cos.length+'/10</div></div></div>';   /* (#R153) /8→/10: the cap is 10 (matches _coToggleCompare + the dock) */
+    h+='<div class="scp-ctrlrow"><div class="scp-modes">'+modes.map(m=>'<button data-cmpmode="'+m[0]+'" class="'+(_coCmpMode===m[0]?'on':'')+'">'+m[1]+'</button>').join('')+'</div>';
+    if(_coCmpMode!=='ts') h+='<button class="scp-mtog'+(_coCmpMetOpen?' open':'')+'" data-cmpmtog="1">'+HOST._coL('Metrics','指標','Kennzahlen','Показатели','Métricas')+' <span class="scp-mcount">'+_coCmpMet.size+'/'+_CO_CMP_METS.length+'</span></button>';   /* (#R153) the generic multi-metric picker only applies to Bar/Table — HIDE it in Time-series mode where it did nothing (rev/ni/emp/pe have no history); TS has its own metric toggle inside the chart */
+    h+='</div>';
+    if(_coCmpMetOpen&&_coCmpMode!=='ts') h+='<div class="scp-metrics">'+_CO_CMP_METS.map(k=>'<button class="scp-m'+(_coCmpMet.has(k)?' on':'')+'" data-cmpmet="'+k+'">'+IntMapSafe.html(_coCmpMetLbl(k))+'</button>').join('')+'</div>';
+    h+='<div style="position:relative;margin:6px 0 2px;"><input class="scp-add" id="co-cmp-add" placeholder="'+HOST._coL('Add a company…','企業を追加…','Firma hinzufügen…','Добавить компанию…','Añadir empresa…')+'" autocomplete="off"><div id="co-cmp-list"></div></div>';
+    h+='<div style="display:flex;flex-wrap:wrap;gap:6px;margin:4px 0 2px;">'+cos.map((c,i)=>'<span class="scp-chip"><span class="scp-dot" style="background:'+_CO_CMP_PAL[i%_CO_CMP_PAL.length]+'"></span>'+IntMapSafe.html(HOST._coName(c))+' <span class="scp-x" data-cmpx="'+IntMapSafe.html(c.tk)+'">×</span></span>').join('')+'</div>';
+    if(hy) h+='<div class="stats-timebanner co-banner" style="margin:4px 0 0;"><b>'+hy+(HOST.lang==='jp'?'年':'')+'</b> · '+HOST._coL('market cap at year-end · today\'s share counts · other figures latest reported','その年の年末時点の時価総額 · 株数は現在値 · 他の指標は最新報告値','Marktkap. zum Jahresende · heutige Aktienzahl · übrige Angaben aktuell','капитализация на конец года · число акций текущее · прочие показатели последние','cap. a fin de año · acciones actuales · demás cifras recientes')+'</div>';
+    h+='</div><div id="co-cmp-body"></div>';
+    root.innerHTML=h; _coCmpBody(cos); _coCmpWire(cos); }
+
+  function _coCmpBody(cos){ const body=document.getElementById('co-cmp-body'); if(!body) return;
+    const met=_CO_CMP_METS.filter(k=>_coCmpMet.has(k));
+    if(_coCmpMode==='table'){ const tmet=met.length?met:_CO_CMP_METS; body.innerHTML=_coCmpTable(cos,tmet); const b=body.querySelector('[data-cmpcsv]'); if(b) b.onclick=()=>_coCmpCsv(cos,tmet); body.querySelectorAll('[data-cmpsort]').forEach(th=>th.onclick=()=>{ const k=th.getAttribute('data-cmpsort'); if(_coCmpSort.key===k) _coCmpSort.dir=-_coCmpSort.dir; else { _coCmpSort.key=k; _coCmpSort.dir=-1; } _coCmpBody(cos); }); }   /* (#R147) sortable columns */
+    else if(_coCmpMode==='ts'){ _coCmpTs(cos,body); }
+    else body.innerHTML=_coCmpBar(cos,met); }
+
+  function _coCmpBar(cos,met){ if(!met.length) return '<div class="co-ts-note">'+HOST._coL('Pick at least one metric above.','上で指標を1つ以上選択してください。','Mindestens eine Kennzahl wählen.','Выберите хотя бы один показатель.','Elige al menos una métrica.')+'</div>';
+    let h='';
+    met.forEach(k=>{ const fin=cos.map(c=>_coVal(c,k)).filter(v=>isFinite(v)); if(!fin.length) return;
+      const hi=Math.max(0,Math.max.apply(null,fin)), lo=Math.min(0,Math.min.apply(null,fin)); const span=(hi-lo)||1; const zero=(0-lo)/span*100;
+      h+='<div class="scp-sec">'+IntMapSafe.html(_coCmpMetLbl(k))+'</div><div class="scp-bars">';
+      cos.forEach((c,i)=>{ const v=_coVal(c,k); const col=_CO_CMP_PAL[i%_CO_CMP_PAL.length]; let fill='';
+        if(isFinite(v)){ const pv=(v-lo)/span*100; const l=Math.min(zero,pv), w=Math.max(1,Math.abs(pv-zero)); fill='<span class="scp-bfill" style="left:'+l.toFixed(2)+'%;width:'+w.toFixed(2)+'%;background:'+col+'"></span>'; }
+        const zl=(lo<0)?'<span class="scp-zline" style="left:'+zero.toFixed(2)+'%"></span>':'';
+        h+='<div class="scp-brow"><span class="scp-bnm">'+IntMapSafe.html(HOST._coName(c))+'</span><span class="scp-btrack">'+zl+fill+'</span><span class="scp-bval">'+(isFinite(v)?IntMapSafe.html(_coMetric(c,k)):'—')+'</span></div>'; });
+      h+='</div>'; });
+    return h||'<div class="co-ts-note">'+HOST._coL('No data for the selected metrics.','選択した指標のデータがありません。','Keine Daten.','Нет данных.','Sin datos.')+'</div>'; }
+
+  function _coCmpTable(cos,met){ const ths=met.map(k=>{ const act=_coCmpSort.key===k, arr=act?(_coCmpSort.dir<0?' ▼':' ▲'):''; return '<th class="scp-th-sort'+(act?' on':'')+'" data-cmpsort="'+k+'" style="cursor:pointer;user-select:none;white-space:nowrap;">'+IntMapSafe.html(_coCmpMetLbl(k))+arr+'</th>'; }).join('');
+    let h='<div class="scp-ttools"><button data-cmpcsv="1">'+HOST._coL('Export CSV','CSV書き出し','CSV-Export','Экспорт CSV','Exportar CSV')+'</button></div><div class="scp-tblwrap"><table class="scp-tbl"><thead><tr><th>'+HOST._coL('Company','企業','Firma','Компания','Empresa')+'</th>'+ths+'</tr></thead><tbody>';
+    let rows=cos.slice(); const sk=_coCmpSort.key;   /* (#R147) sort rows by the active metric column, blanks last */
+    if(sk&&met.indexOf(sk)>=0){ const d=_coCmpSort.dir; rows.sort((a,b)=>{ const va=_coVal(a,sk),vb=_coVal(b,sk),fa=isFinite(va),fb=isFinite(vb); if(!fa&&!fb) return 0; if(!fa) return 1; if(!fb) return -1; return (va-vb)*d; }); }
+    rows.forEach(c=>{ h+='<tr><td>'+IntMapSafe.html(HOST._coName(c))+'</td>'+met.map(k=>'<td>'+IntMapSafe.html(_coMetric(c,k))+'</td>').join('')+'</tr>'; });
+    return h+'</tbody></table></div>'; }
+
+  function _coCmpCsv(cos,met){ const esc=s=>{ s=String(s==null?'':s); return /[",\n]/.test(s)?'"'+s.replace(/"/g,'""')+'"':s; };
+    const rows=[[HOST._coL('Company','企業','Firma','Компания','Empresa')].concat(met.map(k=>_coCmpMetLbl(k)))];
+    cos.forEach(c=>rows.push([HOST._coName(c)].concat(met.map(k=>{ const v=_coVal(c,k); return isFinite(v)?v:''; }))));
+    const csv='﻿'+rows.map(r=>r.map(esc).join(',')).join('\r\n'); const blob=new Blob([csv],{type:'text/csv;charset=utf-8'}); const url=URL.createObjectURL(blob);
+    const a=document.createElement('a'); a.href=url; a.download='companies-compare.csv'; document.body.appendChild(a); a.click(); setTimeout(()=>{ try{ a.remove(); URL.revokeObjectURL(url); }catch(_){} },200); }
+
+  async function _coCmpTs(cos,body){ const cur=new Date().getFullYear(); if(_coCmpTsTo==null) _coCmpTsTo=cur; if(_coCmpTsFrom==null) _coCmpTsFrom=cur-20;   /* (#R153) default the Time-series to a DEEPER 20-year window (was 10) so the available deep history is visible immediately ("もっと昔も見れる"); the picker still reaches Yahoo's keyless floor of 1962 for the oldest names */
+    if(_coCmpTsFrom>_coCmpTsTo) _coCmpTsFrom=_coCmpTsTo; const from=_coCmpTsFrom, to=_coCmpTsTo, gen=++_coCmpTsGen;
+    const metric=(_coCmpTsMetric==='price')?'price':'mcap';   /* (#R153) the TS metric picker now DRIVES the chart (was ignored) */
+    const yrs=[]; for(let y=cur;y>=1962;y--) yrs.push(y); const opt=sel=>yrs.map(y=>'<option value="'+y+'"'+(y===sel?' selected':'')+'>'+y+'</option>').join('');   /* (#R152) 1990→1962: reach back as far as Yahoo has data ("もっと昔も見れる"); names without data that far show "no history" honestly */
+    const mBtn=(k)=>'<button class="scp-tsm'+(metric===k?' on':'')+'" data-cmptsm="'+k+'" type="button">'+IntMapSafe.html(_coCmpMetLbl(k))+'</button>';   /* (#R153) TS metric toggle — only mcap/price have real history */
+    body.innerHTML='<div class="scp-tsrange"><span class="scp-tsl">'+HOST._coL('Years','期間','Jahre','Годы','Años')+'</span><select data-cmptsfrom="1">'+opt(from)+'</select><span>–</span><select data-cmptsto="1">'+opt(to)+'</select><span class="scp-tsmsel">'+mBtn('mcap')+mBtn('price')+'</span></div>'
+      +'<div class="co-ts-wrap" id="co-ts-wrap"><div class="co-ts-note">'+HOST._coL('Loading price history…','株価履歴を読み込み中…','Kursverlauf wird geladen…','Загрузка истории цен…','Cargando histórico…')+'</div></div>';
+    const wf=body.querySelector('[data-cmptsfrom]'), wt=body.querySelector('[data-cmptsto]');
+    if(wf) wf.onchange=()=>{ _coCmpTsFrom=+wf.value; _coCmpTs(cos,body); }; if(wt) wt.onchange=()=>{ _coCmpTsTo=+wt.value; _coCmpTs(cos,body); };
+    body.querySelectorAll('[data-cmptsm]').forEach(b=>b.onclick=()=>{ _coCmpTsMetric=b.getAttribute('data-cmptsm'); _coCmpTs(cos,body); });
+    const series=await Promise.all(cos.map(async c=>{ if(c.sh<=0) return {c,data:null}; try{ return {c,data:await IntMapCompanies.priceSeriesFine(c.tk,from,to)}; }catch(_){ return {c,data:null}; } }));   /* (#R152) MONTHLY series for a high-precision curve */
+    if(gen!==_coCmpTsGen) return; const wrap=document.getElementById('co-ts-wrap'); if(!wrap) return;
+    const W=600,H=150,padL=6,padR=6,padT=10,padB=6, innerW=W-padL-padR, innerH=H-padT-padB;
+    const lines=[]; let vmin=Infinity,vmax=-Infinity;
+    series.forEach(s=>{ const arr=s.data; if(!arr||arr.length<2) return;
+      let pts;
+      if(metric==='mcap'){ const sh=s.c.sh; if(!(sh>0)) return; pts=arr.filter(p=>p[1]>0).map(p=>({fy:p[0],v:p[1]*sh,ts:p[2]})); }   /* (#R153) ABSOLUTE market cap = today's share count × historical price (same approximation the time-machine already uses); (#R158) carry the point's real timestamp */
+      else { const base=arr[0][1]; if(!(base>0)) return; pts=arr.filter(p=>p[1]>0).map(p=>({fy:p[0],v:p[1]/base*100,ts:p[2]})); }   /* share price indexed to 100 at the first point */
+      if(pts.length<2) return;
+      pts.forEach(p=>{ if(p.v<vmin)vmin=p.v; if(p.v>vmax)vmax=p.v; }); lines.push({c:s.c,col:_CO_CMP_PAL[cos.indexOf(s.c)%_CO_CMP_PAL.length],pts}); });
+    if(!lines.length){ wrap.innerHTML='<div class="co-ts-note">'+HOST._coL('No price history for these companies (US-listed live names only).','これらの企業の株価履歴がありません（米国上場のライブ銘柄のみ）。','Kein Kursverlauf (nur live gelistete US-Namen).','Нет истории цен (только листингованные в США).','Sin histórico (solo cotizadas en EE. UU.).')+'</div>'; return; }
+    const lo=(metric==='mcap')?0:vmin, hi=(metric==='mcap')?(vmax||1):vmax; const vspan=(hi-lo)||1;   /* (#R153) mcap on a real $ axis from 0; indexed price on [min,max] */
+    const _sp=((to+1)>from)?((to+1)-from):1; const X=fy=>padL+((to>from)?(fy-from)/_sp:0.5)*innerW; const Y=v=>padT+(1-(v-lo)/vspan)*innerH;   /* (#R152) X by fractional year over [from, to+1) */
+    let svg='<svg viewBox="0 0 '+W+' '+H+'" preserveAspectRatio="none">';
+    if(metric==='price'&&vmin<=100&&vmax>=100){ const y1=Y(100).toFixed(1); svg+='<line x1="'+padL+'" y1="'+y1+'" x2="'+(W-padR)+'" y2="'+y1+'" stroke="var(--text-muted)" stroke-opacity="0.3" stroke-dasharray="3 3" vector-effect="non-scaling-stroke"/>'; }
+    lines.forEach(ln=>{ svg+='<path d="'+ln.pts.map((p,j)=>(j?'L':'M')+X(p.fy).toFixed(1)+' '+Y(p.v).toFixed(1)).join(' ')+'" fill="none" stroke="'+ln.col+'" stroke-width="2" vector-effect="non-scaling-stroke"/>'; });
+    svg+='</svg>';
+    const axHi=(metric==='mcap')?('<span class="co-ts-ax co-ts-axhi">'+IntMapSafe.html(HOST.fmtMoney(hi))+'</span><span class="co-ts-ax co-ts-axlo">$0</span>'):'';   /* (#R153) real $ axis labels for the mcap view */
+    const missing=cos.filter(c=>!lines.find(l=>l.c===c));
+    let note=(metric==='mcap')
+      ? HOST._coL('Market cap: today\'s share count × historical price · US-listed live names only','時価総額：現在の株数×当時の株価 · 米国上場のライブ銘柄のみ','Marktkap.: heutige Aktienzahl × historischer Kurs · nur live gelistete US-Namen','Капитализация: текущее число акций × историческая цена · только листингованные в США','Cap. bursátil: acciones actuales × precio histórico · solo cotizadas en EE. UU.')
+      : HOST._coL('Share price indexed to 100 at '+from+' · US-listed live names only','株価を'+from+'年＝100に指数化 · 米国上場のライブ銘柄のみ','Aktienkurs indexiert auf 100 ('+from+') · nur live gelistete US-Namen','Цена акции: индекс 100 в '+from+' · только листингованные в США','Precio de acción base 100 en '+from+' · solo cotizadas en EE. UU.');
+    if(missing.length) note+=' · '+HOST._coL('no history','履歴なし','kein Verlauf','нет истории','sin histórico')+': '+missing.map(c=>IntMapSafe.html(HOST._coName(c))).join(', ');
+    wrap.innerHTML='<div class="co-ts-chart" style="position:relative;">'+svg+axHi+'<div class="co-ts-cursor"></div><div class="co-ts-tip"></div></div><div class="co-ts-note">'+note+'</div>';
+    /* (#R153) crosshair tooltip (Countries-parity) — hover shows the year + each company's value at that year. */
+    const chart=wrap.querySelector('.co-ts-chart'), cursor=wrap.querySelector('.co-ts-cursor'), tip=wrap.querySelector('.co-ts-tip');
+    /* (#R158) hover date shows the MATCHED data point's REAL month/day (was Math.round(year) only — "月/日が出ない").
+       The monthly series now carries each point's raw timestamp, so the tooltip reads the actual date localised. */
+    const _tsLoc=HOST.lang==='jp'?'ja-JP':HOST.lang==='de'?'de-DE':HOST.lang==='ru'?'ru-RU':HOST.lang==='es'?'es-ES':'en-US';
+    const _fmtTsD=(ts,fyFb)=>{ try{ if(ts!=null&&isFinite(+ts)) return new Date(+ts).toLocaleDateString(_tsLoc,{year:'numeric',month:'short',day:'numeric'}); }catch(_){} return String(Math.round(fyFb)); };
+    if(chart&&cursor&&tip){ const onMove=(e)=>{ const rc=chart.getBoundingClientRect(); if(!rc.width) return; const fx=Math.min(1,Math.max(0,(e.clientX-rc.left)/rc.width)); const fyr=from+fx*_sp;
+        cursor.style.left=(fx*100).toFixed(2)+'%'; cursor.style.display='block';
+        const rows=lines.map(ln=>{ let best=ln.pts[0],bd=Infinity; ln.pts.forEach(p=>{ const d=Math.abs(p.fy-fyr); if(d<bd){bd=d;best=p;} }); return {c:ln.c,col:ln.col,p:best}; });
+        let hdTs=null,hdBd=Infinity; rows.forEach(r=>{ if(r.p&&r.p.ts!=null){ const d=Math.abs(r.p.fy-fyr); if(d<hdBd){ hdBd=d; hdTs=r.p.ts; } } });   /* (#R158) date of the nearest actual point */
+        tip.innerHTML='<div class="co-ts-tth">'+IntMapSafe.html(_fmtTsD(hdTs,Math.min(to,Math.max(from,fyr))))+'</div>'+rows.map(r=>'<div class="co-ts-ttr"><span class="co-ts-ttd" style="background:'+r.col+'"></span><span class="co-ts-ttn">'+IntMapSafe.html(HOST._coName(r.c))+'</span><b>'+(metric==='mcap'?IntMapSafe.html(HOST.fmtMoney(r.p.v)):(Math.round(r.p.v)+''))+'</b></div>').join('');
+        tip.style.display='block'; tip.style.left=Math.min(Math.max(4,e.clientX-rc.left+12), Math.max(4,rc.width-150))+'px'; };
+      chart.addEventListener('mousemove',onMove); chart.addEventListener('mouseleave',()=>{ cursor.style.display='none'; tip.style.display='none'; }); } }
+
+  function _coCmpWire(cos){ const root=document.getElementById('co-cmp-view'); if(!root) return;
+    const bk=root.querySelector('[data-cmpback]'); if(bk) bk.onclick=()=>{ root.remove(); try{ renderCompanies(); }catch(_){} };
+    root.querySelectorAll('[data-cmpmode]').forEach(b=>b.onclick=()=>{ _coCmpMode=b.getAttribute('data-cmpmode'); _coCmpRender(cos); });
+    const mt=root.querySelector('[data-cmpmtog]'); if(mt) mt.onclick=()=>{ _coCmpMetOpen=!_coCmpMetOpen; _coCmpRender(cos); };
+    root.querySelectorAll('[data-cmpmet]').forEach(b=>b.onclick=()=>{ const k=b.getAttribute('data-cmpmet'); if(_coCmpMet.has(k)){ if(_coCmpMet.size>1) _coCmpMet.delete(k); } else _coCmpMet.add(k); _coCmpRender(cos); });
+    root.querySelectorAll('[data-cmpx]').forEach(b=>b.onclick=()=>{ HOST.coCompareSet.delete(b.getAttribute('data-cmpx')); const left=[...HOST.coCompareSet]; if(left.length<2){ root.remove(); try{ renderCompanies(); }catch(_){} } else HOST.showCoCompare(left); });
+    const inp=root.querySelector('#co-cmp-add'), list=root.querySelector('#co-cmp-list'); if(inp&&list){ const have=new Set(cos.map(c=>c.tk));
+      const upd=()=>{ const q=inp.value.trim().toLowerCase(); if(!q){ list.style.display='none'; return; }
+        const hits=IntMapCompanies.DATA.filter(c=>!have.has(c.tk)&&(((HOST._coName(c)||'').toLowerCase().includes(q))||c.tk.toLowerCase().includes(q)||(c.n||'').toLowerCase().includes(q))).slice(0,30);
+        if(!hits.length){ list.style.display='none'; return; }
+        list.innerHTML=hits.map(c=>'<div class="scp-cr" data-cmpadd="'+IntMapSafe.html(c.tk)+'">'+IntMapSafe.html(HOST._coName(c))+' <span style="color:var(--text-muted);font-size:11px;">'+IntMapSafe.html(c.tk)+'</span></div>').join(''); list.style.display='block';
+        list.querySelectorAll('[data-cmpadd]').forEach(r=>r.onmousedown=e=>{ e.preventDefault(); const tk=r.getAttribute('data-cmpadd'); if(HOST.coCompareSet.size<10){ HOST.coCompareSet.add(tk); HOST.showCoCompare([...HOST.coCompareSet]); } }); };
+      inp.oninput=upd; inp.onfocus=upd; inp.onblur=()=>setTimeout(()=>{ try{ list.style.display='none'; }catch(_){} },180); } }
+
+  const _coSec=(k)=>{ const s=CO_SECTORS[k]; return s?HOST._coL(s[0],s[1],s[2],s[3],s[4]):k; };
+
+  const _coCountry=(cc)=>{ const c=CO_CC[cc]; return c?(HOST.lang==='jp'?c[1]:c[0]):cc; };
+
+  const _coFlag=(cc)=>{ const c=CO_CC[cc]; return c?c[2]:''; };
+
+  const CO_IND=()=>[['mcap',HOST._coL('Market cap','時価総額','Marktkap.','Капитализация','Cap. bursátil')],['rev',HOST._coL('Revenue','売上高','Umsatz','Выручка','Ingresos')],['ni',HOST._coL('Net income','純利益','Nettogewinn','Чистая прибыль','Beneficio neto')],['pe',HOST._coL('P/E ratio','株価収益率 (P/E)','KGV','P/E','P/E')],['emp',HOST._coL('Employees','従業員数','Mitarbeiter','Сотрудники','Empleados')],['price',HOST._coL('Share price','株価','Aktienkurs','Цена акции','Precio acción')],['fnd',HOST._coL('Founded','設立年','Gegründet','Год основания','Fundada')],['name',HOST._coL('Name','名称','Name','Название','Nombre')]];
+
+  function _coVal(c,key){ const _pr=IntMapCompanies.priceOf(c); switch(key){ case 'rev':return c.rev; case 'ni':return c.ni; case 'emp':return c.emp; case 'fnd':return c.fnd; case 'price':return _pr>0?_pr:NaN; case 'pe':{ const mc=IntMapCompanies.mcap(c); return (c.ni>0&&mc>0)?(mc/c.ni):NaN; } case 'name':return 0; default:return IntMapCompanies.mcap(c); } }
+
+  function _coMetric(c,key){ const _pr=IntMapCompanies.priceOf(c); switch(key){ case 'rev':return HOST.fmtMoney(c.rev); case 'ni':return (c.ni<0?'-':'')+HOST.fmtMoney(Math.abs(c.ni)); case 'emp':return (c.emp?c.emp.toLocaleString():'—'); case 'fnd':return ''+c.fnd; case 'price':return _pr>0?('$'+_pr.toFixed(2)):'—'; case 'pe':{ const v=_coVal(c,'pe'); return (isFinite(v)&&v>0)?v.toFixed(1):'—'; } case 'mcap':{ const m=IntMapCompanies.mcap(c); return isFinite(m)?HOST.fmtMoney(m):'—'; } default:{ const m=IntMapCompanies.mcap(c); return isFinite(m)?HOST.fmtMoney(m):'—'; } } }
+
+  const _coLogoCache=new Map();
+
+  function _coLogoInner(dom,nm,hue){
+    const d=String(dom||''), r=_coLogoCache.get(d);
+    if(r==='mono'){ const ch=(String(nm||'?').trim().slice(0,1)||'?').toUpperCase(); return '<span class="co-mono" style="background:hsl('+hue+',55%,45%)">'+IntMapSafe.html(ch)+'</span>'; }
+    const step=r?'1':'0';   /* a cached url is already resolved → on any later error skip straight to the monogram */
+    const src=r||('https://logo.clearbit.com/'+encodeURIComponent(d));
+    return '<img class="co-logo" alt="" data-dom="'+IntMapSafe.html(d)+'" data-name="'+IntMapSafe.html(nm)+'" data-hue="'+hue+'" data-step="'+step+'" src="'+IntMapSafe.html(src)+'">';
+  }
+
+  function _coWireLogo(img){ if(!img) return;
+    img.onload=function(){ try{ if(this.src && this.dataset.dom) _coLogoCache.set(this.dataset.dom,this.src); }catch(_){} };
+    img.onerror=function(){ const s=+this.dataset.step||0, dom=this.dataset.dom||'';
+      if(s===0){ this.dataset.step='1'; this.src='https://www.google.com/s2/favicons?domain='+encodeURIComponent(dom)+'&sz=64'; }
+      else { this.onerror=null; try{ if(dom) _coLogoCache.set(dom,'mono'); }catch(_){} const mono=document.createElement('span'); mono.className='co-mono'; mono.textContent=(this.dataset.name||'?').trim().slice(0,1).toUpperCase(); try{ mono.style.background='hsl('+(this.dataset.hue||0)+',55%,45%)'; }catch(_){} this.replaceWith(mono); } };
+  }
+
+  let _coRrT=null;
+
+  function _coRerenderSoon(){ if(_coRrT) return; _coRrT=setTimeout(()=>{ _coRrT=null; if(HOST.mode==='info'||document.body.classList.contains('ws-mode')){ try{ renderCompanies(); }catch(_){} } },350); }
+
+  function renderCompanies(q){
+    const feed=document.getElementById('info-dashboard'); if(!feed) return;
+    if(document.getElementById('co-cmp-view')) return;   /* (#R142) the compare view owns the feed — don't clobber it */
+    try{ _coWireTime(); }catch(_){}   /* (#R142) subscribe to the time machine once */
+    try{ HOST.clearMarkers(); }catch(_){}
+    if(q==null) q=HOST._companiesSearchVal();   /* (#R153) reads the ws-mode Companies filter box too (Countries parity) — was '' in ws-mode → un-filterable */
+    let arr=IntMapCompanies.DATA.slice();
+    if(q){ const ql=String(q).toLowerCase(); arr=arr.filter(c=>c.n.toLowerCase().includes(ql)||(c.nJp&&c.nJp.includes(q))||c.tk.toLowerCase().includes(ql)||_coSec(c.sec).toLowerCase().includes(ql)); }
+    const actF=HOST.coFilters.filter(f=>f&&f.key&&isFinite(f.val));
+    if(actF.length) arr=arr.filter(c=>actF.every(f=>{ const v=_coVal(c,f.key); if(!isFinite(v)) return false; return f.op==='lte'?(v<=f.val):(v>=f.val); }));
+    const key=HOST.coSort, dir=HOST.coSortDir;
+    arr.sort((a,b)=>{ if(key==='name'){ const av=HOST._coName(a),bv=HOST._coName(b); const cc=av.localeCompare(bv,HOST.lang==='jp'?'ja':undefined); return dir==='asc'?cc:-cc; }
+      const av=_coVal(a,key), bv=_coVal(b,key); const aok=isFinite(av), bok=isFinite(bv); if(!aok&&!bok)return 0; if(!aok)return 1; if(!bok)return -1; return dir==='asc'?(av-bv):(bv-av); });
+    /* (#R142) rank = the company's standing in the CURRENTLY-SORTED metric by VALUE (largest = 1), independent of
+       sort DIRECTION — so toggling asc/desc actually moves "#1" and the number means something (the old code printed
+       the row position i+1, which stayed 1,2,3… for every sort → "順序を変えても順位が変わらない"). Name/text sort
+       falls back to the canonical market-cap rank so the badge stays meaningful. Rank is over the displayed set. */
+    const _rankKey=(key==='name'||key==='fnd')?'mcap':key;
+    const _rankOf=new Map(); arr.slice().filter(c=>isFinite(_coVal(c,_rankKey))).sort((a,b)=>_coVal(b,_rankKey)-_coVal(a,_rankKey)).forEach((c,ri)=>_rankOf.set(c.tk,ri+1));
+    const IND=CO_IND();
+    const _arrow=up=>'<svg class="ssd-arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">'+(up?'<path d="M12 19.5V5M6.5 11l5.5-6 5.5 6"/>':'<path d="M12 4.5V19M6.5 13l5.5 6 5.5-6"/>')+'</svg>';
+    const dirLbl=_arrow(dir==='asc')+'<span class="ssd-labels" data-dir="'+(dir==='asc'?'asc':'desc')+'"><span class="ssd-l ssd-l-asc">'+HOST.t('sortAsc')+'</span><span class="ssd-l ssd-l-desc">'+HOST.t('sortDesc')+'</span></span>';
+    const _FIND=IND.filter(([k])=>k!=='name');
+    const nAct=HOST.coFilters.filter(f=>f&&f.key&&isFinite(f.val)).length;
+    const funnel='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h18l-7 8v6l-4 2v-8z"/></svg>';
+    const filterBtn=`<button type="button" class="stats-filter-btn${HOST.coFilterOpen?' on':''}${nAct?' has':''}" onclick="_coSfToggle()" title="${HOST._sfL('Filter by value','値でフィルター','Nach Wert filtern','Фильтр по значению','Filtrar por valor')}">${funnel}${nAct?`<span class="sf-badge">${nAct}</span>`:''}</button>`;   /* (#R152) Countries-parity: filter button now has the same tooltip Countries has */
+    const sfPanel=(()=>{ if(!HOST.coFilterOpen) return ''; const opts=(sel)=>_FIND.map(([k,l])=>`<option value="${k}"${sel===k?' selected':''}>${l}</option>`).join('');
+      const rows=HOST.coFilters.map((f,i)=>`<div class="sf-row"><select onchange="_coSfSetKey(${i},this.value)">${opts(f.key)}</select><select class="sf-op" onchange="_coSfSetOp(${i},this.value)"><option value="gte"${f.op!=='lte'?' selected':''}>≥</option><option value="lte"${f.op==='lte'?' selected':''}>≤</option></select><input type="text" class="sf-val" value="${(f.raw||'').replace(/"/g,'&quot;')}" placeholder="${HOST._sfL('value (5B, 100000…)','値（5B, 100000…）','Wert','значение','valor')}" onchange="_coSfSetVal(${i},this.value)"><button type="button" class="sf-x" onclick="_coSfRemove(${i})">✕</button></div>`).join('');
+      return `<div class="stats-filter-panel">${rows||`<div class="sf-empty">${HOST._sfL('No conditions yet.','条件がありません。','Keine Bedingungen.','Нет условий.','Sin condiciones.')}</div>`}<div class="sf-actions"><button type="button" class="sf-add" onclick="_coSfAdd()">+ ${HOST._sfL('Add condition','条件を追加','Bedingung','Условие','Añadir')}</button>${HOST.coFilters.length?`<button type="button" class="sf-clear" onclick="_coSfClear()">${HOST._sfL('Clear','クリア','Löschen','Очистить','Limpiar')}</button>`:''}</div></div>`; })();
+    let html=`<div class="stats-toolbar"><select class="stats-sort-sel" onchange="setCoSort(this.value)">${IND.map(([k,l])=>`<option value="${k}"${HOST.coSort===k?' selected':''}>${l}</option>`).join('')}</select><button type="button" class="stats-sort-dir" onclick="toggleCoSortDir()" title="${HOST.t('sortDir')}">${dirLbl}</button>${filterBtn}</div>${sfPanel}`;
+    const _hy=(IntMapCompanies.histYear&&IntMapCompanies.histYear())||null;   /* (#R142) time-machine year (null = present) */
+    html+=_hy?`<div class="stats-timebanner co-banner"><b>${_hy}${HOST.lang==='jp'?'年':''}</b> · ${HOST._coL('market cap at year-end · today\'s share counts · other figures latest reported','その年の年末時点の時価総額 · 株数は現在値 · 他の指標は最新報告値','Marktkap. zum Jahresende · heutige Aktienzahl · übrige Angaben aktuell','капитализация на конец года · число акций текущее · прочие показатели последние','cap. a fin de año · acciones actuales · demás cifras recientes')}</div>`:`<div class="stats-timebanner co-banner">${HOST._coL('Market cap live where available · figures: latest reported','時価総額は可能な限りライブ · 指標は最新の報告値','Marktkap. live, wo verfügbar · Angaben: zuletzt berichtet','Капитализация в реальном времени, где возможно · показатели: последние отчётные','Cap. en vivo cuando es posible · cifras: últimas reportadas')}</div>`;
+    if(!arr.length) html+=`<div class="empty-msg">${HOST.t('noMatch')}</div>`;
+    arr.forEach((c,i)=>{ const nm=HOST._coName(c);
+      const cn=_coCountry(c.cc), fl=_coFlag(c.cc);
+      const sub=_coSec(c.sec)+(cn?(' / '+(fl?fl+' ':'')+cn):'');
+      const hue=[...nm].reduce((a,ch)=>a+ch.charCodeAt(0),0)%360;
+      const logo=_coLogoInner(c.dom,nm,hue);   /* (#R147) cached-logo builder — no flicker */
+      html+=`<div class="stat-row co-row${HOST.coCompareSet.has(c.tk)?' compare-on':''}" data-tk="${IntMapSafe.html(c.tk)}" title="${IntMapSafe.html(nm)}">${(window.imShowRank!=='off')?`<span class="stat-rank">${_rankOf.get(c.tk)||'—'}</span>`:''}<span class="stat-flag co-logo-box">${logo}</span><div class="stat-main"><div class="stat-name">${IntMapSafe.html(nm)}</div><div class="stat-sub">${IntMapSafe.html(sub)}</div></div><div class="stat-val">${_coMetric(c,key)}</div></div>`;
+    });
+    const st0=feed.scrollTop;
+    feed.innerHTML=html;
+    try{ feed.scrollTop=st0; }catch(_){}
+    feed.querySelectorAll('.co-logo').forEach(_coWireLogo);   /* (#R147) shared cached-logo wiring */
+    /* (#R142) single-click selects the row for comparison, double-click opens the detail overlay — mirrors Countries. */
+    feed.querySelectorAll('.co-row').forEach(row=>{ let ct=null; row.onclick=()=>{ const tk=row.getAttribute('data-tk');
+      if(ct){ clearTimeout(ct); ct=null; try{ showCompanyDetail(tk); }catch(_){} return; }
+      ct=setTimeout(()=>{ ct=null; try{ window._coToggleCompare(tk); }catch(_){} },250); }; });
+    feed.style.paddingBottom='92px';   /* (#R152) reserve room for the absolute-overlay compare dock, matching Countries (was 24px for the old in-feed sticky tray) */
+    try{ HOST.renderCoCompareFixed(); }catch(_){}   /* (#R142) re-attach the compare selection tray after the rebuild */
+    if(!(IntMapCompanies.histYear&&IntMapCompanies.histYear())){ try{ IntMapCompanies.loadPrices(_coRerenderSoon); }catch(_){} }   /* (#R142) live prices only in the present; historical prices come from setYear; (#R147) debounced re-render kills repaint churn */
+  }
+
+  /* Company detail overlay — every indicator for one company + a link to its site (all figures honestly sourced). */
+  function showCompanyDetail(tk){ const c=IntMapCompanies.DATA.find(x=>x.tk===tk); if(!c) return;
+    let ov=document.getElementById('co-detail-ov'); if(ov) ov.remove();
+    ov=document.createElement('div'); ov.id='co-detail-ov'; ov.className='co-detail-ov';
+    const nm=HOST._coName(c); const hue=[...nm].reduce((a,ch)=>a+ch.charCodeAt(0),0)%360;
+    const mc=IntMapCompanies.mcap(c), live=IntMapCompanies.isLive(c);
+    const peV=_coVal(c,'pe');
+    const rows=[ [HOST._coL('Market cap','時価総額','Marktkap.','Капитализация','Cap. bursátil'), HOST.fmtMoney(mc)+' · '+(live?HOST._coL('live','ライブ','live','в реальном времени','en vivo'):HOST._coL('reported','報告値','berichtet','отчёт','reportado'))],
+      [HOST._coL('Share price','株価','Aktienkurs','Цена акции','Precio acción'), c.price>0?('$'+c.price.toFixed(2)):'—'],
+      [HOST._coL('P/E ratio','株価収益率 (P/E)','KGV','P/E','P/E'), (isFinite(peV)&&peV>0)?peV.toFixed(1):'—'],
+      [HOST._coL('Revenue','売上高','Umsatz','Выручка','Ingresos'), HOST.fmtMoney(c.rev)],
+      [HOST._coL('Net income','純利益','Nettogewinn','Чистая прибыль','Beneficio neto'), (c.ni<0?'-':'')+HOST.fmtMoney(Math.abs(c.ni))],
+      [HOST._coL('Employees','従業員数','Mitarbeiter','Сотрудники','Empleados'), c.emp?c.emp.toLocaleString():'—'],
+      [HOST._coL('Founded','設立年','Gegründet','Год основания','Fundada'), ''+c.fnd],
+      [HOST._coL('Sector','セクター','Sektor','Сектор','Sector'), _coSec(c.sec)],
+      [HOST._coL('Headquarters','本社','Hauptsitz','Штаб-квартира','Sede'), (_coFlag(c.cc)?_coFlag(c.cc)+' ':'')+_coCountry(c.cc)] ];
+    const site='https://'+c.dom;
+    ov.innerHTML=`<div class="co-detail" role="dialog" aria-modal="true"><button class="co-detail-x" type="button" aria-label="Close">✕</button>`+
+      `<div class="co-detail-head"><span class="co-logo-box co-logo-lg">${_coLogoInner(c.dom,nm,hue)}</span>`+
+      `<div class="co-detail-title"><div class="co-detail-name">${IntMapSafe.html(nm)}</div><div class="co-detail-tk">${IntMapSafe.html(c.tk)}</div></div></div>`+
+      `<div class="co-detail-btns"><button class="co-detail-btn${HOST.coCompareSet.has(c.tk)?' on':''}" data-cmp="1" type="button">${HOST.coCompareSet.has(c.tk)?HOST._coL('In comparison','比較中','Im Vergleich','В сравнении','En comparación'):HOST._coL('Compare','比較する','Vergleichen','Сравнить','Comparar')}${HOST.coCompareSet.size?` (${HOST.coCompareSet.size}/8)`:''}</button></div>`+
+      `<div class="co-detail-rows">${rows.map(r=>`<div class="co-drow"><span>${IntMapSafe.html(r[0])}</span><b>${IntMapSafe.html(String(r[1]))}</b></div>`).join('')}</div>`+
+      (c.sh>0?`<div class="co-detail-spark" id="co-detail-spark"><div class="co-spark-note">${HOST._coL('Loading share-price history…','株価履歴を読み込み中…','Kursverlauf wird geladen…','Загрузка истории цен…','Cargando histórico…')}</div></div>`:'')+
+      `<a class="co-detail-link" href="${IntMapSafe.html(IntMapSafe.url(site)||'#')}" target="_blank" rel="noopener">${IntMapSafe.html(c.dom)} ↗</a></div>`;
+    document.body.appendChild(ov);
+    const close=()=>{ try{ ov.remove(); }catch(_){} };
+    ov.addEventListener('click',e=>{ if(e.target===ov) close(); });
+    const xb=ov.querySelector('.co-detail-x'); if(xb) xb.onclick=close;
+    /* (#R146) Compare from the detail (Countries parity): add this company; open the compare view once ≥2 are selected */
+    const cmpB=ov.querySelector('[data-cmp]'); if(cmpB) cmpB.onclick=()=>{ const wasIn=HOST.coCompareSet.has(c.tk);
+      try{ window._coToggleCompare(c.tk); }catch(_){} try{ HOST.renderCoCompareFixed(); }catch(_){}
+      if(!wasIn && HOST.coCompareSet.size>=2){ close(); try{ window._coShowCompare(); }catch(_){} }
+      else { close(); } };
+    const img=ov.querySelector('.co-logo'); if(img) _coWireLogo(img);   /* (#R147) shared cached-logo wiring */
+    /* (#R153) real share-price SPARKLINE in the detail (Countries-parity enrichment — the detail was a static rows-only
+       stub). Uses the same monthly full-history data as the compare Time-series; snapshot-only names show an honest note. */
+    if(c.sh>0){ (async()=>{ try{ const cur=new Date().getFullYear(), from=cur-15, to=cur;
+        const data=await IntMapCompanies.priceSeriesFine(c.tk, from, to); const el=document.getElementById('co-detail-spark'); if(!el) return;
+        const pts=(data||[]).filter(p=>p&&p[1]>0);
+        if(pts.length<2){ el.innerHTML='<div class="co-spark-note">'+HOST._coL('No share-price history (snapshot figure only).','株価履歴なし（スナップショットのみ）。','Kein Kursverlauf (nur Momentaufnahme).','Нет истории цен (только снимок).','Sin histórico (solo instantánea).')+'</div>'; return; }
+        const W=280,H=52,pad=3; let vmin=Infinity,vmax=-Infinity; const fmin=pts[0][0], fmax=pts[pts.length-1][0];
+        pts.forEach(p=>{ if(p[1]<vmin)vmin=p[1]; if(p[1]>vmax)vmax=p[1]; });
+        const span=(vmax-vmin)||1, fsp=(fmax-fmin)||1; const X=f=>pad+(f-fmin)/fsp*(W-2*pad), Y=v=>pad+(1-(v-vmin)/span)*(H-2*pad);
+        const d=pts.map((p,i)=>(i?'L':'M')+X(p[0]).toFixed(1)+' '+Y(p[1]).toFixed(1)).join(' ');
+        const first=pts[0][1], last=pts[pts.length-1][1], chg=first>0?(last-first)/first*100:0, up=chg>=0, col=up?'#30d158':'#ff453a';
+        el.innerHTML='<div class="co-spark-head"><span>'+HOST._coL('Share price','株価','Aktienkurs','Цена акции','Precio acción')+' · '+Math.round(fmin)+'–'+Math.round(fmax)+'</span><span style="color:'+col+';font-weight:700;">'+(up?'+':'')+chg.toFixed(0)+'%</span></div>'
+          +'<svg viewBox="0 0 '+W+' '+H+'" preserveAspectRatio="none" class="co-spark-svg"><path d="'+d+'" fill="none" stroke="'+col+'" stroke-width="1.6" vector-effect="non-scaling-stroke"/></svg>'
+          +'<div class="co-spark-note">$'+first.toFixed(2)+' → $'+last.toFixed(2)+' · '+HOST._coL('monthly close, split-adjusted (Yahoo)','月次終値・分割調整済（Yahoo）','Monatsschluss, splitbereinigt (Yahoo)','мес. закрытие, скорр. (Yahoo)','cierre mensual, ajustado (Yahoo)')+'</div>';
+      }catch(_){ const el=document.getElementById('co-detail-spark'); if(el) el.innerHTML=''; } })(); }
+  }
+
+  /* Cache & lazy-fetch the lead image from a Wikipedia URL */
+  const wikiImgCache={};
+
+  async function fetchWikiImage(wikiUrl){
+    if(!wikiUrl) return null;
+    if(wikiImgCache[wikiUrl]!==undefined) return wikiImgCache[wikiUrl];
+    try{
+      const m=wikiUrl.match(/^https?:\/\/([a-z]+)\.wikipedia\.org\/wiki\/(.+)$/);
+      if(!m) { wikiImgCache[wikiUrl]=null; return null; }
+      const lang=m[1], title=m[2];
+      const r=await fetch(`https://${lang}.wikipedia.org/api/rest_v1/page/summary/${title}`);
+      if(!r.ok){ wikiImgCache[wikiUrl]=null; return null; }
+      const j=await r.json();
+      const url=(j&&j.thumbnail&&j.thumbnail.source)||(j&&j.originalimage&&j.originalimage.source)||null;
+      wikiImgCache[wikiUrl]=url; return url;
+    }catch(e){ wikiImgCache[wikiUrl]=null; return null; }
+  }
+
+  function applyWikiImageBackground(info){
+    if(info.img||!info.wiki) return;
+    const wikiUrl=info.wiki[HOST.lang]||info.wiki.en;
+    fetchWikiImage(wikiUrl).then(url=>{
+      if(!url) return;
+      const card=document.getElementById('card-'+info.id); if(!card) return;
+      const img=card.querySelector('.wiki-card-img');
+      if(img){ img.style.backgroundImage=`url('${url}')`; img.classList.remove('wc-noimg'); }   /* (#R23) real image loaded → restore the gradient */
+    });
+  }
+
+  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
+  const {_DASH_BADGE}=window.IntMapTables;
+
+  function dashBadgeLabel(b){ if(!b||HOST.lang==='en') return b||''; const e=_DASH_BADGE[b]; return (e&&e[HOST.lang])||b; }
+
+  function renderDashboard(){
+    /* (#R139) The Information dashboard was RETIRED — the "info" tab is now COMPANIES. Every renderDashboard() call
+       site (tab render, ws window, search input, Supabase/cache hooks) delegates here, so they all render Companies
+       and can never clobber the Companies view. The original dashboard body below is retained (dead) to avoid
+       touching the many references it holds; it is unreachable. */
+    try{ return renderCompanies(); }catch(_){ }
+    const dash=document.getElementById('info-dashboard'); HOST.clearMarkers(); const dict=HOST.i18n[HOST.lang];
+    const q=(HOST.mode==='info')?HOST.searchVal():'';   /* live text filter (#27) */
+    /* (#R20) World Events Archive — the Information tab is split into Places (the original cards)
+       and Events (curated historical events, year-range + text searchable, plotted on the map). */
+    if(window._dashView==='events' && typeof window._renderEventsArchive==='function'){ window._renderEventsArchive(dash,q); return; }
+    const filtered=HOST.extendedDashDB.filter(i=>HOST.activeDashCategories.has(i.cat) && (!q ||
+      ((i.title.en+' '+(i.title.jp||'')+' '+(i.body.en||'')+' '+(i.body.jp||'')+' '+(i.badge||'')).toLowerCase().includes(q))));
+    /* Push features into WebGL source. Pins are mathematically placed by the GPU. */
+    HOST.dashFeatures=filtered.map(info=>({type:'Feature',id:info.id,geometry:{type:'Point',coordinates:info.loc},properties:{
+      fid:info.id, type:info.type, color:INFO_COLORS[info.type]||'#007aff',
+      title:info.title[HOST.lang]||info.title.en, body:info.body[HOST.lang]||info.body.en, layerRef:info.layerRef||''
+    }}));
+    /* Ensure pin layers exist NOW. Without this, on first tab-switch the source may not yet
+       have been created → pins appeared with a delay. */
+    if(map&&map.isStyleLoaded()) HOST.setupIntelLayers();
+    if(map&&map.getSource('dash-points')) map.getSource('dash-points').setData({type:'FeatureCollection',features:HOST.dashFeatures});
+    /* Sidebar cards */
+    let cards='<div class="dash-cards-container">';
+    filtered.forEach(info=>{
+      let specsHTML='';
+      if(info.specs){
+        const items=Object.entries(info.specs).map(([k,v])=>`<div class="spec-item"><span class="spec-label">${dict[k]||k}</span><span class="spec-value">${v[HOST.lang]||v.en||'—'}</span></div>`).join('');
+        if(items) specsHTML=`<div class="wiki-card-specs">${items}</div>`;
+      }
+      /* (#R23) imageless cards must NOT emit background-image:url('') and must NOT paint the dark ::before
+         gradient over the bare card — that overlay over the white card read as "うっすらグレーの四角いもの".
+         The wc-noimg class drops the gradient; the real image (+ its gradient) returns once it lazy-loads. */
+      const _cimg=info.img||'';
+      cards+=`<div class="wiki-card" id="card-${info.id}" onclick="flyToLoc(${info.loc[0]},${info.loc[1]})" onmouseenter="triggerLayerHover('${info.layerRef||''}',true); highlightDashMarker('${info.id}',true)" onmouseleave="triggerLayerHover('${info.layerRef||''}',false); highlightDashMarker('${info.id}',false)">
+        <div class="wiki-card-img${_cimg?'':' wc-noimg'}" data-type="${info.type||''}"${_cimg?` style="background-image:url('${_cimg}');"`:''}><span class="wiki-card-badge">${dashBadgeLabel(info.badge)}</span></div>
+        <div class="wiki-card-content"><h4 class="wiki-card-title">${info.title[HOST.lang]||info.title.en}</h4><p class="wiki-card-body">${info.body[HOST.lang]||info.body.en}</p>${specsHTML}<div class="wiki-card-footer"><a href="${IntMapSafe.html(IntMapSafe.url(info.wiki[HOST.lang]||info.wiki.en)||'#')}" target="_blank" rel="noopener" class="wiki-link" onclick="event.stopPropagation()">${dict.readWiki}</a></div></div></div>`;
+    });
+    cards+='</div>';
+    /* (#R20) top-level Places | Events switch, then the existing category nav */
+    const seg=`<div class="dash-nav"><button class="dash-nav-btn active" onclick="_setDashView('places')">${({en:'📍 Places',jp:'📍 場所',de:'📍 Orte',ru:'📍 Места',es:'📍 Lugares'})[HOST.lang]||'📍 Places'}</button><button class="dash-nav-btn" onclick="_setDashView('events')">${({en:'🗓 Events',jp:'🗓 出来事',de:'🗓 Ereignisse',ru:'🗓 События',es:'🗓 Eventos'})[HOST.lang]||'🗓 Events'}</button></div>`;
+    const nav=`<div class="dash-nav" id="dash-nav"><button class="dash-nav-btn ${HOST.activeDashCategories.has('mil')?'active':''}" onclick="toggleDashCat('mil')">${dict.dashCatMil}</button><button class="dash-nav-btn ${HOST.activeDashCategories.has('tech')?'active':''}" onclick="toggleDashCat('tech')">${dict.dashCatTech}</button><button class="dash-nav-btn ${HOST.activeDashCategories.has('maritime')?'active':''}" onclick="toggleDashCat('maritime')">${dict.dashCatMar}</button><button class="dash-nav-btn ${HOST.activeDashCategories.has('geo')?'active':''}" onclick="toggleDashCat('geo')">${dict.dashCatGeo}</button></div>`;
+    dash.innerHTML=seg+nav+cards;
+    /* Mouse wheel → horizontal scroll on the category nav */
+    const dnav=document.getElementById('dash-nav');
+    if(dnav){ dnav.addEventListener('wheel',(e)=>{ if(e.deltaY===0)return; e.preventDefault(); dnav.scrollLeft+=e.deltaY+e.deltaX; },{passive:false}); }
+    /* Lazy-fetch Wikipedia thumbnails for cards without an explicit image */
+    filtered.forEach(info=>{ if(!info.img) applyWikiImageBackground(info); });
+  }
+
+  /* The names index.html still calls: it keeps a hoisted shim for each (#R168). */
+  return { renderCompanies, showCompanyDetail, renderDashboard, _coCmpEnsureCss, _coCmpRender };
+};

--- a/js/countries-ui.js
+++ b/js/countries-ui.js
@@ -1,0 +1,402 @@
+/* ============================================================================
+ *  IntMap · Countries tab & country detail  (#R168)
+ * ----------------------------------------------------------------------------
+ *  The Countries subject: the boundary/stat loader, the map country layers, the ranked country
+ *  list, the country card and its detail body. Fifteen closure statements — nine function
+ *  declarations and six small tables/caches that only this subject reads.
+ *  index.html keeps a hoisted shim for each of the five names it still calls by name.
+ *
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure: the only edit is that free
+ *  references to closure variables became HOST.<member> reads (Architecture.md §3.1). The
+ *  extraction was done by script and reversed byte-for-byte against the original text.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.countriesUi=function(map,HOST){
+  const GDP_YEAR='2023', POP_YEAR='2024';
+
+  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
+  const {GDP,HDI,DEM,MILSPEND,LIFE,INTERNET,CAPITAL,CURRENCY,LANGS}=window.IntMapTables;
+
+  function flagFromISO2(a2){ if(!a2||a2.length!==2||a2==='-9')return'🏳️'; try{return a2.toUpperCase().replace(/./g,c=>String.fromCodePoint(127397+c.charCodeAt(0)));}catch(e){return'🏳️';} }
+
+  function loadCountryData(){
+    if(HOST.countryDataPromise) return HOST.countryDataPromise;
+    HOST.countryDataPromise=(async()=>{
+      try{
+        let gj=null;
+        /* (#R13) Highest-resolution Natural Earth borders (10 m) so the boundary lines are crisp and
+           track the real borders — the user reported the 50 m lines were too coarse and ran parallel-
+           offset from reality. 10 m gzips to ~4.7 MB and loads async (doesn't block the map), with a
+           graceful fall back to 50 m then 110 m if it can't be fetched. */
+        const NE='https://cdn.jsdelivr.net/gh/nvkelso/natural-earth-vector@master/geojson/';
+        try{ const r=await fetch(NE+'ne_10m_admin_0_countries.geojson'); if(r.ok) gj=await r.json(); }catch(e){}
+        if(!(gj&&gj.features)){ try{ const r=await fetch(NE+'ne_50m_admin_0_countries.geojson'); if(r.ok) gj=await r.json(); }catch(e){} }
+        if(!(gj&&gj.features)){ try{ const r=await fetch(NE+'ne_110m_admin_0_countries.geojson'); if(r.ok) gj=await r.json(); }catch(e){} }
+        if(gj&&gj.features){
+          HOST.countryGeo=gj; window.countryGeo=HOST.countryGeo;   /* reused by the projection viewer (#16,#17) */
+          gj.features.forEach(f=>{
+            const p=f.properties||{};
+            let code=(p.ISO_A3_EH&&p.ISO_A3_EH!=='-99')?p.ISO_A3_EH:((p.ISO_A3&&p.ISO_A3!=='-99')?p.ISO_A3:(p.ADM0_A3||''));
+            if(!code||code==='-99'){ f.id=undefined; return; }
+            f.id=code; if(f.properties) f.properties.__code=code;  /* used as promoteId so feature ids are stable codes */
+            let area=0; try{ area=turf.area(f)/1e6; }catch(e){}
+            /* (#R15) Natural Earth 10 m assigns minor territory polygons (Ashmore & Cartier, Coral Sea
+               Islands, Indian Ocean Territories …) the SOVEREIGN's ISO_A3_EH code. Whichever such polygon
+               came last in the file overwrote the real country's name/stats — e.g. "Australia" turned into
+               a tiny territory's name. Keep the LARGEST-area feature per code so the mainland always wins. */
+            const existing=HOST.countryStats[code];
+            if(existing && existing._area!=null && existing._area>=area) return;
+            const pop=+p.POP_EST||0;
+            const gdp=(GDP[code]!=null)?GDP[code]:(p.GDP_MD!=null?+p.GDP_MD/1000:(p.GDP_MD_EST!=null?+p.GDP_MD_EST/1000:null));
+            const a2=(p.ISO_A2_EH&&p.ISO_A2_EH!=='-99')?p.ISO_A2_EH:p.ISO_A2;
+            /* (#R23) flag non-sovereign / unrecognized features (Scarborough Shoal, Bir Tawil, Bajo Nuevo,
+               ice fields …) so "Random country" + quizzes never serve them as if they were states. */
+            const _nonSov=(p.TYPE==='Indeterminate')||/indetermin|unrecogn/i.test(String(p.FCLASS_TLC||p.featurecla||p.FEATURECLA||''));
+            HOST.countryStats[code]={ code, ccn3:String(p.ISO_N3||''), nameEn:p.NAME_EN||p.ADMIN||p.NAME||code, nameJp:p.NAME_JA||p.NAME_EN||p.ADMIN||code,
+              sov:!_nonSov,
+              pop, area:Math.round(area), _area:area, density:(pop&&area)?pop/area:null, region:p.CONTINENT||'', subregion:p.SUBREGION||'',
+              capital:CAPITAL[code]||'', latlng:(p.LABEL_Y!=null&&p.LABEL_X!=null)?[+p.LABEL_Y,+p.LABEL_X]:null, flag:flagFromISO2(a2),
+              currency:CURRENCY[code]||'', languages:LANGS[code]||'', gdp, gdppc:(gdp&&pop)?(gdp*1e9/pop):null,
+              hdi:HDI[code]||null, dem:DEM[code]||null, milSpend:MILSPEND[code]||null, lifeExp:LIFE[code]||null, internet:INTERNET[code]||null };
+          });
+        }
+      }catch(e){ console.warn('country load failed',e); }
+      finally{
+        /* (#R40) ROOT CAUSE of "Isolate / Country borders / Countries(info) を押しても反応しない、再読み込みで治る":
+           if the FIRST border-GeoJSON fetch failed (slow/blocked CDN on a cold load), countryGeo stayed null
+           but countryDataPromise stayed RESOLVED FOREVER, so every later call short-circuited on the cached
+           (empty) promise and nothing ever worked — until a full page reload reset the promise. Now, on a
+           FAILED load, clear the cached promise + flags so the very next call (a click) transparently retries
+           the fetch. On success, latch as before. */
+        const ok=!!(HOST.countryGeo&&HOST.countryGeo.features&&HOST.countryGeo.features.length);
+        if(ok){ HOST.countryDataLoaded=true; if(map&&map.isStyleLoaded()) addCountryLayers();
+          /* (#R25/#28) now that countryStats exists, rebuild the geo index so the auto-country/capital
+             entries join the gazetteer → the non-AI news locator gains full global coverage. */
+          try{ HOST.rebuildGeoIndex(); }catch(_){}
+          /* (#R127) borders are here now → re-spread any live news pins that were placed as a tight blob while
+             countryGeo was still loading (regionFor had no polygon), so country clusters fill the real territory. */
+          try{ if(typeof HOST._respreadNews==='function') HOST._respreadNews(); }catch(_){}
+        } else { HOST.countryDataLoaded=false; HOST.countryDataPromise=null; }
+      } }
+    )();
+    HOST.countryDataPromise.then(()=>{ try{ HOST.loadGdpPPP(); }catch(_){} });   /* (#R22) enrich with PPP once base stats exist */
+    return HOST.countryDataPromise;
+  }
+
+  let hoveredCid=null;
+
+  function addCountryLayers(){
+    if(!map||!map.isStyleLoaded()||!HOST.countryGeo||map.getSource('countries')) return;
+    map.addSource('countries',{type:'geojson',data:HOST.countryGeo,promoteId:'__code'});
+    map.addLayer({id:'country-fill',type:'fill',source:'countries',layout:{visibility:'none'},paint:{'fill-color':'#007aff','fill-opacity':['case',['boolean',['feature-state','hover'],false],0.30,0]}},'tool-poly');
+    map.addLayer({id:'country-line',type:'line',source:'countries',layout:{visibility:'none'},paint:{'line-color':'#007aff','line-opacity':0.7,'line-width':['case',['boolean',['feature-state','hover'],false],2.4,0.6]}},'tool-poly');
+    /* (#R26) Create the always-on country-BORDERS line HERE (when the countries source first exists), not
+       only inside the cb-borders change handler — that lazy-create meant borders were checked-by-default but
+       NOT drawn on load until you re-toggled them ("デフォルト選択されているのに表示されない"). applyTheme()
+       sets its visibility from bordersOn (default true). */
+    try{ HOST.ensureBordersLayer(); }catch(_){}   /* (#R40) borders-only-line now comes from the OFM boundary layer (accurate, basemap-aligned) — created here too in case Countries(info) initializes first */
+    map.on('mousemove','country-fill',(e)=>{ if(!HOST.countryInfoOn||HOST.toolMode||!e.features.length)return;
+      /* (#R130) during time-travel do NOT highlight / read out the MODERN country under the cursor — that showed
+         modern Ukraine/Lithuania info while hovering interwar Poland. The era name labels identify countries; the
+         click handler above resolves the era entity on demand. */
+      if(window.IntMapTimeBorders&&window.IntMapTimeBorders.active&&window.IntMapTimeBorders.active()){ if(hoveredCid!==null){ try{ map.setFeatureState({source:'countries',id:hoveredCid},{hover:false}); }catch(_){} hoveredCid=null; } return; }
+      const f=e.features[0]; if(hoveredCid!==null)map.setFeatureState({source:'countries',id:hoveredCid},{hover:false}); hoveredCid=f.id; map.setFeatureState({source:'countries',id:hoveredCid},{hover:true}); showCountryInfo(f); });
+    map.on('mouseleave','country-fill',()=>{ if(hoveredCid!==null)map.setFeatureState({source:'countries',id:hoveredCid},{hover:false}); hoveredCid=null; HOST.hideCountryInfo(); });
+    /* (#R130) ROOT CAUSE of the long-standing "昔の年代でも地図クリック国選択が現代国境になる" re-report (survived
+       R122–R129): every prior round fixed the era-aware CROSSHAIR pickers (#scp-pick / #csearch-pick) + the resolveHist
+       ladder — which were already correct — but the gesture the user actually performs, a PLAIN click on a country
+       during time-travel, was handled by THIS era-UNAWARE country-fill handler. It resolved against the MODERN
+       countryGeo, so clicking interwar Poland's Lwów gave modern Ukraine and Vilnius gave modern Lithuania (Warsaw/
+       Kraków only looked "right" because their modern carrier is still POL — hence the intermittent, 1920s-Poland
+       feel). Now, during travel, the plain click routes through the SAME era PIP → resolveHist path the pickers use
+       and NEVER falls back to the modern polygon. */
+    map.on('click','country-fill',(e)=>{ if(!(HOST.countryInfoOn&&!HOST.toolMode&&!window.__scpPick&&e.features.length)) return;
+      const TB=window.IntMapTimeBorders;
+      if(TB&&TB.active&&TB.active()){
+        try{
+          /* defer to a specific place label under the click (city / water / peak / river) so a city still opens as a
+             PLACE, exactly like the era name-label handler (_clk) does — only bare country land opens the country. */
+          const specific=['ofm-city','ofm-other','geo-sea','ofm-water','ofm-water2','ofm-river','ofm-peak'].filter(id=>{ try{ return !!map.getLayer(id); }catch(_){ return false; } });
+          if(specific.length&&e.point&&map.queryRenderedFeatures(e.point,{layers:specific}).length) return;
+          const ll=e.lngLat; let nm=null, geom=null; const fc=TB.currentFC&&TB.currentFC();
+          if(fc&&fc.features&&typeof turf!=='undefined'){ const tp=turf.point([ll.lng,ll.lat]); let bA=Infinity;
+            for(const ff of fc.features){ try{ if(ff.geometry&&turf.booleanPointInPolygon(tp,ff)){ const bb=turf.bbox(ff); const a=(bb[2]-bb[0])*(bb[3]-bb[1]); if(a<bA){ bA=a; nm=ff.properties&&(ff.properties.NAME||ff.properties.name); geom=ff.geometry; } } }catch(_){} } }
+          if(nm&&TB.resolveHist){ const R=TB.resolveHist(nm,ll)||{};
+            if(R.code&&HOST.countryStats[R.code]){ showCountryDetail(R.code, R.name||nm); return; }
+            /* a real era entity with no comparable stats carrier — open its era place popup (name/wiki/flag), not the
+               modern country that sits there today. */
+            if(typeof window._imPlacePopup==='function'){ window._imPlacePopup(ll,(R.name||nm),true,{geojson:(R.geometry||geom),wiki:(R.wiki||nm),flag:R.flag}); return; } }
+        }catch(_){}
+        return;   /* during travel, NEVER resolve a country click to the modern polygon */
+      }
+      const f=e.features[0]; const p=f.properties||{}; const id=HOST.resolveCountryId(f); showCountryDetail(id, p.NAME_EN||p.ADMIN||p.NAME); });
+    HOST.applyCountryVisibility();
+  }
+
+  const fmtNum=(n)=>n||n===0?Number(Math.round(n)).toLocaleString():'—';
+
+  const fmtArea=(a)=>a?Number(Math.round(a)).toLocaleString()+' km²':'—';
+
+  function showCountryInfo(feat){
+    const id=HOST.resolveCountryId(feat), s=HOST.countryStats[id], p=document.getElementById('country-info'),
+          name=HOST.cName(s,feat.properties&&(feat.properties.NAME_EN||feat.properties.ADMIN||feat.properties.NAME));
+    const haveAny = s && (s.pop||s.gdp||s.area||s.hdi||s.dem||s.milSpend);
+    p.innerHTML=`<div class="ci-name">${s&&s.flag?s.flag+' ':'🏳️ '}${name}</div>
+      <div class="ci-row"><span>${HOST.t('statPop')} (${POP_YEAR})</span><b>${s&&s.pop?fmtNum(s.pop):HOST.t('dataNA')}</b></div>
+      <div class="ci-row"><span>${HOST.t('statGdp')} (${GDP_YEAR})</span><b>${s&&s.gdp?HOST.fmtMoney(s.gdp):HOST.t('dataNA')}</b></div>
+      <div class="ci-row"><span>${HOST.t('statGdpPPP')}</span><b>${s&&s.gdpPPP?HOST.fmtMoney(s.gdpPPP):HOST.t('dataNA')}</b></div>
+      <div class="ci-row"><span>${HOST.t('statGdpPc')}</span><b>${s&&s.gdppc?HOST.fmtPc(s.gdppc):HOST.t('dataNA')}</b></div>
+      <div class="ci-row"><span>${HOST.t('statGdpPcPPP')}</span><b>${s&&s.gdppcPPP?HOST.fmtPc(s.gdppcPPP):HOST.t('dataNA')}</b></div>
+      <div class="ci-row"><span>${HOST.t('statHDI')}</span><b>${s&&s.hdi?s.hdi.toFixed(3):HOST.t('dataNA')}</b></div>
+      <div class="ci-row"><span>${HOST.t('statDem')}</span><b>${s&&s.dem?s.dem.toFixed(2):HOST.t('dataNA')}</b></div>
+      <div class="ci-row"><span>${HOST.t('statMil')}</span><b>${s&&s.milSpend?'$'+s.milSpend+'B':HOST.t('dataNA')}</b></div>
+      <div class="ci-row"><span>${HOST.t('statCapital')}</span><b>${s&&s.capital?s.capital:HOST.t('dataNA')}</b></div>
+      <div class="ci-row"><span>${HOST.t('statArea')}</span><b>${s&&s.area?fmtArea(s.area):HOST.t('dataNA')}</b></div>`;
+    p.style.display='block';
+  }
+
+  async function enrichCountry(id){
+    if(!id) return null;
+    const s=HOST.countryStats[id];
+    if(!s) return null;
+    if(s._enrichedTried) return s;
+    s._enrichedTried=true;
+    try{
+      const r=await fetch(`https://restcountries.com/v3.1/alpha/${encodeURIComponent(id)}?fields=name,capital,languages,currencies,population,area,region,subregion,flag,latlng,timezones,car,callingCodes,demonyms,borders,independent,unMember`);
+      if(!r.ok) return s;
+      const j=await r.json(); const c=Array.isArray(j)?j[0]:j; if(!c) return s;
+      if(!s.capital && c.capital && c.capital.length) s.capital=c.capital[0];
+      if(!s.languages && c.languages) s.languages=Object.values(c.languages).join(', ');
+      if(!s.currency && c.currencies){ const cur=Object.entries(c.currencies)[0]; if(cur) s.currency=`${cur[0]}${cur[1]&&cur[1].name?' ('+cur[1].name+')':''}`; }
+      if(!s.pop && c.population) s.pop=c.population;
+      if((!s.area||s.area<1) && c.area) s.area=c.area;
+      if(!s.density && s.pop && s.area) s.density=s.pop/s.area;
+      if(!s.region && c.region) s.region=c.region;
+      if(!s.subregion && c.subregion) s.subregion=c.subregion;
+      if((!s.flag||s.flag==='🏳️') && c.flag) s.flag=c.flag;
+      if(!s.latlng && c.latlng && c.latlng.length===2) s.latlng=c.latlng;
+      if(c.timezones) s.timezones=c.timezones;
+      if(c.borders) s.borders=c.borders;
+      if(c.independent!=null) s.independent=c.independent;
+      if(c.unMember!=null) s.unMember=c.unMember;
+      if(c.demonyms){ const eng=c.demonyms.eng; if(eng){ s.demonym=(eng.m||eng.f||''); } }
+    }catch(e){}
+    return s;
+  }
+
+  function renderCountryDetailBody(s){
+    if(!s) return `<div class="cm-row"><span>${HOST.t('dataNA')}</span><b>—</b></div>`;
+    const _de=HOST.lang==='de', _jp=HOST.lang==='jp', _ru=HOST.lang==='ru', _es=HOST.lang==='es';
+    const TR=(en,jp,de,ru,es)=>_jp?jp:_de?de:_ru?ru:_es?(es||en):en;
+    const yn=v=>v?TR('Yes','はい','Ja','Да','Sí'):TR('No','いいえ','Nein','Нет','No');
+    const sec=(title,rows)=>{ const r=rows.filter(Boolean); if(!r.length) return ''; return `<div class="cp-sec"><div class="cp-sec-h">${title}</div>`+r.map(([k,v])=>`<div class="cm-row"><span>${k}</span><b>${v}</b></div>`).join('')+`</div>`; };
+    const geo=sec('🌍 '+TR('Geography','地理','Geografie','География','Geografía'),[
+      [HOST.t('statRegion'),(s.region||'—')+(s.subregion?' / '+s.subregion:'')],
+      [HOST.t('statCapital'),s.capital||'—'],
+      [HOST.t('statArea'),fmtArea(s.area)],
+      [HOST.t('statDensity'),s.density?fmtNum(Math.round(s.density))+' /km²':'—'],
+      (s.borders&&s.borders.length)?[TR('Borders','隣接','Nachbarländer','Соседи','Fronteras'),s.borders.join(', ')]:null,
+      (s.timezones&&s.timezones.length)?[TR('Timezones','時間帯','Zeitzonen','Часовые пояса','Zonas horarias'),s.timezones.slice(0,3).join(', ')+(s.timezones.length>3?'…':'')]:null
+    ]);
+    /* (#R94) when the master clock has travelled to a past year, the WB-synced rows carry THAT year;
+       HDI (UNDP) and the Democracy Index (EIU) have no WB annual series so they keep their own year. */
+    const _ty=(typeof window!=='undefined'&&window._imTimeYear)||null; const YR=(def)=>_ty||def; const yrTag=()=>(_ty?` (${_ty})`:'');
+    const _milB=(v)=>'$'+(Math.round(v*10)/10)+'B';
+    const econ=sec('💰 '+TR('Economy','経済','Wirtschaft','Экономика','Economía'),[
+      [((s._real||window._imTimeReal)?('GDP · '+TR('real 2011 int$','実質2011年国際ドル','real, int$ 2011','реальный, межд.$ 2011','real int$ 2011')):HOST.t('statGdp'))+` (${YR(GDP_YEAR)})`,HOST.fmtMoney(s.gdp)],
+      s.gdpPPP?[HOST.t('statGdpPPP'),HOST.fmtMoney(s.gdpPPP)]:null,
+      [HOST.t('statGdpPc')+yrTag(),HOST.fmtPc(s.gdppc)],
+      s.gdppcPPP?[HOST.t('statGdpPcPPP'),HOST.fmtPc(s.gdppcPPP)]:null,
+      [HOST.t('statCurrency'),s.currency||'—']
+    ]);
+    const soc=sec('👥 '+TR('Society','社会','Gesellschaft','Общество','Sociedad'),[
+      [HOST.t('statPop')+` (${YR(POP_YEAR)})`,fmtNum(s.pop)],
+      s.hdi?[HOST.t('statHDI')+' (2022)',s.hdi.toFixed(3)]:null,
+      s.lifeExp?[HOST.t('statLife')+yrTag(),s.lifeExp.toFixed(1)+' '+TR('yr','年','J','лет','a')]:null,
+      s.internet?[HOST.t('statInet')+yrTag(),(Math.round(s.internet*10)/10)+'%']:null,
+      [HOST.t('statLang'),s.languages||'—']
+    ]);
+    const pol=sec('🏛 '+TR('Politics & defense','政治・防衛','Politik & Verteidigung','Политика и оборона','Política y defensa'),[
+      s.dem?[HOST.t('statDem')+' (2023)',s.dem.toFixed(2)]:null,
+      s.milSpend?[HOST.t('statMil')+` (${YR(2023)})`,_milB(s.milSpend)]:null,
+      s.unMember!=null?[TR('UN member','国連加盟','UN-Mitglied','Член ООН','Miembro de la ONU'),yn(s.unMember)]:null
+    ]);
+    let histNote='';
+    if(s._hist){ const yrs=(s._from?s._from.slice(0,4):'')+'–'+(s._to?s._to.slice(0,4):'');
+      histNote=`<div class="cp-histnote">🏛 <b>${TR('Former state','かつて存在した国家','Ehemaliger Staat','Бывшее государство','Estado desaparecido')}</b> · ${yrs}<br>${TR('GDP & population: Maddison Project (real GDP, 2011 int$). Other indicators: World Bank aggregate of the successor states.','GDP・人口: マディソン・プロジェクト（実質GDP・2011年国際ドル）。その他の指標: 後継国の世界銀行データを合算。','BIP & Bevölkerung: Maddison-Projekt (reales BIP, int$ 2011). Übrige: Weltbank-Summe der Nachfolgestaaten.','ВВП и население: проект Мэддисона (реальный ВВП, межд.$ 2011). Прочее: сумма стран-преемников (Всемирный банк).','PIB y población: Proyecto Maddison (PIB real, int$ 2011). Resto: suma del Banco Mundial de los estados sucesores.')} ${TR('Borders on the map follow the era.','地図の国境も当時のものになります。','Grenzen folgen der Epoche.','Границы на карте — той эпохи.','Las fronteras del mapa siguen la época.')}</div>`; }
+    return `<div id="cp-intro" class="cp-intro"></div>`+histNote+geo+econ+soc+pol;
+  }
+
+  /* (#R39) Fill the intro with a Wikipedia summary (extract + thumbnail + link) in the active language. */
+  const _cpIntroCache={};
+
+  function _fillCountryIntro(name){
+    try{
+      const intro=document.getElementById('cp-intro'); if(!intro||!name) return;
+      const wl=HOST.lang==='jp'?'ja':HOST.lang==='de'?'de':HOST.lang==='ru'?'ru':HOST.lang==='es'?'es':'en';
+      const key=wl+':'+name;
+      const esc=tt=>String(tt==null?'':tt).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+      const paint=(html)=>{ const i2=document.getElementById('cp-intro'); if(i2&&html) i2.innerHTML=html; };
+      if(_cpIntroCache[key]!=null){ paint(_cpIntroCache[key]); return; }   /* re-render flash-free */
+      fetch('https://'+wl+'.wikipedia.org/api/rest_v1/page/summary/'+encodeURIComponent(String(name).replace(/ /g,'_')))
+        .then(r=>r.ok?r.json():null).then(j=>{
+          if(!j || j.type==='disambiguation'){ _cpIntroCache[key]=''; return; }
+          const extract=j.extract||'', img=(j.thumbnail&&j.thumbnail.source)||'', url=(j.content_urls&&j.content_urls.desktop&&j.content_urls.desktop.page)||'';
+          if(!extract && !img){ _cpIntroCache[key]=''; return; }
+          const html=(img?'<img src="'+esc(img)+'" alt="" class="cp-intro-img" loading="lazy">':'')
+            +(extract?'<p class="cp-intro-text">'+esc(extract)+'</p>':'')
+            +(url?'<a href="'+esc(url)+'" target="_blank" rel="noopener" class="cp-wiki-link">'+HOST.t('readWiki')+'</a>':'');
+          _cpIntroCache[key]=html; paint(html);
+        }).catch(()=>{});
+    }catch(_){}
+  }
+
+  function showCountryDetail(id,fallback){
+    const idStr=String(id||'');
+    let s=HOST.countryStats[idStr];
+    const name=HOST.cName(s,fallback);
+    const popup=document.getElementById('country-popup');
+    document.getElementById('cp-title').innerHTML=(s&&s.flag?s.flag+' ':'🏳️ ')+name;
+    const body=document.getElementById('cp-body');
+    window._cpCurrent={code:idStr,name:name};   /* read by the isolate + time-series buttons */
+    const _isoSvg='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8V5a2 2 0 0 1 2-2h3M16 3h3a2 2 0 0 1 2 2v3M21 16v3a2 2 0 0 1-2 2h-3M8 21H5a2 2 0 0 1-2-2v-3"/></svg>';
+    const _tsSvg='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m7 14 4-4 3 3 5-6"/></svg>';
+    const _topBtnCss='flex:1;display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:9px 6px;border:none;border-radius:10px;background:var(--input-bg);color:var(--text-main);font-weight:600;font-size:12px;cursor:pointer;';
+    const _aiSvg='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v3M5.6 5.6l2.1 2.1M3 12h3M18 12h3M16.3 7.7l2.1-2.1"/><circle cx="12" cy="14" r="5"/></svg>';
+    const _cmpSvg='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 20V10M12 20V4M18 20v-7"/></svg>';
+    const _aiName=encodeURIComponent(name).replace(/'/g,'%27');
+    const topBtns=()=>`<div style="display:flex;gap:6px;margin:0 0 12px;">`
+      +`<button onclick="window.IntMapIsolate&&window.IntMapIsolate.enter((window._cpCurrent||{}).code)" style="${_topBtnCss}"><span style="color:var(--primary-color);display:inline-flex;">${_isoSvg}</span>${HOST.lang==='de'?'Nur dieses Land':HOST.lang==='jp'?'この国だけ':HOST.lang==='ru'?'Только эту страну':'Isolate'}</button>`
+      +`<button onclick="window.IntMapTimeSeries&&window.IntMapTimeSeries.open()" style="${_topBtnCss}"><span style="color:var(--primary-color);display:inline-flex;">${_tsSvg}</span>${HOST.lang==='de'?'Zeitverlauf':HOST.lang==='jp'?'時系列グラフ':HOST.lang==='ru'?'Динамика':'Time-series'}</button>`
+      +`<button onclick="try{var _n=decodeURIComponent('${_aiName}'),_l=(window._cpCurrent&&window._cpCurrent._ll)||null;if(window.IntMapConsole&&window.IntMapConsole.brief){window.IntMapConsole.brief(_n,_l);}else if(window.IntMapAIResearch){window.IntMapAIResearch.open(_n,_l);}}catch(e){}" style="${_topBtnCss}"><span style="color:var(--primary-color);display:inline-flex;">${_aiSvg}</span>${HOST.lang==='de'?'KI-Bericht':HOST.lang==='jp'?'AI調査':HOST.lang==='ru'?'ИИ-справка':'AI brief'}</button>`
+      +`<button onclick="try{window.IntMapStatsCompare&&window.IntMapStatsCompare.open()}catch(e){}" style="${_topBtnCss}"><span style="color:var(--primary-color);display:inline-flex;">${_cmpSvg}</span>${HOST.lang==='de'?'Vergleichen':HOST.lang==='jp'?'国を比較':HOST.lang==='ru'?'Сравнить':HOST.lang==='es'?'Comparar':'Compare'}</button>`
+      +`</div>`;
+    if(s && s.latlng) window._cpCurrent._ll={lng:s.latlng[1],lat:s.latlng[0]};
+    body.innerHTML=topBtns()+renderCountryDetailBody(s);
+    _fillCountryIntro((s&&(s._hist||s._histId)&&s.wiki)||name);
+    if(s && s.latlng&&map) map.flyTo({center:[s.latlng[1],s.latlng[0]],zoom:3.5,speed:1.0});
+    /* Asynchronously enrich and re-render (#R9b: keep the action buttons at the top) */
+    if(s) enrichCountry(idStr).then(()=>{ if(popup.style.display==='block'){ body.innerHTML=topBtns()+renderCountryDetailBody(HOST.countryStats[idStr]); _fillCountryIntro((s&&(s._hist||s._histId)&&s.wiki)||name); } document.getElementById('cp-title').innerHTML=(s.flag?s.flag+' ':'🏳️ ')+HOST.cName(s,fallback); });
+    /* (#R94) let the time-machine refresh THIS card's numbers in place (no re-fly / no re-fetch) when the
+       global clock moves — closes over the live idStr/body/topBtns for the currently-open country. */
+    window._imCountryCardRefresh=()=>{ try{ if(popup.style.display!=='block'||!window._cpCurrent||window._cpCurrent.code!==idStr) return; const s2=HOST.countryStats[idStr]; if(s2&&body){ body.innerHTML=topBtns()+renderCountryDetailBody(s2); _fillCountryIntro((s&&(s._hist||s._histId)&&s.wiki)||name); } }catch(_){} };
+    popup.style.display='block';
+    /* Initial centered position (viewport coords). Drag handle wires in once. */
+    if(!popup.dataset.placed){
+      const vw=window.innerWidth, vh=window.innerHeight;
+      const w=popup.offsetWidth||380, h=popup.offsetHeight||400;
+      popup.style.left=Math.max(12,(vw-w)/2)+'px';
+      popup.style.top=Math.max(60,(vh-h)/2)+'px';
+      popup.dataset.placed='1';
+      HOST.makeDraggable(popup, popup.querySelector('.country-popup-header'));
+    }
+  }
+
+  function renderStats(q){
+    const feed=document.getElementById('countries-feed')||document.getElementById('live-news-feed'); HOST.clearMarkers();
+    /* (#R69) the 5-country comparison view owns the feed while it is open — a deferred renderStats (e.g. the
+       loadCountryData().then below firing after the user opened the comparison) must NOT clobber it; its own
+       "Back to statistics" button removes the view before calling renderStats. */
+    if(document.getElementById('scp-view')) return;
+    if(!HOST.countryDataLoaded){ feed.innerHTML=`<div class="empty-msg">${HOST.t('loadingData')}</div>`; loadCountryData().then(()=>{ if(HOST.mode==='stats')renderStats(HOST.searchVal()); }); return; }
+    /* (#R94b) hide successors while a former state is shown. (#R101) also drop non-sovereign geographic features
+       (reefs / glaciers / no-man's-land — Scarborough Shoal, Southern Patagonian Ice Field, Bir Tawil …) that are
+       flagged sov:false; they are neither states, unrecognized states, nor regions and don't belong in Countries. */
+    let arr=Object.values(HOST.countryStats).filter(s=>s.nameEn && !s._histHidden && s.sov!==false);
+    if(arr.length===0){ feed.innerHTML=`<div class="empty-msg">${HOST.t('noData')}</div>`; return; }
+    if(q) arr=arr.filter(s=>s.nameEn.toLowerCase().includes(q)||(s.nameJp&&s.nameJp.includes(q)));
+    /* (#R122) apply the numeric threshold filters (each active condition must hold; a country missing that
+       indicator is excluded from a threshold on it — honest, not counted as passing). */
+    const _actF=HOST.statsFilters.filter(f=>f&&f.key&&isFinite(f.val));
+    if(_actF.length) arr=arr.filter(s=>_actF.every(f=>{ const v=s[f.key]; if(!isFinite(v)) return false; return f.op==='lte'?(v<=f.val):(v>=f.val); }));
+    const key=HOST.statsSort, dir=HOST.statsSortDir;
+    /* (#R102) sort by the chosen indicator in the chosen direction. Numeric: missing/zero values sort to the END in
+       BOTH directions (so ascending never fills the top with un-populated countries). Name: locale-aware A–Z / Z–A. */
+    arr.sort((a,b)=>{
+      if(key==='name'){ const av=(HOST.lang==='jp'?(a.nameJp||a.nameEn||''):(a.nameEn||'')), bv=(HOST.lang==='jp'?(b.nameJp||b.nameEn||''):(b.nameEn||'')); const c=av.localeCompare(bv,HOST.lang==='jp'?'ja':undefined); return dir==='asc'?c:-c; }
+      const av=a[key], bv=b[key]; const aOk=isFinite(av)&&av>0, bOk=isFinite(bv)&&bv>0;
+      if(!aOk&&!bOk) return 0; if(!aOk) return 1; if(!bOk) return -1;
+      return dir==='asc'?(av-bv):(bv-av);
+    });
+    /* (#R102) indicator PULLDOWN + ascending/descending toggle (replaces the old button row). */
+    /* (#R105) + GDP per capita, GDP (PPP) and GDP per capita (PPP) selectable in the Countries pulldown (real WB data). */
+    const IND=[['gdp',HOST.t('sortGdp')],['gdppc',HOST.t('statGdpPc')],['gdpPPP',HOST.t('statGdpPPP')],['gdppcPPP',HOST.t('statGdpPcPPP')],['pop',HOST.t('sortPop')],['area',HOST.t('sortArea')],['hdi',HOST.t('sortHDI')],['milSpend',HOST.t('sortMil')],['lifeExp',HOST.t('sortLife')],['tfr',HOST.t('sortTfr')],['name',HOST.t('sortName')]];
+    /* (#R104) refined minimal SVG arrow instead of the plain-text ↑ / ↓ glyphs; both labels stacked so the button
+       width never changes on toggle (see .ssd-labels CSS). */
+    const _ssdArrow=up=>'<svg class="ssd-arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">'+(up?'<path d="M12 19.5V5M6.5 11l5.5-6 5.5 6"/>':'<path d="M12 4.5V19M6.5 13l5.5 6 5.5-6"/>')+'</svg>';
+    const dirLbl=_ssdArrow(dir==='asc')+'<span class="ssd-labels" data-dir="'+(dir==='asc'?'asc':'desc')+'"><span class="ssd-l ssd-l-asc">'+HOST.t('sortAsc')+'</span><span class="ssd-l ssd-l-desc">'+HOST.t('sortDesc')+'</span></span>';
+    /* (#R122) numeric-filter control next to the sort. Indicators = the sortable numeric ones (drop 'name'). */
+    const _FIND=IND.filter(([k])=>k!=='name');
+    const _nActF=HOST.statsFilters.filter(f=>f&&f.key&&isFinite(f.val)).length;
+    const _funnel='<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h18l-7 8v6l-4 2v-8z"/></svg>';
+    const filterBtn=`<button type="button" class="stats-filter-btn${HOST.statsFilterOpen?' on':''}${_nActF?' has':''}" onclick="_sfToggle()" title="${HOST._sfL('Filter by value','数値で絞り込み','Nach Wert filtern','Фильтр по значению','Filtrar por valor')}">${_funnel}${_nActF?`<span class="sf-badge">${_nActF}</span>`:''}</button>`;
+    const _sfPanel=(()=>{ if(!HOST.statsFilterOpen) return '';
+      const opts=(sel)=>_FIND.map(([k,l])=>`<option value="${k}"${sel===k?' selected':''}>${l}</option>`).join('');
+      const rows=HOST.statsFilters.map((f,i)=>`<div class="sf-row"><select onchange="_sfSetKey(${i},this.value)">${opts(f.key)}</select><select class="sf-op" onchange="_sfSetOp(${i},this.value)"><option value="gte"${f.op!=='lte'?' selected':''}>≥</option><option value="lte"${f.op==='lte'?' selected':''}>≤</option></select><input type="text" class="sf-val" value="${(f.raw||'').replace(/"/g,'&quot;')}" placeholder="${HOST._sfL('value (5M, 20000…)','値（5M, 20000…）','Wert','значение','valor')}" onchange="_sfSetVal(${i},this.value)"><button type="button" class="sf-x" onclick="_sfRemove(${i})" title="${HOST.t('remove')||'✕'}">✕</button></div>`).join('');
+      return `<div class="stats-filter-panel">${rows||`<div class="sf-empty">${HOST._sfL('No conditions yet.','条件がありません。','Keine Bedingungen.','Нет условий.','Sin condiciones.')}</div>`}<div class="sf-actions"><button type="button" class="sf-add" onclick="_sfAdd()">+ ${HOST._sfL('Add condition','条件を追加','Bedingung','Условие','Añadir')}</button>${HOST.statsFilters.length?`<button type="button" class="sf-clear" onclick="_sfClear()">${HOST._sfL('Clear','クリア','Löschen','Очистить','Limpiar')}</button>`:''}</div></div>`; })();
+    let html=`<div class="stats-toolbar"><select class="stats-sort-sel" onchange="setStatsSort(this.value)">${IND.map(([k,l])=>`<option value="${k}"${HOST.statsSort===k?' selected':''}>${l}</option>`).join('')}</select><button type="button" class="stats-sort-dir" onclick="toggleStatsSortDir()" title="${HOST.t('sortDir')}">${dirLbl}</button>${filterBtn}</div>${_sfPanel}`;
+    /* (#R101) in time-machine (historical) mode the figures are REAL GDP (Maddison, 2011 int$), not nominal. */
+    const _histY=window._imTimeYear||null;
+    /* (#R102) the value column now carries ONLY the number ($3.4T etc.) — no indicator name on the card, per request. */
+    const metricVal=(s)=>{ switch(key){
+      case 'pop': return fmtNum(s.pop);
+      case 'area': return fmtArea(s.area);
+      case 'gdppc': return (s.gdppc&&isFinite(s.gdppc))?('$'+Math.round(s.gdppc).toLocaleString()):'—';
+      case 'gdpPPP': return (s.gdpPPP&&isFinite(s.gdpPPP))?HOST.fmtMoney(s.gdpPPP):'—';
+      case 'gdppcPPP': return (s.gdppcPPP&&isFinite(s.gdppcPPP))?('$'+Math.round(s.gdppcPPP).toLocaleString()):'—';
+      case 'hdi': return s.hdi?(+s.hdi).toFixed(3):'—';
+      case 'milSpend': return s.milSpend?'$'+s.milSpend+'B':'—';
+      case 'lifeExp': return (s.lifeExp&&isFinite(s.lifeExp))?((+s.lifeExp).toFixed(1)+(HOST.lang==='jp'?'歳':HOST.lang==='de'?' J':HOST.lang==='ru'?' л':HOST.lang==='es'?' a':' yr')):'—';
+      case 'tfr': return (s.tfr&&isFinite(s.tfr))?(+s.tfr).toFixed(2):'—';
+      default: return HOST.fmtMoney(s.gdp);   /* gdp + name */
+    } };
+    /* (#R94/#R101) Time-machine status bar — year + the CURRENTLY-SORTED indicator. (#R103) it used to always say
+       "real GDP" no matter which indicator was chosen ("どの指標を選んでもGDPとなっている") — reflect the selection. */
+    const _L5b=(en,jp,de,ru,es)=>HOST.lang==='jp'?jp:HOST.lang==='de'?de:HOST.lang==='ru'?ru:HOST.lang==='es'?es:en;
+    const _bMetric=(key==='pop')?_L5b('population','人口','Bevölkerung','население','población')
+      :(key==='area')?_L5b('area','面積','Fläche','площадь','superficie')
+      :(key==='hdi')?'HDI'
+      :(key==='milSpend')?_L5b('military spending','軍事費','Militärausgaben','военные расходы','gasto militar')
+      :(key==='lifeExp')?_L5b('life expectancy','平均寿命','Lebenserwartung','прод. жизни','esperanza de vida')
+      :(key==='tfr')?_L5b('fertility rate','合計特殊出生率','Geburtenrate','рождаемость','fecundidad')
+      :_L5b('real GDP (2011 int$)','実質GDP（2011年国際ドル）','reales BIP (int$ 2011)','реальный ВВП (межд.$ 2011)','PIB real (int$ 2011)');
+    try{ const _ty=_histY, _pw=window._imTimePreWB;
+      if(_ty){ html+=`<div class="stats-timebanner"><b>${_ty}${HOST.lang==='jp'?'年':''}</b> · ${_bMetric}</div>`; }
+      else if(_pw){ html+=`<div class="stats-timebanner warn"><b>${_pw}</b> · ${HOST.lang==='jp'?'最新の入手可能な値':HOST.lang==='de'?'neueste verfügbare Werte':HOST.lang==='ru'?'последние доступные значения':HOST.lang==='es'?'últimos valores disponibles':'latest available figures'}</div>`; }
+    }catch(_){}
+    /* (#R70) the separate "Compare countries (up to 5)" button is RETIRED per instruction — country-row clicks
+       build the selection and the dock's view button opens the unified comparison. */
+    if(arr.length===0) html+=`<div class="empty-msg">${HOST.t('noMatch')}</div>`;
+    /* (#R137) optional rank number on the far left (Settings → "Rank numbers", default OFF). The rank is the row's
+       position in the CURRENT sort+filter, so it tracks whatever indicator/direction is active. */
+    const _showRank=(window.imShowRank!=='off');   /* (#R139) rank numbers now default ON (show unless explicitly turned off) */
+    /* (#R142) rank = the country's standing in the CURRENTLY-SORTED indicator by VALUE (largest = 1), NOT the row
+       position — so toggling ascending/descending actually moves "#1" (the old i+1 kept showing 1,2,3… top-to-bottom
+       for every sort/direction → "順序を変えても順位が変わらない"). In time-machine mode s[key] already holds the
+       historical value, so the rank is the historical rank. Name sort falls back to the GDP rank. Rank over the shown set. */
+    const _rankKey=(key==='name')?'gdp':key;
+    const _rankOf=new Map(); arr.slice().filter(s=>isFinite(s[_rankKey])&&s[_rankKey]>0).sort((a,b)=>b[_rankKey]-a[_rankKey]).forEach((s,ri)=>_rankOf.set(s.code,ri+1));
+    arr.forEach((s,i)=>{
+      const active=HOST.compareSet.has(s.code)?'compare-on':'';
+      /* (#R102) region / capital separated by a SLASH (was a middot); the value column shows the number only. */
+      const subline=`${s.region||''}${(s.region&&s.capital)?' / ':''}${s.capital||''}`;
+      const rankHTML=_showRank?`<span class="stat-rank">${_rankOf.get(s.code)||'—'}</span>`:'';
+      /* (#R115) native hover tooltip = the FULL country name (the .stat-name is ellipsized on narrow cards). */
+      html+=`<div class="stat-row ${active}" data-ccn="${s.code}" title="${String(HOST.cName(s)||'').replace(/"/g,'&quot;')}">${rankHTML}<span class="stat-flag">${s.flag||'🏳️'}</span><div class="stat-main"><div class="stat-name">${HOST.cName(s)}</div><div class="stat-sub">${subline}</div></div><div class="stat-val">${metricVal(s)}</div></div>`;
+    });
+    feed.innerHTML=html;
+    feed.querySelectorAll('.stat-row').forEach(row=>{
+      /* Single-click → add/remove from compare; double-click → open detail */
+      let clickTimer=null;
+      row.onclick=(e)=>{
+        if(clickTimer){ clearTimeout(clickTimer); clickTimer=null; showCountryDetail(row.getAttribute('data-ccn')); return; }
+        clickTimer=setTimeout(()=>{ window._toggleCompare(row.getAttribute('data-ccn')); clickTimer=null; },250);
+      };
+    });
+    feed.style.paddingBottom='92px';   /* leave room for the fixed compare panel */
+    HOST.renderCompareFixed();
+  }
+
+  /* The names index.html still calls: it keeps a hoisted shim for each (#R168). */
+  return { renderStats, showCountryDetail, renderCountryDetailBody, loadCountryData, addCountryLayers };
+};

--- a/js/news-ui.js
+++ b/js/news-ui.js
@@ -1,0 +1,557 @@
+/* ============================================================================
+ *  IntMap · News feed, pins & reader  (#R168)
+ * ----------------------------------------------------------------------------
+ *  The news presentation layer: the intel/news map layers, duplicate-pin spreading, the feed
+ *  renderer and its lazy batches, the article reader (with its AI translate) and the AI
+ *  geocoding pass. The news DATA pipeline (fetch/cache/filter) stays in index.html — this is
+ *  everything that turns it into pins and DOM.
+ *
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure: the only edit is that free
+ *  references to closure variables became HOST.<member> reads (Architecture.md §3.1). The
+ *  extraction was done by script and reversed byte-for-byte against the original text.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.newsUi=function(map,HOST){
+  const saveBookmarks=()=>localStorage.setItem('intmap_bookmarks',JSON.stringify(HOST.bookmarks));
+
+  const tzOpt=()=>(HOST.userTZ==='auto'?undefined:HOST.userTZ);
+
+  const ymd=(d,tz)=>new Intl.DateTimeFormat('en-CA',{timeZone:tz,year:'numeric',month:'2-digit',day:'2-digit'}).format(d);
+
+  const hm=(d,tz)=>new Intl.DateTimeFormat('en-GB',{timeZone:tz,hour:'2-digit',minute:'2-digit',hour12:false}).format(d);
+
+  function formatCustomDate(s){ const d=HOST.parseDate(s),tz=tzOpt(),now=new Date(); const a=ymd(d,tz),today=ymd(now,tz),yest=ymd(new Date(now.getTime()-864e5),tz),time=hm(d,tz);
+    /* (#R37) localize "today"/"yesterday" for ALL four languages — the old en?…:… else-branch showed Japanese to DE/RU. */
+    const TODAY=({en:'today',jp:'今日',de:'heute',ru:'сегодня'})[HOST.lang]||'today', YEST=({en:'yesterday',jp:'昨日',de:'gestern',ru:'вчера'})[HOST.lang]||'yesterday';
+    if(a===today)return `${TODAY} ${time}`; if(a===yest)return `${YEST} ${time}`; const[,M,D]=a.split('-'); return `${+M}/${+D} ${time}`; }
+
+  let hoveredNewsId=null, hoveredDashId=null;
+
+  function setupIntelLayers(){
+    /* (#R161 MapLibre reduction, Phase 3) the NEWS overlay is created through IntMapGeoEngine.
+       `GE` falls back to nothing only if the engine has not been constructed yet (it is built in
+       map.on('load') before the first call), in which case we simply return and the existing
+       styledata re-run creates the layers. */
+    const GE=window.IntMapGeoEngine;
+    if(!GE||!GE.ready()) return;
+    HOST.ensureLabelPill();
+    if(!GE.layers.hasSource('news-points')){
+      GE.layers.addSource('news-points',{type:'geojson',data:{type:'FeatureCollection',features:[]},promoteId:'fid'});
+      GE.layers.add({id:'news-pulse',type:'circle',source:'news-points',filter:['match',['get','mapped'],['true','publisher'],true,false],paint:{
+        'circle-radius':['interpolate',['linear'],['zoom'],0,8,4,14,10,22],
+        'circle-color':['match',['get','mapped'],'publisher','#5856d6','#007aff'],
+        'circle-opacity':0.18,
+        'circle-stroke-width':0
+      }});
+      GE.layers.add({id:'news-dots',type:'circle',source:'news-points',paint:{
+        'circle-radius':['case',['boolean',['feature-state','hover'],false],10,7],
+        'circle-color':['match',['get','mapped'],
+          'true','#007aff',
+          'publisher','#5856d6',
+          'none','#9b59b6',
+          '#9b59b6'],
+        'circle-opacity':['match',['get','mapped'],
+          'true',1.0,
+          'publisher',0.85,
+          'none',0.5,
+          0.5],
+        'circle-stroke-width':2,
+        'circle-stroke-color':'#ffffff'
+      }});
+      /* Title preview "band" to the right of the pin; hidden when hovered (popup takes over).
+         (#R15) Shown for publisher-located pins too, not just subject pins. */
+      GE.layers.add({id:'news-labels',type:'symbol',source:'news-points',layout:{   /* (#R15c) band on ALL pins incl. not-yet-located */
+        'text-field':['get','short'],
+        'text-size':11.5,
+        'text-font':['literal',['Noto Sans Regular']],
+        'text-anchor':'left',
+        'text-offset':[1.25,0],
+        /* (#R36) ROOT CAUSE of "ズームインすると帯が見えなくなる / 空間に余裕があるピンにも帯が出ない / 高速点滅":
+           GL collision is GLOBAL across every symbol layer, so allow-overlap:false made the news bands compete
+           against ALL the base-map place labels (cities/towns/streets). Zooming in spawns more base labels →
+           the bands lose the collision even when there's plenty of room between NEWS pins, and the per-frame
+           re-placement flickered. Fix: take the bands OUT of GL collision entirely (allow-overlap + ignore
+           placement) and decide visibility ourselves with a JS de-clutter that only considers OTHER NEWS bands
+           (see _declutterNewsBands). A band shows iff feature-state `bnd` is true; it runs on moveend (not every
+           frame) so it never blinks. Dense clusters → only the winners show, the rest stay dots; zoom in →
+           pins spread → more win. Independent of base labels. */
+        'symbol-sort-key':['match',['get','mapped'],'true',0,'publisher',1,'none',3,2],
+        'text-allow-overlap':true,
+        'text-ignore-placement':true,
+        'text-optional':false,
+        'text-max-width':14,
+        'icon-image':'news-pill',
+        'icon-text-fit':'both',
+        'icon-text-fit-padding':[2,9,2,9],
+        'icon-allow-overlap':true,
+        'icon-ignore-placement':true,
+        'icon-optional':false
+      },paint:{
+        'text-color':'#ffffff',
+        'text-halo-color':'rgba(0,0,0,0.55)',
+        'text-halo-width':0.8,
+        'text-opacity':['case',['boolean',['feature-state','hover'],false],0,['case',['boolean',['feature-state','bnd'],false],1,0]],
+        'icon-opacity':['case',['boolean',['feature-state','hover'],false],0,['case',['boolean',['feature-state','bnd'],false],1,0]]
+      }});
+      GE.events.on('moveend',HOST.scheduleNewsDeclutter); GE.events.on('zoomend',HOST.scheduleNewsDeclutter);
+      /* If pins were accumulated before map.load, flush them now. */
+      if(HOST.newsFeatures.length){ GE.layers.setSourceData('news-points',{type:'FeatureCollection',features:HOST.newsFeatures}); try{HOST.scheduleNewsDeclutter();}catch(_){} }
+      try{ HOST.refreshNewsPill(); }catch(_){}   /* (#R32) set the band's initial colors for the current theme */
+    }
+    if(!GE.layers.hasSource('dash-points')){
+      GE.layers.addSource('dash-points',{type:'geojson',data:{type:'FeatureCollection',features:[]},promoteId:'fid'});
+      GE.layers.add({id:'dash-pulse',type:'circle',source:'dash-points',paint:{
+        'circle-radius':['interpolate',['linear'],['zoom'],0,10,4,18,10,28],
+        'circle-color':['get','color'],
+        'circle-opacity':0.20,
+        'circle-stroke-width':0
+      }});
+      GE.layers.add({id:'dash-dots',type:'circle',source:'dash-points',paint:{
+        'circle-radius':['case',['boolean',['feature-state','hover'],false],11,8],
+        'circle-color':['get','color'],
+        'circle-stroke-width':2,
+        'circle-stroke-color':'#ffffff'
+      }});
+      if(HOST.dashFeatures.length) GE.layers.setSourceData('dash-points',{type:'FeatureCollection',features:HOST.dashFeatures});
+    }
+    if(window._intelHandlersBound) return;
+    window._intelHandlersBound=true;
+    /* News hover/click — (#R161 Phase 3) bound through IntMapGeoEngine.events.onLayer */
+    GE.events.onLayer('mousemove','news-dots',e=>{
+      if(!e.features.length) return;
+      GE.render.setCursor('pointer');
+      const f=e.features[0];
+      if(hoveredNewsId!==f.id){
+        if(hoveredNewsId!=null) try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:false});}catch(err){}
+        hoveredNewsId=f.id;
+        try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:true});}catch(err){}
+      }
+      const el=HOST.ensureMapTooltip(); el.style.display='block';
+      el.innerHTML=`<div style="display:flex;justify-content:space-between;gap:8px;"><span style="color:var(--primary-color);font-weight:600;font-size:11px;">[${IntMapSafe.html(f.properties.name)}]</span><span style="color:var(--text-muted);font-size:11px;font-weight:500;">${formatCustomDate(f.properties.pubDate)}</span></div><div style="line-height:1.4;font-weight:500;margin-top:4px;">${IntMapSafe.html(f.properties.title)}</div><div style="color:var(--text-muted);margin-top:6px;font-size:11px;">${IntMapSafe.html(f.properties.publisher)}</div>`;   /* (#R138 SEC) news name/title/publisher come from external RSS → escape */
+      HOST.positionTooltip(GE.coords.project(f.geometry.coordinates));
+    });
+    GE.events.onLayer('mouseleave','news-dots',()=>{
+      if(hoveredNewsId!=null){ try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:false});}catch(err){} hoveredNewsId=null; }
+      GE.render.setCursor('');
+      if(HOST.mapTooltipEl) HOST.mapTooltipEl.style.display='none';
+    });
+    /* (#R38) MOBILE: tapping a news pin/band shows a POPUP with a "Read" button rather than jumping straight
+       to the article (the explicit request "直接ニュース記事に行くのではなく、ポップアップが出て、そこに読むボタン").
+       Desktop keeps the direct open (its hover tooltip already previews the item). */
+    function _showMobileNewsPopup(pr){
+      if(!pr) return;
+      let back=document.getElementById('m-news-pop-back');
+      if(!back){ back=document.createElement('div'); back.id='m-news-pop-back'; back.className='m-news-pop-back'; back.innerHTML='<div class="m-news-pop"></div>'; document.body.appendChild(back);
+        back.addEventListener('click',(ev)=>{ if(ev.target===back) back.classList.remove('show'); }); }
+      const pop=back.querySelector('.m-news-pop'), link=pr.link||'';
+      const readLbl=HOST.lang==='jp'?'記事を読む':HOST.lang==='de'?'Artikel lesen':HOST.lang==='ru'?'Читать статью':'Read article';
+      const closeLbl=HOST.lang==='jp'?'閉じる':HOST.lang==='de'?'Schließen':HOST.lang==='ru'?'Закрыть':'Close';
+      pop.innerHTML=`<div class="mnp-head"><span class="mnp-loc">${pr.name?('['+IntMapSafe.html(pr.name)+']'):''}</span><span class="mnp-date">${formatCustomDate(pr.pubDate)}</span></div><div class="mnp-title">${IntMapSafe.html(pr.title||'')}</div><div class="mnp-pub">${IntMapSafe.html(pr.publisher||'')}</div><div class="mnp-actions">${link?`<button class="mnp-read" type="button">${readLbl}</button>`:''}<button class="mnp-close" type="button">${closeLbl}</button></div>`;   /* (#R138 SEC) escape external news fields */
+      const rb=pop.querySelector('.mnp-read'); if(rb) rb.onclick=()=>{ try{ const _u=IntMapSafe.url(link); if(_u) window.open(_u,'_blank','noopener'); }catch(_){} back.classList.remove('show'); };   /* (#R138 SEC) http(s) only — never open a javascript: link */
+      const cb=pop.querySelector('.mnp-close'); if(cb) cb.onclick=()=>back.classList.remove('show');
+      back.classList.add('show');
+    }
+    window._showMobileNewsPopup=_showMobileNewsPopup;
+    GE.events.onLayer('click','news-dots',e=>{
+      if(!e.features.length) return;
+      const p=e.features[0].properties;
+      if(HOST.isMobile()){ _showMobileNewsPopup(p); return; }
+      /* Desktop: open the article straight in the device's browser (the in-app mini-browser was removed) */
+      if(p.link){ const _u=IntMapSafe.url(p.link); if(_u) window.open(_u,'_blank','noopener'); }   /* (#R138 SEC) http(s)-only */
+    });
+    /* (#R37) The BAND (news-labels = the place-name pill) is the big, natural tap target — make it clickable
+       too, not just the tiny dot ("地名ラベルを押しても反応しない"). */
+    GE.events.onLayer('click','news-labels',e=>{ if(!e.features.length) return; const p=e.features[0].properties; if(HOST.isMobile()){ _showMobileNewsPopup(p); return; } if(p.link){ const _u=IntMapSafe.url(p.link); if(_u) window.open(_u,'_blank','noopener'); }   /* (#R138 SEC) http(s)-only */ });
+    GE.events.onLayer('mousemove','news-labels',e=>{ if(!e.features.length) return; GE.render.setCursor('pointer'); const f=e.features[0];
+      /* (#R159) hovering the BAND itself must hide the band while the popup shows — the band's icon/text-opacity
+         collapses to 0 when this feature's `hover` state is set (same rule the dot uses). The band sits offset to the
+         right of the dot and swallows the pointer, so the news-dots handler never fires here; set the state directly,
+         reusing the shared `hoveredNewsId` so crossing dot↔band never leaves a stuck-hover. */
+      if(hoveredNewsId!==f.id){
+        if(hoveredNewsId!=null) try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:false});}catch(err){}
+        hoveredNewsId=f.id;
+        try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:true});}catch(err){}
+      }
+      const el=HOST.ensureMapTooltip(); el.style.display='block';
+      el.innerHTML=`<div style="display:flex;justify-content:space-between;gap:8px;"><span style="color:var(--primary-color);font-weight:600;font-size:11px;">[${IntMapSafe.html(f.properties.name)}]</span><span style="color:var(--text-muted);font-size:11px;font-weight:500;">${formatCustomDate(f.properties.pubDate)}</span></div><div style="line-height:1.4;font-weight:500;margin-top:4px;">${IntMapSafe.html(f.properties.title)}</div><div style="color:var(--text-muted);margin-top:6px;font-size:11px;">${IntMapSafe.html(f.properties.publisher)}</div>`;   /* (#R138 SEC) news name/title/publisher come from external RSS → escape */
+      HOST.positionTooltip(GE.coords.project(f.geometry.coordinates)); });
+    GE.events.onLayer('mouseleave','news-labels',()=>{ GE.render.setCursor(''); if(HOST.mapTooltipEl) HOST.mapTooltipEl.style.display='none';
+      if(hoveredNewsId!=null){ try{GE.layers.setFeatureState({source:'news-points',id:hoveredNewsId},{hover:false});}catch(err){} hoveredNewsId=null; }   /* (#R159) restore the band when the pointer leaves it */ });
+    /* (#R37) MOBILE crosshair → news popup, the same way the DESKTOP cursor reveals the pin under it
+       ("モバイル版でも…十字ポインターの位置のニュースは…ポップアップが出るように"). On every settle, look for a news
+       pin/band right under the centre crosshair and show the same popup there; tap it to open the article. */
+    let _xhrNewsId=null, _xhrLink=null, _xhrProps=null;
+    function _crosshairNews(){ try{
+      /* (#R107) DISABLED on mobile per request ("disable hover news pin and popping news popup in mobile version"):
+         no auto hover-highlight of the pin under the crosshair and no auto-popping news tooltip. Tapping a pin/label
+         still opens the article (that handler is separate). Clear any lingering state and bail. */
+      if(HOST.mapTooltipEl){ HOST.mapTooltipEl.style.display='none'; HOST.mapTooltipEl.style.pointerEvents='none'; }
+      if(_xhrNewsId!=null){ try{map.setFeatureState({source:'news-points',id:_xhrNewsId},{hover:false});}catch(_){} _xhrNewsId=null; _xhrLink=null; _xhrProps=null; }
+      return;
+      if(!HOST.isMobile()||!map||!map.isStyleLoaded()||!map.getLayer('news-dots')) return;
+      if(HOST.toolMode||document.body.classList.contains('pg-we')){ if(HOST.mapTooltipEl) HOST.mapTooltipEl.style.display='none'; return; }
+      const c=map.project(map.getCenter()); const R=22;
+      const layers=['news-labels','news-dots'].filter(l=>map.getLayer(l));
+      let hits=[]; try{ hits=map.queryRenderedFeatures([[c.x-R,c.y-R],[c.x+R,c.y+R]],{layers}); }catch(_){}
+      if(hits&&hits.length){ let best=hits[0],bd=Infinity; hits.forEach(f=>{ try{ const p=map.project(f.geometry.coordinates); const d=Math.hypot(p.x-c.x,p.y-c.y); if(d<bd){bd=d;best=f;} }catch(_){} }); const f=best, pr=f.properties||{};
+        if(_xhrNewsId!==f.id){ if(_xhrNewsId!=null) try{map.setFeatureState({source:'news-points',id:_xhrNewsId},{hover:false});}catch(_){}
+          _xhrNewsId=f.id; try{map.setFeatureState({source:'news-points',id:f.id},{hover:true});}catch(_){} }
+        _xhrLink=pr.link||null; _xhrProps=pr;
+        const el=HOST.ensureMapTooltip(); el.style.display='block'; el.style.pointerEvents='auto'; el.style.cursor='pointer';
+        el.innerHTML=`<div style="display:flex;justify-content:space-between;gap:8px;"><span style="color:var(--primary-color);font-weight:600;font-size:11px;">[${pr.name}]</span><span style="color:var(--text-muted);font-size:11px;font-weight:500;">${formatCustomDate(pr.pubDate)}</span></div><div style="line-height:1.4;font-weight:500;margin-top:4px;">${pr.title}</div><div style="color:var(--text-muted);margin-top:6px;font-size:11px;">${pr.publisher}${' · '+(HOST.lang==='jp'?'タップで詳細':HOST.lang==='de'?'Für Details tippen':HOST.lang==='ru'?'Нажмите для подробностей':'tap for details')}</div>`;
+        try{ HOST.positionTooltip(map.project(f.geometry.coordinates)); }catch(_){}
+      } else { if(_xhrNewsId!=null){ try{map.setFeatureState({source:'news-points',id:_xhrNewsId},{hover:false});}catch(_){} _xhrNewsId=null; } _xhrLink=null; _xhrProps=null; if(HOST.mapTooltipEl){ HOST.mapTooltipEl.style.display='none'; HOST.mapTooltipEl.style.pointerEvents='none'; } }
+    }catch(_){} }
+    window._crosshairNews=_crosshairNews;
+    map.on('moveend',_crosshairNews);
+    /* tap the crosshair popup itself → open the article (the dot under the crosshair is too small to hit) */
+    document.addEventListener('click',(ev)=>{ try{ if(!HOST.isMobile()||!_xhrProps) return; if(HOST.mapTooltipEl&&HOST.mapTooltipEl.style.display!=='none'&&HOST.mapTooltipEl.contains(ev.target)){ _showMobileNewsPopup(_xhrProps); } }catch(_){} });
+    /* Dash hover/click */
+    map.on('mousemove','dash-dots',e=>{
+      if(!e.features.length) return;
+      map.getCanvas().style.cursor='pointer';
+      const f=e.features[0];
+      if(hoveredDashId!==f.id){
+        if(hoveredDashId!=null){
+          try{map.setFeatureState({source:'dash-points',id:hoveredDashId},{hover:false});}catch(err){}
+          const oc=document.getElementById('card-'+hoveredDashId); if(oc) oc.classList.remove('hovered');
+          const olditem=HOST.extendedDashDB.find(i=>i.id===hoveredDashId); if(olditem&&olditem.layerRef) window.triggerLayerHover(olditem.layerRef,false);
+        }
+        hoveredDashId=f.id;
+        try{map.setFeatureState({source:'dash-points',id:hoveredDashId},{hover:true});}catch(err){}
+        const card=document.getElementById('card-'+hoveredDashId);
+        if(card){ card.classList.add('hovered'); }
+        if(f.properties.layerRef) window.triggerLayerHover(f.properties.layerRef,true);
+      }
+      const el=HOST.ensureMapTooltip(); el.style.display='block';
+      el.innerHTML=`<div style="color:${f.properties.color};font-weight:600;font-size:14px;">${f.properties.title}</div><div style="line-height:1.4;margin-top:4px;color:var(--text-muted);">${f.properties.body}</div>`;
+      HOST.positionTooltip(map.project(f.geometry.coordinates));
+    });
+    map.on('mouseleave','dash-dots',()=>{
+      if(hoveredDashId!=null){
+        try{map.setFeatureState({source:'dash-points',id:hoveredDashId},{hover:false});}catch(err){}
+        const oc=document.getElementById('card-'+hoveredDashId); if(oc) oc.classList.remove('hovered');
+        const olditem=HOST.extendedDashDB.find(i=>i.id===hoveredDashId); if(olditem&&olditem.layerRef) window.triggerLayerHover(olditem.layerRef,false);
+        hoveredDashId=null;
+      }
+      map.getCanvas().style.cursor='';
+      if(HOST.mapTooltipEl) HOST.mapTooltipEl.style.display='none';
+    });
+    map.on('click','dash-dots',e=>{
+      if(!e.features.length) return;
+      const f=e.features[0], id=f.id;
+      map.flyTo({center:f.geometry.coordinates,zoom:4,speed:1.2});
+      const wasInfo=HOST.mode==='info';
+      if(!wasInfo) HOST.setMode('info','btn-info');   /* clicking a pin reveals its card */
+      setTimeout(()=>{ const card=document.getElementById('card-'+id); if(card){ card.scrollIntoView({behavior:'smooth',block:'center'}); card.classList.add('hovered'); setTimeout(()=>card.classList.remove('hovered'),1800); } }, wasInfo?60:280);
+    });
+  }
+
+  function _spreadDupNewsPins(feats){ try{ if(!Array.isArray(feats)||feats.length<2) return feats;
+    const groups=new Map();
+    feats.forEach(f=>{ if(!f||!f.geometry) return;
+      /* (#R127) remember each pin's ORIGINAL anchor so the spread is IDEMPOTENT — re-running it (once the async
+         country borders finish loading, see _respreadNews) re-groups by the TRUE stacked coords instead of the
+         already-scattered ones (which no longer collide → a permanent tight blob if countryGeo wasn't ready on the
+         first pass — the strongest systemic cause of "密集的に散らすだけ"). */
+      if(!f.__oc){ const c=f.geometry.coordinates; if(!c||!isFinite(+c[0])||!isFinite(+c[1])) return; f.__oc=[+c[0],+c[1]]; }
+      const c=f.__oc; const k=c[0].toFixed(3)+','+c[1].toFixed(3); let g=groups.get(k); if(!g){ g=[]; groups.set(k,g); } g.push(f); });
+    const GA=2.399963229; /* golden angle (rad) */
+    const cg=(window.countryGeo&&window.countryGeo.features&&window.countryGeo.features.length)?window.countryGeo:null;
+    const haveTurf=(typeof turf!=='undefined');
+    const _regCache=new Map();
+    /* the country polygon under an anchor + its bbox / representative centre, AND the LARGEST ring's own bbox +
+       polygon (used to spread when the whole-feature bbox is an antimeridian artifact). */
+    function regionFor(c0){ if(!cg||!haveTurf) return null; const key=c0[0].toFixed(2)+','+c0[1].toFixed(2);
+      if(_regCache.has(key)) return _regCache.get(key);
+      let out=null; try{ const pt=turf.point(c0);
+        for(const f of cg.features){ if(!f.geometry) continue; try{ if(turf.booleanPointInPolygon(pt,f)){
+          const bb=turf.bbox(f);
+          /* (#R124) representative point = centroid of the LARGEST ring (by bbox area), NOT the whole-feature bbox
+             centre — the latter is skewed by outlying territory (Alaska pulls the US centre up into Canada).
+             (#R127) also keep that largest ring's OWN bbox + polygon: a country whose polygon crosses the
+             antimeridian (USA/Aleutians, Russia, Fiji, NZ) has turf.bbox ≈ [-180…180], so sampling the WHOLE bbox
+             lands ~99% in open ocean → EVERY rejection sample misses → the old code collapsed to a 0.12° dot. This
+             is exactly the reported "アメリカに分類された…アメリカの領域内に分散できていない". Sample the mainland ring. */
+          let bc=[(bb[0]+bb[2])/2,(bb[1]+bb[3])/2], rbb=bb.slice(), rPoly=f;
+          try{ const polys=f.geometry.type==='MultiPolygon'?f.geometry.coordinates:[f.geometry.coordinates]; let bestA=-1;
+            polys.forEach(poly=>{ const ring=poly&&poly[0]; if(!ring||ring.length<3) return; let mnx=1e9,mny=1e9,mxx=-1e9,mxy=-1e9,sx=0,sy=0; ring.forEach(p=>{ if(p[0]<mnx)mnx=p[0]; if(p[0]>mxx)mxx=p[0]; if(p[1]<mny)mny=p[1]; if(p[1]>mxy)mxy=p[1]; sx+=p[0]; sy+=p[1]; }); const a=(mxx-mnx)*(mxy-mny); if(a>bestA){ bestA=a; bc=[sx/ring.length,sy/ring.length]; rbb=[mnx,mny,mxx,mxy]; rPoly={type:'Feature',properties:{},geometry:{type:'Polygon',coordinates:[ring]}}; } });
+          }catch(_){}
+          out={f,bb,bc,rbb,rPoly}; break; } }catch(_){} } }catch(_){}
+      _regCache.set(key,out); return out; }
+    function seeded(c0){ let s=Math.abs(Math.round(c0[0]*1000+c0[1]*7919))||1; return ()=>{ s=(s*1103515245+12345)&0x7fffffff; return s/0x7fffffff; }; }
+    groups.forEach(g=>{ if(g.length<2) return; const c0=g[0].__oc.slice();
+      const ptype=String((g[0].properties&&g[0].properties.ptype)||'').toLowerCase();
+      const reg=regionFor(c0);
+      /* country-level = the gazetteer typed it 'country', OR the anchor sits near the containing country's
+         representative centre — a country-representative point (a stacked cluster ON the centroid), not a real city
+         inside it. (#R127) the proximity test now also rescues a country cluster mis-typed 'city' (a "US"/"America"
+         headline that resolved to a city term) — a genuine city almost never sits within ~1.6° of the mainland
+         centroid AND stacks dozens of duplicate stories there. */
+      let countryLevel=false;
+      if(reg){ if(ptype==='country'||ptype==='nation') countryLevel=true;
+        else if(ptype!=='region'&&ptype!=='flashpoint'){ const near=Math.hypot(c0[0]-reg.bc[0],c0[1]-reg.bc[1]); countryLevel = near < (ptype==='city'?1.6:2.6); } }
+      if(countryLevel && reg){
+        /* (#R127) antimeridian-safe: if the whole-feature bbox is absurdly wide it's a dateline artifact → spread
+           over the mainland ring; otherwise the full feature (best coverage for compact archipelagos like
+           Indonesia/Philippines that don't cross 180°). */
+        const crossAM=(reg.bb[2]-reg.bb[0])>180;
+        const sbb=crossAM?reg.rbb:reg.bb, sf=crossAM?reg.rPoly:reg.f, rnd=seeded(c0), cosl=Math.max(0.2,Math.cos(c0[1]*Math.PI/180));
+        const diag=Math.hypot(sbb[2]-sbb[0],sbb[3]-sbb[1]);
+        g.forEach((ft,i)=>{ let placed=null;
+          for(let k=0;k<44;k++){ const lng=sbb[0]+rnd()*(sbb[2]-sbb[0]), lat=sbb[1]+rnd()*(sbb[3]-sbb[1]);
+            try{ if(turf.booleanPointInPolygon(turf.point([lng,lat]),sf)){ placed=[lng,lat]; break; } }catch(_){} }
+          if(!placed){ const r=Math.min(diag*0.42,0.5+0.14*Math.sqrt(i)), ang=i*GA;   /* miss → REGION-scaled disk (mainland diagonal), genuinely wide — not a 0.12° dot */
+            placed=[c0[0]+r*Math.cos(ang)/cosl, c0[1]+r*Math.sin(ang)]; }
+          ft.geometry={type:'Point',coordinates:placed}; });
+      } else {
+        const cosl=Math.max(0.2,Math.cos(c0[1]*Math.PI/180));
+        /* (#R127) widened so a mis-classified or borderless cluster still reads as DISTRIBUTED, not a dense knot;
+           still latitude-corrected and clipped back inside the containing country when one is known. */
+        const base=(ptype==='region')?0.12:(ptype==='city'||ptype==='flashpoint')?0.05:0.08;
+        const cap=(ptype==='region')?1.1:(ptype==='city'||ptype==='flashpoint')?0.32:0.5;
+        g.forEach((ft,i)=>{ if(i===0){ ft.geometry={type:'Point',coordinates:c0.slice()}; return; }   /* leave one pin on the true spot (reset on a re-spread) */
+          let r=Math.min(cap,base*Math.sqrt(i)); const ang=i*GA;
+          let lng=c0[0]+r*Math.cos(ang)/cosl, lat=c0[1]+r*Math.sin(ang);
+          if(reg&&haveTurf){ try{ if(!turf.booleanPointInPolygon(turf.point([lng,lat]),reg.f)){ r*=0.5; lng=c0[0]+r*Math.cos(ang)/cosl; lat=c0[1]+r*Math.sin(ang); } }catch(_){} }
+          ft.geometry={type:'Point',coordinates:[lng,lat]}; }); }
+    });
+    return feats; }catch(_){ return feats; } }
+
+  function renderUI(){
+    const feed=document.getElementById('live-news-feed'),
+          cfeed=document.getElementById('countries-feed'),
+          dash=document.getElementById('info-dashboard'),
+          comm=document.getElementById('community-feed'),
+          afeed=document.getElementById('atlas-feed'),   /* (#R112) Atlas tab content area */
+          sb=document.getElementById('sidebar-search-bar'),   /* (#R79e) by ID — #countries-search-bar also has class .search-bar, so querySelector('.search-bar') could grab it after a ws cycle and renderUI would leak the "Filter countries" box into the normal sidebar */
+          filterToggle=document.getElementById('news-filter-toggle');
+    HOST.clearMarkers();
+    try{ HOST.pushCommunityFeatures(); }catch(_){}   /* show community pins only on the Community tab */
+    /* Hide all panels first (pin-mode toggle now lives inside #ai-geocode-row, #28) */
+    feed.style.display='none'; if(cfeed) cfeed.style.display='none'; dash.style.display='none'; comm.style.display='none'; if(afeed) afeed.style.display='none'; filterToggle.style.display='none';
+    { const _mf=document.getElementById('monitors-feed'); if(_mf) _mf.style.display='none'; }   /* (#R141) hide Monitors feed unless its tab is active */
+    { const gr=document.getElementById('ai-geocode-row'); if(gr) gr.style.display='none'; }
+    /* Stats compare panel only belongs on the Stats tab (#26) */
+    if(HOST.mode!=='stats'){ const scf=document.getElementById('stats-compare-fixed'); if(scf){ scf.classList.remove('show'); scf.innerHTML=''; } feed.style.paddingBottom=''; }
+    if(HOST.mode!=='info'){ const cof=document.getElementById('co-compare-fixed'); if(cof){ cof.classList.remove('show'); cof.innerHTML=''; } }   /* (#R152) Companies compare dock only belongs on the Companies tab — mirror the Countries dock hide above so the absolute overlay never lingers over another tab */
+    /* Search-bar UI per tab (#27): News keeps a Search button (matching is slow);
+       Info & Stats filter live as you type, so their button is hidden.
+       Summarize-this-view button shows only on the News tab (#20). */
+    const searchBtn=document.getElementById('btn-search');
+    const sumBtn=document.getElementById('ai-view-summary-btn');
+    const isNewsTab=(HOST.mode==='news'||HOST.mode==='saved');
+    if(searchBtn) searchBtn.style.display=isNewsTab?'':'none';
+    /* (#R129) the Countries search bar's "pick on the map" crosshair shows only on the Countries tab (the bar is
+       shared with News/Info); leaving Countries cancels an active pick so the crosshair/handler never lingers. */
+    { const cpk=document.getElementById('csearch-pick'); if(cpk) cpk.classList.toggle('on-tab', HOST.mode==='stats'); }
+    if(!document.body.classList.contains('ws-mode') && HOST.mode!=='stats' && window.__countryPickActive && window.__countryPickActive()){ try{ window.__countryPick(false); }catch(_){} }
+    /* (#R85) "要約ボタンがニュースウィンドウを開いてなくても表示される": in workspace mode renderUI still runs with
+       currentMode==='news' even when the News WINDOW is hidden, so the summarize-view button leaked onto the map.
+       Also require the News window to be visible in ws-mode (_wsNewsHidden() is always false outside ws-mode, so
+       the normal News-tab behaviour is unchanged). */
+    if(sumBtn) sumBtn.style.display=(isNewsTab && !(window._wsNewsHidden&&window._wsNewsHidden()))?'':'none';
+    { const ip=document.getElementById('search-input'); if(ip) ip.placeholder = (HOST.mode==='stats'||HOST.mode==='info'||HOST.mode==='monitors') ? (HOST.lang==='jp'?'絞り込み...':HOST.lang==='de'?'Filtern…':HOST.lang==='ru'?'Фильтр…':HOST.lang==='es'?'Filtrar…':'Filter…') : HOST.t('searchPh'); }
+
+    /* (#R11) No tab selected → blank sidebar content (map stays prominent). News pins still load when the
+       user opens the News tab. (#R19) The blank state now hosts the opt-in Apple-style widget board. */
+    if(!HOST.mode){ if(sb) sb.style.display='none'; try{ window.IntMapWidgets2&&window.IntMapWidgets2.sync(); }catch(_){} try{ HOST.updateOcclusion(); }catch(_){} return; }
+    try{ window.IntMapWidgets2&&window.IntMapWidgets2.sync(); }catch(_){}
+    /* (#R112) Atlas tab — the console renders IN FLOW inside #atlas-feed (below the tab bar), exactly like News /
+       Information / Countries. Its own input replaces the news search bar. Workspace mode never reaches here (Atlas
+       is its own window there). */
+    if(HOST.mode==='atlas'){ if(afeed) afeed.style.display='flex'; if(sb) sb.style.display='none';
+      try{ window.IntMapConsole&&window.IntMapConsole.mountTab&&window.IntMapConsole.mountTab(); }catch(_){}
+      try{ HOST.updateOcclusion(); }catch(_){} return; }
+    if(HOST.mode==='info'){ dash.style.display='flex'; sb.style.display='flex'; HOST.renderDashboard(); HOST.updateOcclusion(); return; }
+    if(HOST.mode==='monitors'){ const mf=document.getElementById('monitors-feed'); if(mf) mf.style.display='flex'; sb.style.display='flex';   /* (#R141) Monitors tab */
+      try{ window.IntMapMonitors&&window.IntMapMonitors.render(HOST.searchVal()); }catch(_){}
+      try{ HOST.updateOcclusion(); }catch(_){} return; }
+    if(HOST.mode==='community'){ comm.style.display='flex'; sb.style.display='none'; HOST.loadCommunity(); HOST.updateOcclusion(); return; }
+    if(HOST.mode==='stats'){ if(cfeed) cfeed.style.display='flex'; sb.style.display='flex'; HOST.renderStats(HOST.searchVal()); return; }
+    if(HOST.mode==='news'||HOST.mode==='saved'){
+      feed.style.display='flex'; sb.style.display='flex';
+      filterToggle.style.display='block';
+      /* (#R30) Translate titles only when the news set actually carries a non-UI language. */
+      { const gr=document.getElementById('ai-geocode-row'); if(gr) gr.style.display=HOST._newsHasForeignLang()?'block':'none'; }
+      try{ HOST.aiSyncFeatureButtons(); }catch(_){}
+      /* sync the All / ★ Saved sub-filter (Saved now lives inside the News tab) */
+      document.getElementById('newsfilter-all').textContent = HOST.lang==='jp'?'すべて':HOST.lang==='de'?'Alle':HOST.lang==='ru'?'Все':HOST.lang==='es'?'Todo':'All';
+      document.getElementById('newsfilter-saved').textContent = HOST.lang==='jp'?'★ 保存済み':HOST.lang==='de'?'★ Gespeichert':HOST.lang==='ru'?'★ Сохранённые':HOST.lang==='es'?'★ Guardado':'★ Saved';
+      document.getElementById('newsfilter-all').classList.toggle('active', HOST.mode==='news');
+      document.getElementById('newsfilter-saved').classList.toggle('active', HOST.mode==='saved');
+      /* sync the segmented control with current mode */
+      document.getElementById('pinmode-loc').classList.toggle('active', HOST.newsPinMode==='location');
+      document.getElementById('pinmode-pub').classList.toggle('active', HOST.newsPinMode==='publisher');
+      HOST.startNews(); return;
+    }
+    feed.style.display='flex'; sb.style.display='none'; feed.innerHTML=`<div class="empty-msg">${HOST.t('emptyHint')}</div>`;
+  }
+
+  /* Rebuild news-points from the current filter WITHOUT touching the sidebar feed (so a
+     progressive update during geocoding doesn't reset scroll). Mirrors startNews()'s shape. */
+  function aiRefreshNewsPins(){
+    if(!(map&&map.getSource('news-points'))) return;
+    HOST.newsFeatures=[];
+    HOST.computeFilteredNews().forEach(item=>{ const a=item.analysis; if(a&&a.loc){
+      const fid='n_'+Math.random().toString(36).slice(2,10);
+      const mappedStr=a.mapped===true?'true':(a.mapped==='publisher'?'publisher':'none');
+      HOST.newsFeatures.push({type:'Feature',id:fid,geometry:{type:'Point',coordinates:a.loc},properties:{
+        fid, mapped:mappedStr, ptype:a.ptype||'', title:item.title, name:a.name||'', short:a.short||'', publisher:item.publisher, link:item.link, pubDate:item.pubDate }});
+    }});
+    _spreadDupNewsPins(HOST.newsFeatures);   /* (#R122) fan out pins sharing an anchor */
+    map.getSource('news-points').setData({type:'FeatureCollection',features:HOST.newsFeatures}); try{HOST.scheduleNewsDeclutter();}catch(_){}
+  }
+
+  const AI_GEO_CAP=120;
+
+  async function aiGeocodeNews(force){
+    if(!HOST.aiGate()) return;
+    const mode=HOST.newsPinMode, pub=(mode==='publisher'), cacheKey=pub?'_aiPub':'_aiGeo';
+    const need=it=>{ const a=it.analysis; if(!a) return false;
+      if(force) return true;
+      return pub ? (!a.pubLoc && !a[cacheKey]) : (!a.subjectLoc && !a[cacheKey]); };
+    const todo=HOST.computeFilteredNews().filter(need).slice(0,AI_GEO_CAP);
+    const btn=document.getElementById('ai-geocode-btn');
+    if(!todo.length){ HOST.aiToast(HOST.t('aiGeoNone')); return; }
+    HOST.aiSetBtnBusy(btn,true,HOST.t('aiGeoBusy'));
+    const sys=pub
+      ? "You are a precise geocoder. Each numbered line is the NAME of a news outlet / publisher. Return the city where that outlet is headquartered. Reply with ONLY a JSON array, one object per identifiable outlet: {\"i\":<index>,\"name\":\"<City, Country>\",\"lat\":<number>,\"lng\":<number>}. Omit outlets you cannot place. No commentary, no code fences."
+      : "You are a precise geocoder for a world news map. For EACH numbered headline, return the SUBJECT LOCATION: the single specific real-world place where the main event/incident actually happens. RULES: (1) NOT the news outlet's HQ or dateline (e.g. ignore 'Reuters, London'). (2) NOT a place where someone merely SPOKE about the event — if an official at the White House in Washington comments on the Middle East, return the specific Middle-East country/city the event concerns, NOT Washington. (3) Be as SPECIFIC as possible — prefer city/landmark over country (e.g. 'Mariupol' over 'Ukraine', 'Rafah' over 'Gaza' when identifiable). Reply with ONLY a JSON array; one object per locatable item: {\"i\":<index number>,\"name\":\"<short English place name, most specific>\",\"lat\":<number>,\"lng\":<number>}. Omit any item with no clear subject location. No commentary, no code fences.";
+    const BATCH=12; let done=0, hit=0, failed=false;
+    try{
+      for(let i=0;i<todo.length;i+=BATCH){
+        const chunk=todo.slice(i,i+BATCH);
+        const list=pub
+          ? chunk.map((it,k)=>`${k}. ${it.publisher||'?'}`).join('\n')
+          : chunk.map((it,k)=>`${k}. ${it.title}${it.desc?' — '+String(it.desc).slice(0,160):''}`).join('\n');
+        let arr=null;
+        try{ arr=await HOST.askAIJSON((pub?'Outlets:\n':'Headlines:\n')+list, sys); }
+        catch(e){ HOST.aiToast((e&&e.message)||HOST.t('aiGeoErr')); failed=true; break; }
+        if(Array.isArray(arr)) arr.forEach(o=>{
+          if(!o||typeof o.lat!=='number'||typeof o.lng!=='number') return;
+          if(o.lat<-90||o.lat>90||o.lng<-180||o.lng>180) return;
+          const it=chunk[o.i]; if(!it||!it.analysis) return;
+          if(pub){ it.analysis.pubLoc=[o.lng,o.lat]; it.analysis.pubName=(HOST.lang==='jp'?'発信: ':HOST.lang==='de'?'Quelle: ':HOST.lang==='ru'?'Источник: ':HOST.lang==='es'?'Fuente: ':'Source: ')+(o.name||it.publisher||''); }
+          else { it.analysis.subjectLoc=[o.lng,o.lat]; it.analysis.subjectName=o.name||it.analysis.subjectName||''; }
+          HOST.applyPinMode(it.analysis); hit++;
+        });
+        /* mark the whole chunk attempted so auto-mode won't re-ask outlets the AI couldn't place */
+        chunk.forEach(it=>{ if(it.analysis) it.analysis[cacheKey]=true; });
+        done+=chunk.length;
+        HOST.aiSetBtnBusy(btn,true,HOST.t('aiGeoBusy')+' '+done+'/'+todo.length);
+        aiRefreshNewsPins(); /* progressive pin update */
+      }
+    } finally { HOST.aiSetBtnBusy(btn,false); }
+    if(HOST.mode==='news'||HOST.mode==='saved') HOST.startNews(); /* refresh feed chips + pins */
+    if(!failed) HOST.aiToast(hit? HOST.t('aiGeoDone').replace('{n}',hit) : HOST.t('aiGeoNone'));
+  }
+
+  function appendNewsBatch(){
+    const feed=document.getElementById('live-news-feed');
+    const next=HOST.newsFiltered.slice(HOST.renderedCount, HOST.renderedCount+HOST.NEWS_BATCH);
+    next.forEach(item=>{
+      const card=document.createElement('div'); card.className='news-item'; const bm=HOST.bookmarks.includes(item.link);
+      let chipCls='loc-chip';
+      if(item.analysis.mapped===true) chipCls='loc-chip';
+      else if(item.analysis.mapped==='publisher') chipCls='loc-chip publisher';
+      else chipCls='loc-chip unmapped';
+      const readLabel = HOST.lang==='jp'?'記事を読む ↗':HOST.lang==='de'?'Lesen ↗':HOST.lang==='ru'?'Читать ↗':HOST.lang==='es'?'Leer ↗':'Read ↗';
+      card.innerHTML=`<button class="btn-bookmark ${bm?'active':''}">★</button>
+        <div class="news-head"><span class="${chipCls}">${IntMapSafe.html(item.analysis.name)||(HOST.lang==='jp'?'場所不明':HOST.lang==='de'?'Ort unbekannt':HOST.lang==='ru'?'Место неизвестно':HOST.lang==='es'?'Ubicación desconocida':'Location unknown')}</span><small class="news-date">${formatCustomDate(item.pubDate)}</small></div>
+        <div class="news-title">${HOST.newsTitleHTML(item)}</div>
+        <div class="news-foot"><small class="news-pub"${item.publisher?' role="link" tabindex="0" title="'+IntMapSafe.html(item.publisher+' — Wikipedia ↗')+'"':''}>${IntMapSafe.html(item.publisher)}</small><button class="btn-read">${readLabel}</button></div>`;   /* (#R138 SEC) name/publisher from external RSS → escape (newsTitleHTML self-escapes) */
+      card.querySelector('.btn-bookmark').onclick=async(e)=>{ e.stopPropagation();
+        if(HOST.user){ const on=await toggleFavorite(item.link,item.title); if(HOST.mode==='saved')HOST.startNews(); else card.querySelector('.btn-bookmark').classList.toggle('active',on); }
+        else { /* guest: keep a local list until they log in */ if(HOST.bookmarks.includes(item.link))HOST.bookmarks=HOST.bookmarks.filter(b=>b!==item.link); else HOST.bookmarks.push(item.link); saveBookmarks(); if(HOST.mode==='saved')HOST.startNews(); else card.querySelector('.btn-bookmark').classList.toggle('active'); }
+      };
+      /* (#R11) Read article → open directly in the device's browser (reverted per request). */
+      card.querySelector('.btn-read').onclick=(e)=>{ e.stopPropagation(); const _u=IntMapSafe.url(item.link); if(_u) window.open(_u,'_blank','noopener'); };   /* (#R138 SEC) http(s)-only */
+      /* (#R142) Clicking the OUTLET NAME opens that outlet's Wikipedia page in the UI language (jp→ja subdomain). Uses
+         Special:Search&go=Go so an exact title jumps straight to the article and a near-miss lands on search results
+         instead of a 404 (publisher strings from RSS don't always match a Wikipedia title exactly). stopPropagation so
+         it doesn't also fly the card. */
+      { const pub=card.querySelector('.news-pub');
+        if(pub&&item.publisher){ const openWiki=(e)=>{ e.stopPropagation(); const wl=(HOST.lang==='jp')?'ja':HOST.lang; const _u=IntMapSafe.url('https://'+wl+'.wikipedia.org/w/index.php?title=Special:Search&search='+encodeURIComponent(item.publisher)+'&go=Go'); if(_u) window.open(_u,'_blank','noopener'); };
+          pub.onclick=openWiki; pub.addEventListener('keydown',e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); openWiki(e); } }); } }
+      /* Whole card → fly to the map location (replaces the old "Show on map" button) */
+      card.onclick=()=>{ if(map&&item.analysis.loc) map.flyTo({center:item.analysis.loc,zoom:4,speed:1.0}); };
+      item._cardEl=card; /* lets the translation pass update this title in place */
+      feed.appendChild(card);
+      /* Pins are populated in bulk by startNews(); no per-batch pin push here. */
+    });
+    HOST.renderedCount+=next.length;
+    HOST.updateOcclusion();
+  }
+
+  function readerBar(item,mode){
+    const back=HOST.lang==='jp'?'戻る':HOST.lang==='de'?'Zurück':HOST.lang==='ru'?'Назад':HOST.lang==='es'?'Atrás':'Back';
+    const other=mode==='reader'?(HOST.lang==='jp'?'🌐 ページ表示':HOST.lang==='de'?'🌐 Web':HOST.lang==='ru'?'🌐 Веб':HOST.lang==='es'?'🌐 Web':'🌐 Web'):(HOST.lang==='jp'?'📖 リーダー':HOST.lang==='de'?'📖 Reader':HOST.lang==='ru'?'📖 Читалка':HOST.lang==='es'?'📖 Lector':'📖 Reader');
+    return `<div class="nrp-bar"><button class="nrp-back" id="nrp-back-btn">‹ ${back}</button><button class="nrp-mode" id="nrp-mode-btn">${other}</button>${mode==='reader'?`<button class="nrp-mode" id="nrp-translate-btn">✨ ${HOST.t('aiTranslate')}</button>`:''}<span class="nrp-src">${HOST.escForReader(item.publisher)}</span></div>`;
+  }
+
+  function renderReaderMode(item,res,mode){
+    const pane=document.getElementById('news-reader-pane'); if(!pane) return;
+    const metaRow=`<div class="nrp-meta"><span>${HOST.escForReader(item.publisher)}</span><span class="nrp-dot"></span><span>${HOST.escForReader(formatCustomDate(item.pubDate))}</span></div>`;
+    if(mode==='web'){
+      pane.innerHTML=`${readerBar(item,'web')}
+        <h1 class="nrp-title">${HOST.escForReader(item.title)}</h1>${metaRow}
+        <div class="nrp-webwrap"><div class="nrp-webnote" id="nrp-webnote">${HOST.lang==='jp'?'ページを読み込み中…':HOST.lang==='de'?'Seite lädt…':HOST.lang==='ru'?'Загрузка страницы…':HOST.lang==='es'?'Cargando página…':'Loading page…'}</div><iframe class="nrp-iframe" src="${HOST.escForReader(item.link)}" referrerpolicy="no-referrer" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe></div>
+        <a class="nrp-orig" href="${HOST.escForReader(item.link)}" target="_blank" rel="noopener">${HOST.lang==='jp'?'新しいタブで開く':HOST.lang==='de'?'In neuem Tab öffnen':HOST.lang==='ru'?'Открыть в новой вкладке':HOST.lang==='es'?'Abrir en pestaña nueva':'Open in new tab'} ↗</a>`;
+      const ifr=pane.querySelector('.nrp-iframe'); const note=pane.querySelector('#nrp-webnote');
+      if(ifr){ ifr.addEventListener('load',()=>{ if(note) note.style.display='none'; });
+        setTimeout(()=>{ if(note&&note.style.display!=='none') note.innerHTML=HOST.lang==='jp'?'このサイトは埋め込み表示を許可していません。「📖 リーダー」か「新しいタブで開く」をお使いください。':HOST.lang==='de'?'Diese Seite erlaubt kein Einbetten. Nutze „📖 Reader“ oder öffne sie in einem neuen Tab.':HOST.lang==='ru'?'Сайт запрещает встраивание. Используйте «📖 Читалка» или откройте в новой вкладке.':HOST.lang==='es'?'Este sitio bloquea la inserción. Prueba «📖 Lector» o ábrelo en una pestaña nueva.':'This site blocks embedding. Try “📖 Reader” or open it in a new tab.'; }, 5000); }
+    } else {
+      const locName=(item.analysis&&item.analysis.name)?item.analysis.name:'';
+      const bodyHtml=(res.blocks&&res.blocks.length)
+        ? res.blocks.map(b=> b.t==='h' ? `<h3>${HOST.escForReader(b.v)}</h3>` : `<p>${HOST.escForReader(b.v)}</p>`).join('')
+        : `<p>${HOST.lang==='jp'?'本文を自動取得できませんでした。上の「🌐 ページ表示」で元ページを開けます。':HOST.lang==='de'?'Text konnte nicht extrahiert werden — öffne die Seite über „🌐 Web“ oben.':HOST.lang==='ru'?'Не удалось извлечь текст — откройте страницу через «🌐 Веб» выше.':HOST.lang==='es'?'No se pudo extraer el texto — abre la página con «🌐 Web» arriba.':'Could not extract text — use “🌐 Web” above to open the page.'}</p>`;
+      const heroHtml=res.hero?`<img class="nrp-hero" src="${HOST.escForReader(res.hero)}" onerror="this.style.display='none'">`:'';
+      const locHtml=locName?`<span class="nrp-loc" id="nrp-loc">${HOST.escForReader(locName)}</span>`:'';
+      pane.innerHTML=`${readerBar(item,'reader')}
+        ${heroHtml}${locHtml}
+        <h1 class="nrp-title">${HOST.escForReader(item.title)}</h1>${metaRow}
+        <div class="nrp-body">${bodyHtml}</div>
+        <a class="nrp-orig" href="${HOST.escForReader(item.link)}" target="_blank" rel="noopener">${HOST.lang==='jp'?'元記事を開く':HOST.lang==='de'?'Original öffnen':HOST.lang==='ru'?'Открыть оригинал':HOST.lang==='es'?'Abrir original':'Open original'} ↗</a>`;
+      const locEl=pane.querySelector('#nrp-loc');
+      if(locEl) locEl.onclick=()=>{ if(map&&item.analysis&&item.analysis.loc) map.flyTo({center:item.analysis.loc,zoom:4,speed:1.0}); };
+    }
+    pane.querySelector('#nrp-back-btn').onclick=HOST.closeArticleReader;
+    const mb=pane.querySelector('#nrp-mode-btn');
+    if(mb) mb.onclick=()=>renderReaderMode(item,res, mode==='web'?'reader':'web');
+    const tb=pane.querySelector('#nrp-translate-btn'); if(tb) tb.onclick=()=>aiTranslateReader(item,res,tb);
+    pane.scrollTop=0;
+  }
+
+  async function aiTranslateReader(item,res,btn){
+    if(!HOST.aiGate()) return;
+    const bodyEl=document.querySelector('#news-reader-pane .nrp-body'); if(!bodyEl||!btn) return;
+    const setLbl=on=>{ btn.innerHTML = on ? '↩ '+HOST.aiEsc(HOST.t('aiShowOriginal')) : '✨ '+HOST.aiEsc(HOST.t('aiTranslate')); };
+    if(bodyEl.dataset.translated==='1'){ if(res._origHTML!=null) bodyEl.innerHTML=res._origHTML; bodyEl.dataset.translated='0'; setLbl(false); return; }
+    if(res._translatedHTML){ if(res._origHTML==null) res._origHTML=bodyEl.innerHTML; bodyEl.innerHTML=res._translatedHTML; bodyEl.dataset.translated='1'; setLbl(true); return; }
+    const src=((res.blocks||[]).map(b=>b&&b.v).filter(Boolean).join('\n\n')||'').trim();
+    if(!src){ HOST.aiToast(HOST.t('aiTransNoText')); return; }
+    res._origHTML=bodyEl.innerHTML; btn.disabled=true; btn.innerHTML='<span class="ai-spin"></span>';
+    try{
+      /* (#R39) Translate into the UI language, not always Japanese (DE/RU/EN users got Japanese). */
+      const _tgt=HOST._aiLangName();
+      const sys="You are a professional news translator. Translate the article into natural, fluent "+_tgt+". Keep paragraph breaks. Do not add notes, labels, or the original text — output only the "+_tgt+" translation.";
+      const out=await HOST.askAI('Title: '+item.title+'\n\n'+src, sys);
+      const paras=String(out||'').split(/\n{2,}/).map(s=>s.trim()).filter(Boolean);
+      res._translatedHTML=(paras.length?paras:[String(out||'')]).map(p=>`<p>${HOST.escForReader(p)}</p>`).join('');
+      bodyEl.innerHTML=res._translatedHTML; bodyEl.dataset.translated='1';
+    }catch(e){ HOST.aiToast((e&&e.message)||HOST.t('aiError')); }
+    finally{ btn.disabled=false; setLbl(bodyEl.dataset.translated==='1'); }
+  }
+
+  async function toggleFavorite(link,title){
+    if(!HOST.user){ HOST.openAuthModal(); return false; }
+    const has=HOST.bookmarks.includes(link);
+    if(has){ HOST.bookmarks=HOST.bookmarks.filter(b=>b!==link); await HOST.DB.from('favorites').delete().eq('user_id',HOST.user.id).eq('article_link',link); }
+    else { HOST.bookmarks.push(link); await HOST.DB.from('favorites').insert({ user_id:HOST.user.id, article_link:link, article_title:title||null }); }
+    return !has;
+  }
+
+  /* The names index.html still calls: it keeps a hoisted shim for each (#R168). */
+  return { renderUI, setupIntelLayers, appendNewsBatch, renderReaderMode, aiGeocodeNews, _spreadDupNewsPins };
+};

--- a/js/tool-panel.js
+++ b/js/tool-panel.js
@@ -1,0 +1,261 @@
+/* ============================================================================
+ *  IntMap · Measure / radius tool panel & map context menu  (#R168)
+ * ----------------------------------------------------------------------------
+ *  The tool panel that drives the measure, radius and area tools, the GeoJSON features it puts
+ *  on the map, and the map right-click context menu. Writes tool state through the host: three
+ *  RW members already existed for the Atlas kernel (#R165), four are new.
+ *
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure: the only edit is that free
+ *  references to closure variables became HOST.<member> reads (Architecture.md §3.1). The
+ *  extraction was done by script and reversed byte-for-byte against the original text.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.toolPanel=function(map,HOST){
+  function bearingHTML(a,b){ const d=HOST.bearingDeg(a,b); return `${d.toFixed(1)}° <span class="unit-sub">(${HOST.compassDir(d)})</span>`; }
+
+  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
+  const {RADIUS_PRESETS}=window.IntMapTables;
+
+  /* Radius color quick-presets (#R7): R / G / B one-tap swatches alongside the custom color picker. */
+  const RADIUS_COLOR_PRESETS=[{col:'#ff3b30',lbl:'R'},{col:'#34c759',lbl:'G'},{col:'#007aff',lbl:'B'}];
+
+  function buildToolFeatures(){
+    /* radius circles (saved) — antimeridian + pole safe (#6,#5) */
+    const f=[];
+    HOST.radiusItems.forEach(c=>{
+      try{
+        const steps=c.radiusKm>3000?256:160;
+        HOST.diskFillPolys(c.center,c.radiusKm,steps).forEach(poly=>{
+          f.push({type:'Feature',geometry:{type:'Polygon',coordinates:poly},properties:{color:c.color,opacity:c.opacity,noStroke:true}}); });
+        HOST.diskOutlineLines(c.center,c.radiusKm,steps).forEach(ln=>{
+          f.push({type:'Feature',geometry:{type:'LineString',coordinates:ln},properties:{color:c.color,ringline:true}}); });
+        f.push({type:'Feature',geometry:{type:'Point',coordinates:c.center},properties:{color:c.color}});
+      }catch(e){}
+    });
+    /* live measure/area/radius preview */
+    if(HOST.toolMode==='measure'){
+      const all=HOST.measurePoints;
+      for(let i=1;i<all.length;i++){
+        try{ f.push(turf.greatCircle(turf.point(all[i-1]),turf.point(all[i]),{npoints:64})); }
+        catch(e){ f.push(turf.lineString([all[i-1],all[i]])); }
+      }
+      /* Close-affordance (#47): when ≥3 points and the cursor is hovering near the FIRST point,
+         highlight it so it's obvious the next click closes the shape (vs. adding a new point). */
+      HOST.measurePoints.forEach((p,i)=>f.push(turf.point(p, (i===0&&HOST.measureSnapClose&&HOST.measurePoints.length>=3)?{snap:true}:{})));
+      /* Dashed preview from the last fixed point to the live cursor */
+      if(HOST.liveCursor && HOST.measurePoints.length>=1){
+        const last=HOST.measurePoints[HOST.measurePoints.length-1];
+        try{ const gc=turf.greatCircle(turf.point(last),turf.point(HOST.liveCursor),{npoints:32}); gc.properties={...(gc.properties||{}),preview:true}; f.push(gc); }
+        catch(e){ f.push({type:'Feature',geometry:{type:'LineString',coordinates:[last,HOST.liveCursor]},properties:{preview:true}}); }
+      }
+    } else if(HOST.toolMode==='area'){
+      if(HOST.measurePoints.length>=3){
+        /* Great-circle polygon, antimeridian + pole safe (#5): build the ring in continuous lon,
+           then split into pieces that each stay inside [-180,180] (no seam-jump fill bug). */
+        try{
+          const ring=HOST._gcRingUnwrapped(HOST.measurePoints,48);
+          HOST._splitPolyToWindows(ring).forEach(r=>f.push({type:'Feature',geometry:{type:'Polygon',coordinates:[r]},properties:{color:'#007aff',opacity:0.18,noStroke:true}}));
+          HOST._splitLineToWindows(ring).forEach(ln=>f.push({type:'Feature',geometry:{type:'LineString',coordinates:ln},properties:{color:'#007aff',ringline:true}}));
+        }catch(e){ try{ f.push(turf.polygon([[...HOST.measurePoints,HOST.measurePoints[0]]],{color:'#007aff',opacity:0.18,noStroke:true})); }catch(_){} }
+      } else if(HOST.measurePoints.length>=2){
+        try{
+          const gc=turf.greatCircle(turf.point(HOST.measurePoints[0]),turf.point(HOST.measurePoints[1]),{npoints:48});
+          f.push(gc);
+        }catch(e){ f.push(turf.lineString(HOST.measurePoints)); }
+      }
+      HOST.measurePoints.forEach(p=>f.push(turf.point(p)));
+      /* Dashed preview while drawing area: great-circle line to cursor + closing arc */
+      if(HOST.liveCursor && HOST.measurePoints.length>=1){
+        const last=HOST.measurePoints[HOST.measurePoints.length-1];
+        try{ const gc=turf.greatCircle(turf.point(last),turf.point(HOST.liveCursor),{npoints:32}); gc.properties={...(gc.properties||{}),preview:true}; f.push(gc); }
+        catch(e){ f.push({type:'Feature',geometry:{type:'LineString',coordinates:[last,HOST.liveCursor]},properties:{preview:true}}); }
+        if(HOST.measurePoints.length>=2){
+          try{ const gc=turf.greatCircle(turf.point(HOST.liveCursor),turf.point(HOST.measurePoints[0]),{npoints:32}); gc.properties={...(gc.properties||{}),preview:true}; f.push(gc); }
+          catch(e){ f.push({type:'Feature',geometry:{type:'LineString',coordinates:[HOST.liveCursor,HOST.measurePoints[0]]},properties:{preview:true}}); }
+        }
+      }
+    }
+    return f;
+  }
+
+  function ringPerimeter(p){ if(p.length<2)return 0; let s=HOST.totalDistance(p); if(p.length>=3)s+=turf.distance(turf.point(p[p.length-1]),turf.point(p[0]),{units:'kilometers'}); return s; }
+
+  function updateToolPanel(){
+    const p=document.getElementById('tool-panel'); if(!HOST.toolMode){ p.style.display='none'; return; } p.style.display='block';
+    const titles={measure:'📏 '+HOST.t('measure'),area:'📐 '+HOST.t('areaTool'),radius:'⭕ '+HOST.t('radius')}; let body='';
+    if(HOST.toolMode==='measure'){
+      const tot=HOST.hasTurf()?HOST.totalDistance(HOST.measurePoints):0; let brg='';
+      if(HOST.measurePoints.length>=2){
+        const a=HOST.measurePoints[HOST.measurePoints.length-2], b=HOST.measurePoints[HOST.measurePoints.length-1];
+        brg=`<div class="tp-row"><span>${HOST.t('bearing')} (${HOST.lang==='jp'?'最終区間':HOST.lang==='de'?'letzter Abschnitt':HOST.lang==='ru'?'последний отрезок':HOST.lang==='es'?'último tramo':'last leg'})</span><b>${bearingHTML(a,b)}</b></div>`;
+        if(HOST.measurePoints.length>=3){
+          const s=HOST.measurePoints[0], e=HOST.measurePoints[HOST.measurePoints.length-1];
+          brg+=`<div class="tp-row"><span>${HOST.lang==='jp'?'始点→終点':HOST.lang==='de'?'Start → Ende':HOST.lang==='ru'?'начало → конец':HOST.lang==='es'?'inicio → fin':'start → end'}</span><b>${bearingHTML(s,e)}</b></div>`;
+        }
+      }
+      body=`<div class="tp-row"><span>${HOST.t('points')}</span><b>${HOST.measurePoints.length}</b></div><div class="tp-row"><span>${HOST.t('total')}</span><b>${HOST.distHTML(tot)}</b></div>${brg}${HOST.measurePoints.length>=2?`<button class="ai-action-btn" id="tp-profile">📈 ${HOST.t('elevProfile')}</button><button class="ai-action-btn" id="tp-finalize">✓ ${HOST.t('finalizeMeas')}</button>`:''}`;
+    } else if(HOST.toolMode==='area'){
+      const pe=HOST.hasTurf()?ringPerimeter(HOST.measurePoints):0, ar=(HOST.hasTurf()&&HOST.measurePoints.length>=3)?HOST.ringArea(HOST.measurePoints):0;
+      body=`<div class="tp-row"><span>${HOST.t('points')}</span><b>${HOST.measurePoints.length}</b></div><div class="tp-row"><span>${HOST.t('perimeter')}</span><b>${HOST.distHTML(pe)}</b></div><div class="tp-row"><span>${HOST.t('area')}</span><b>${ar?HOST.areaHTML(ar):'—'}</b></div><div class="tp-row" id="tp-pop-row" style="display:none;"><span>${HOST.t('popInArea')}</span><b id="tp-pop-val">—</b></div>${HOST.measurePoints.length>=3?`<button class="ai-action-btn" id="tp-pop-btn">${HOST.t('popInArea')}</button><button class="ai-action-btn" id="news-area-btn">📍 ${HOST.t('newsInArea')}</button><button class="ai-action-btn" id="ai-summarize-btn">📰 ${HOST.t('aiSumBtn')}</button><button class="ai-action-btn" id="tp-profile">📈 ${HOST.t('elevProfile')}</button><button class="ai-action-btn" id="tp-finalize">✓ ${HOST.t('finalizeMeas')}</button>`:''}`;
+    } else if(HOST.toolMode==='radius'){
+      let opts=`<option value="">${HOST.t('presetNone')}</option>`;
+      RADIUS_PRESETS.forEach(grp=>{ opts+=`<optgroup label="${grp.g[HOST.lang]}">`+grp.items.map(it=>`<option value="${it[1]}">${it[0]} — ${it[1]} km</option>`).join('')+`</optgroup>`; });
+      let list='';
+      if(HOST.radiusItems.length){
+        list=`<div class="tp-sub">${HOST.radiusItems.length} ${HOST.t('radius')}</div><div class="radius-list">`+HOST.radiusItems.map((c,i)=>`<div class="radius-list-item"><span class="rl-sw" style="background:${c.color}"></span><span class="rl-main">${c.radiusKm} km · ${c.center[1].toFixed(2)}°,${c.center[0].toFixed(2)}°</span><button class="rl-del" onclick="removeRadiusItem('${c.id}')">✕</button></div>`).join('')+`</div><button class="tp-clear" onclick="clearAllRadius()" style="margin-top:6px;">${HOST.t('removeAll')}</button>`;
+      }
+      body=`<div class="tp-row radius-control"><input type="range" id="radius-range" min="1" max="20000" step="10" value="${Math.min(20000,HOST.radiusKm)}"><div class="radius-row"><button type="button" id="radius-dec" class="rad-step" title="${HOST.lang==='jp'?'小さく':HOST.lang==='de'?'Kleiner':HOST.lang==='ru'?'Мельче':HOST.lang==='es'?'Reducir':'Decrease'}">−</button><input type="number" id="radius-num" min="1" value="${HOST.radiusKm}"><button type="button" id="radius-inc" class="rad-step" title="${HOST.lang==='jp'?'大きく':HOST.lang==='de'?'Größer':HOST.lang==='ru'?'Крупнее':HOST.lang==='es'?'Aumentar':'Increase'}">＋</button><select id="radius-unit" style="background:var(--input-bg);color:var(--text-main);border:1px solid var(--glass-border,rgba(128,128,128,0.25));border-radius:6px;padding:2px 4px;font-size:11.5px;"><option value="km">km</option><option value="mi">mi</option></select></div></div>
+        <div class="rad-stats"><div class="rad-stat"><label>${HOST.t('circumference')}</label><b id="rad-c">${HOST.distHTML(2*Math.PI*HOST.radiusKm)}</b></div><div class="rad-stat"><label>${HOST.t('area')}</label><b id="rad-a">${HOST.areaHTML(Math.PI*HOST.radiusKm*HOST.radiusKm)}</b></div></div><!-- (#R147) dropped the redundant Radius tile (already shown in the slider + number field) to declutter ("項目数が増え、煩雑…UIを整理") -->
+        <details class="tp-more"><summary>${HOST.lang==='jp'?'スタイル・プリセット':HOST.lang==='de'?'Stil und Vorlagen':HOST.lang==='ru'?'Стиль и пресеты':HOST.lang==='es'?'Estilo y ajustes':'Style &amp; presets'}</summary>
+        <div class="tp-sub" style="margin-top:4px;">${HOST.t('presetLbl')}</div><select class="tp-select" id="radius-preset">${opts}</select>
+        <div class="radius-color-row"><span>${HOST.t('color')}</span><div class="rad-presets">${RADIUS_COLOR_PRESETS.map(c=>`<button type="button" class="rad-preset${HOST.radiusColor.toLowerCase()===c.col?' on':''}" data-col="${c.col}" title="${c.lbl}" style="background:${c.col}"></button>`).join('')}</div><input type="color" id="radius-color" value="${HOST.radiusColor}" title="${HOST.lang==='jp'?'カスタム色':HOST.lang==='de'?'Eigene Farbe':HOST.lang==='ru'?'Свой цвет':HOST.lang==='es'?'Color personalizado':'Custom color'}"><span class="tp-sub" style="margin:0;">${HOST.t('opacity')}</span><input type="range" id="radius-op" min="0" max="0.6" step="0.02" value="${HOST.radiusOpacity}" style="flex:1; accent-color:var(--primary-color);"></div></details>
+        ${HOST.radiusItems.length?'':`<div class="tp-hint">${HOST.t('radiusHint')}</div>`}${list}${HOST.radiusItems.length?`<div class="rad-actions"><button class="rad-act" id="tp-pop-btn"><span class="ra-l">${HOST.t('popInArea')}</span></button><button class="rad-act" id="news-area-btn"><span class="ra-l">📍 ${HOST.t('newsInArea')}</span></button><button class="rad-act" id="ai-summarize-btn"><span class="ra-l">📰 ${HOST.t('aiSumBtn')}</span></button></div>`:''}<div class="tp-row" id="tp-pop-row" style="display:none;"><span>${HOST.t('popInArea')}</span><b id="tp-pop-val">—</b></div>`;   /* (#R40/#R142/#R146) circles persist; style/colour/opacity in the "Style" disclosure; 3 area actions in a compact grid (not stacked); usage hint hidden once a circle exists */
+    }
+    const footBtns = (HOST.toolMode!=='radius')
+      ? `<div class="tp-foot-btns">${HOST.measurePoints.length?`<button class="tp-clear" id="tp-undo">↶ ${HOST.t('undoPt')}</button>`:''}<button class="tp-clear" id="tp-clear">${HOST.t('clear')}</button></div>`
+      : '';
+    p.innerHTML=`<div class="tp-header"><span class="tp-title">${titles[HOST.toolMode]}</span><span class="tp-hd-btns"><button class="tp-min-btn" title="${HOST.lang==='jp'?'最小化':HOST.lang==='de'?'Minimieren':HOST.lang==='ru'?'Свернуть':HOST.lang==='es'?'Minimizar':'Minimize'}">–</button><button class="tp-close" title="${HOST.t('close')}">✕</button></span></div>${body}${footBtns}`;
+    p.classList.toggle('tp-radius', HOST.toolMode==='radius');   /* (#R22) drives the compact mobile radius layout */
+    if(p.dataset.collapsed==='1'){ p.classList.add('tp-collapsed'); }   /* (#R34) keep minimized state across re-renders */
+    p.querySelector('.tp-close').onclick=HOST.exitTool; HOST.makeDraggable(p,p.querySelector('.tp-header'));
+    /* (#R34) Minimize button ("Enable − in Radius") — collapses the panel to just its header so the tool no
+       longer covers the centre crosshair on mobile ("Radius widget is too big so it hides the cross pointer"). */
+    { const mb=p.querySelector('.tp-min-btn'); if(mb) mb.onclick=(e)=>{ e.stopPropagation(); const on=p.classList.toggle('tp-collapsed'); p.dataset.collapsed=on?'1':'0'; mb.title=(HOST.lang==='jp'?(on?'展開':'最小化'):HOST.lang==='de'?(on?'Ausklappen':'Minimieren'):HOST.lang==='ru'?(on?'Развернуть':'Свернуть'):HOST.lang==='es'?(on?'Expandir':'Minimizar'):(on?'Expand':'Minimize')); }; }   /* (#R35) icon (line↔box) is drawn by CSS off .tp-collapsed — no text –/+ */
+    { const sb=p.querySelector('#ai-summarize-btn'); if(sb){ sb.classList.toggle('ai-needs-key',!HOST.aiReady()); sb.title=HOST.aiReady()?'':HOST.t('aiNoKey');
+      /* (#R119) the area summary now runs INSIDE the Atlas thread (analyze scope:"drawn-area" = news in the area +
+         displayed-layer values + WorldPop population, one conversation surface). The legacy popup stays as fallback. */
+      sb.onclick=()=>{ try{ if(window.IntMapConsole&&window.IntMapConsole.runDirect){
+          const q5=HOST.lang==='jp'?'描画した範囲内の状況を要約・分析して':HOST.lang==='de'?'Fasse die Lage im gezeichneten Gebiet zusammen':HOST.lang==='ru'?'Сводка по нарисованной области':HOST.lang==='es'?'Resume la situación del área dibujada':'Summarize and analyse the situation inside the drawn area';
+          window.IntMapConsole.runDirect(q5,[{type:'analyze',question:q5,scope:'drawn-area'}]); return; } }catch(_){}
+        aiSummarizeArea(); }; } }
+    { const nb=p.querySelector('#news-area-btn'); if(nb) nb.onclick=()=>{ try{ window._searchNewsInArea(); }catch(_){} }; }
+    { const fb=p.querySelector('#tp-finalize'); if(fb) fb.onclick=()=>{ try{ window._finalizeMeasurement(); }catch(_){} }; const pb=p.querySelector('#tp-profile'); if(pb) pb.onclick=()=>{ try{ window._elevationProfile(); }catch(_){} }; }
+    /* (#R118) population inside the drawn polygon / placed circle(s) — WorldPop 100m grid (see IntMapPopArea) */
+    { const pb2=p.querySelector('#tp-pop-btn');
+      const pbL=(txt)=>{ if(!pb2) return; const l=pb2.querySelector('.ra-l'); if(l) l.textContent=txt; else pb2.textContent=txt; };   /* (#R146) label lives in a .ra-l span (grid ellipsis) — update the span, not the button */
+      const showRes=(popv,yr,src,multi)=>{ const row=p.querySelector('#tp-pop-row'), val=p.querySelector('#tp-pop-val');
+        if(row&&val){ row.style.display=''; val.innerHTML=Number(popv).toLocaleString()+' <span style="font-size:10px;color:var(--text-muted);">('+src+' '+yr+(multi?' · Σ':'')+')</span>'; } };
+      /* (#R122/#R139) PROGRESS BAR — the WorldPop summation runs as a server-side task (~10-30 s). WorldPop gives NO
+         true % for a single request (its task API only reports created/finished), so the old time-based ease-out that
+         DECELERATED toward 92% and snapped to 100% read as meaningless ("100%に近づくほど遅くなる／グラフの意味を成さない").
+         Now HONEST (see window._imProgCtl): an INDETERMINATE animated sweep while there is no real fraction, switching
+         to a REAL LINEAR fraction the moment one exists — a large area that must be TILED reports tiles-done/total,
+         and multiple radius circles advance per finished circle (each circle's own tiling fills its band). */
+      const _progLbl=()=>HOST.lang==='jp'?'WorldPop人口グリッドを集計中…':HOST.lang==='de'?'WorldPop-Bevölkerungsraster wird summiert…':HOST.lang==='ru'?'Суммирование сетки населения WorldPop…':HOST.lang==='es'?'Sumando la cuadrícula de población WorldPop…':'Summing the WorldPop population grid…';
+      const _mkProg=()=>{ let box=p.querySelector('.tp-prog'); if(!box){ box=document.createElement('div'); box.className='tp-prog'; box.style.cssText='margin:7px 0 2px;';
+          box.innerHTML='<div style="display:flex;justify-content:space-between;gap:8px;font-size:10.5px;color:var(--text-muted);margin-bottom:3px;"><span class="tp-prog-lbl" style="min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></span><b class="tp-prog-pct" style="flex:0 0 auto;">0%</b></div><div style="height:7px;border-radius:4px;background:rgba(128,128,128,0.22);overflow:hidden;"><div class="tp-prog-fill" style="height:100%;width:0%;background:linear-gradient(90deg,#0a84ff,#5e5ce6);transition:width .2s;"></div></div>';
+          if(pb2&&pb2.parentNode) pb2.parentNode.insertBefore(box,pb2.nextSibling); else p.appendChild(box); }
+        box.querySelector('.tp-prog-lbl').textContent=_progLbl(); box.classList.remove('indet'); box.style.display='block'; return box; };
+      if(pb2) pb2.onclick=async()=>{ const box=_mkProg(); const P=window._imProgCtl(box); P.busy();
+        const onProg=(f)=>P.set(f);   /* fires only when the area is large enough to be TILED → real tiles-done fraction */
+        try{
+          pb2.disabled=true; pbL(HOST.t('popCalcing'));
+          if(HOST.toolMode==='area'&&HOST.measurePoints.length>=3){
+            const geom={type:'Polygon',coordinates:[[...HOST.measurePoints,HOST.measurePoints[0]]]};
+            const r=await window.IntMapPopArea.estimate(geom, onProg); P.done(); setTimeout(()=>{ box.style.display='none'; },450);
+            showRes(r.pop,r.year,r.src,false); pb2.style.display='none'; return; }
+          if(HOST.toolMode==='radius'&&HOST.radiusItems.length){ let tot=0, yr=2020, src='WorldPop'; const N=HOST.radiusItems.length;
+            for(let i=0;i<N;i++){ if(N>1) P.set(i/N); else P.busy();
+              const c=HOST.radiusItems[i]; const g=window.IntMapPopArea.circleGeom(c.center,c.radiusKm);
+              const r=await window.IntMapPopArea.estimate(g, (N>1)?(f=>P.set((i+Math.max(0,Math.min(1,f)))/N)):onProg); tot+=r.pop; yr=r.year; src=r.src;
+              if(N>1) P.set((i+1)/N); }
+            P.done(); setTimeout(()=>{ box.style.display='none'; },450);
+            showRes(tot,yr,src,N>1); pb2.style.display='none'; return; }
+          box.style.display='none'; pb2.disabled=false; pbL(HOST.t('popInArea'));
+        }catch(e){ box.style.display='none'; pb2.disabled=false; pbL(HOST.t('popFail')); setTimeout(()=>{ try{ pbL(HOST.t('popInArea')); }catch(_){} },2600); } }; }
+    const cl=p.querySelector('#tp-clear'); if(cl) cl.onclick=()=>{ HOST.measurePoints=[]; if(HOST.toolMode==='area'){ HOST.toolMode='measure'; try{ HOST._syncToolBtns(); }catch(_){} } HOST.hideMeasureTip(); HOST.refreshTool(); updateToolPanel(); };
+    const un=p.querySelector('#tp-undo'); if(un) un.onclick=()=>window._measureUndo();
+    if(HOST.toolMode==='radius'){
+      const r=p.querySelector('#radius-range'), n=p.querySelector('#radius-num'), op=p.querySelector('#radius-op'), pre=p.querySelector('#radius-preset'), col=p.querySelector('#radius-color');
+      /* (#R11) When a circle is "active" (just dropped, esp. from a pin / map-click popup), the slider /
+         color / opacity edit THAT circle live — not just the defaults for the next one. */
+      const applyActive=()=>{ if(!window._activeRadiusId) return; const c=HOST.radiusItems.find(x=>x.id===window._activeRadiusId); if(c){ c.radiusKm=HOST.radiusKm; c.color=HOST.radiusColor; c.opacity=HOST.radiusOpacity; HOST.refreshTool(); } };
+      /* (#R15d) Radius input unit toggle (km/mi) — imperial is selectable even when the app default is
+         metric. The slider stays km internally; only the number field + its unit follow the toggle. */
+      const unitSel=p.querySelector('#radius-unit'); if(unitSel && (window.unitMode==='imperial')) unitSel.value='mi';
+      const rImp=()=>!!(unitSel && unitSel.value==='mi');
+      const dispVal=(km)=> rImp()? Math.round(km/1.60934*100)/100 : km;
+      const refresh=()=>{ const rc=p.querySelector('#rad-c'), ra=p.querySelector('#rad-a'); if(rc) rc.innerHTML=HOST.distHTML(2*Math.PI*HOST.radiusKm); if(ra) ra.innerHTML=HOST.areaHTML(Math.PI*HOST.radiusKm*HOST.radiusKm); };   /* (#R147) radius tile removed */
+      const setR=(v,fromInput)=>{ HOST.radiusKm=v; if(!fromInput)n.value=dispVal(v); r.value=Math.min(20000,v); refresh(); applyActive(); };
+      r.oninput=()=>setR(Math.max(1,+r.value));
+      n.oninput=()=>{ const raw=parseFloat(n.value); if(!isNaN(raw)&&raw>0){ const km=rImp()? raw*1.60934 : raw; setR(km,true); } };
+      /* (#R33) −/＋ steppers for the radius (10% per tap, min 1km). */
+      { const dec=p.querySelector('#radius-dec'), inc=p.querySelector('#radius-inc');
+        const step=(f)=>{ const nv=Math.max(1, Math.round(HOST.radiusKm*f)); setR(nv); };
+        if(dec) dec.onclick=()=>step(0.9); if(inc) inc.onclick=()=>step(1.1111); }
+      if(unitSel){ unitSel.onchange=()=>{ n.value=dispVal(HOST.radiusKm); }; unitSel.value=rImp()?'mi':'km'; n.value=dispVal(HOST.radiusKm); }
+      op.oninput=()=>{ HOST.radiusOpacity=parseFloat(op.value); applyActive(); };
+      const markPreset=()=>{ p.querySelectorAll('.rad-preset').forEach(b=>b.classList.toggle('on',(b.getAttribute('data-col')||'').toLowerCase()===HOST.radiusColor.toLowerCase())); };
+      col.oninput=()=>{ HOST.radiusColor=col.value; markPreset(); applyActive(); };
+      /* R / G / B quick presets (#R7) — one tap sets the circle color; the swatch ring shows the
+         active choice. The color picker remains for any custom color. */
+      p.querySelectorAll('.rad-preset').forEach(b=>{ b.onclick=()=>{ HOST.radiusColor=b.getAttribute('data-col'); col.value=HOST.radiusColor; markPreset(); applyActive(); }; });
+      pre.onchange=()=>{ const v=parseFloat(pre.value); if(v>0) setR(v); };
+    }
+  }
+
+  async function aiSummarizeArea(){
+    if(!HOST.aiGate()) return;
+    if(!HOST.hasTurf()){ HOST.aiToast('Turf.js unavailable'); return; }
+    let inside=null;
+    if(HOST.toolMode==='radius'){
+      if(!HOST.radiusItems.length){ HOST.aiToast(HOST.t('aiSumNoArea')); return; }
+      inside=(lng,lat)=>HOST.radiusItems.some(c=>{ try{ return turf.distance(turf.point(c.center),turf.point([lng,lat]),{units:'kilometers'})<=c.radiusKm; }catch(_){ return false; } });
+    } else if(HOST.toolMode==='area'){
+      if(HOST.measurePoints.length<3){ HOST.aiToast(HOST.t('aiSumNoArea')); return; }
+      let poly; try{ poly=turf.polygon([[...HOST.measurePoints,HOST.measurePoints[0]]]); }catch(_){ HOST.aiToast(HOST.t('aiSumNoArea')); return; }
+      inside=(lng,lat)=>{ try{ return turf.booleanPointInPolygon(turf.point([lng,lat]),poly); }catch(_){ return false; } };
+    } else { return; }
+    const seen=new Set(), picked=[];
+    HOST.newsFeatures.forEach(f=>{ const c=f.geometry&&f.geometry.coordinates, p=f.properties||{}; if(!c||!inside(c[0],c[1])) return; const k=p.link||p.title; if(seen.has(k)) return; seen.add(k); picked.push(p); });
+    const uniq=picked.slice(0,40);
+    if(!uniq.length){ HOST.aiToast(HOST.t('aiSumNoNews')); return; }
+    HOST._aiAreaSummarize(uniq,'aiSumTitle');
+  }
+
+  /* Context menu */
+  function showContextMenu(point,lngLat){
+    const m=document.getElementById('ctx-menu'); const mc=document.getElementById('map-container').getBoundingClientRect();
+    const items=[
+      {h:`${HOST.t('ctxThisPoint')}: ${HOST.fmtLL(lngLat.lng,lngLat.lat)}`,head:true},
+      {label:`${HOST.lang==='jp'?'ここをAtlasに聞く':HOST.lang==='de'?'Atlas zu diesem Ort fragen':HOST.lang==='ru'?'Спросить Atlas об этом месте':HOST.lang==='es'?'Preguntar a Atlas sobre aquí':'Ask Atlas about here'}`, action:()=>{ try{ if(window.IntMapConsole&&window.IntMapConsole.askHere) window.IntMapConsole.askHere(lngLat); else if(window.IntMapConsole) window.IntMapConsole.open(); }catch(_){} }},
+      {label:`🧍 ${HOST.lang==='jp'?'ここのストリートビュー':HOST.lang==='de'?'Street View hier':HOST.lang==='ru'?'Просмотр улиц здесь':HOST.lang==='es'?'Street View aquí':'Street View here'}`, action:()=>{ try{ window.IntMapStreetView&&window.IntMapStreetView.open({lng:lngLat.lng,lat:lngLat.lat}); }catch(_){} }},
+      {label:`📍 ${HOST.t('ctxDropPin')}`, action:()=>{ const id=HOST.addPin(lngLat.lng,lngLat.lat); HOST.openPinPopup(id); }},
+      {label:`📏 ${HOST.t('ctxMeasureFrom')}`, action:()=>{ if(HOST.toolMode!=='measure') HOST.setTool('measure'); HOST.measurePoints=[[lngLat.lng,lngLat.lat]]; HOST.refreshTool(); updateToolPanel(); }},
+      {label:`⭕ ${HOST.lang==='jp'?'ここからの半径':HOST.lang==='de'?'Radius von hier':HOST.lang==='ru'?'Радиус отсюда':'Radius from here'}`, action:()=>{ try{ window._radiusFromPoint(lngLat.lng,lngLat.lat); }catch(_){} }},
+      {label:`💬 ${HOST.t('ctxPostHere')}`, action:()=>{ if(!HOST.requireLogin()) return; HOST.pendingPostLoc=[lngLat.lng,lngLat.lat]; HOST.communityAddArmed=false; HOST.openComposeModal(); }},
+      {divider:true},
+      /* (#R8c) Alt-projection viewer removed (MapLibre renders only Mercator/Globe). (#R9) "Copy link to
+         this view" removed per request — the live-permalink hash still restores a reload. */
+      {label:`📋 ${HOST.t('ctxCopy')}`, action:()=>{ try{ navigator.clipboard.writeText(`${lngLat.lat.toFixed(5)}, ${lngLat.lng.toFixed(5)}`); }catch(_){} }},
+      /* (#R40/#R42) Share the EXACT current state (position, zoom, projection, base map, layers, time-travel,
+         compare) as a link — opens the surfaced IntMapShare panel (link shown + copy + native share). */
+      {label:`🔗 ${HOST.lang==='jp'?'この表示を共有':HOST.lang==='de'?'Diese Ansicht teilen':HOST.lang==='ru'?'Поделиться этим видом':HOST.lang==='es'?'Compartir esta vista':'Share this view'}`, action:()=>{ try{ window.IntMapShare&&window.IntMapShare.open(); }catch(_){} }},
+      {label:`🌤 ${HOST.lang==='jp'?'ここの天気（最新）':HOST.lang==='de'?'Wetter hier (aktuell)':HOST.lang==='ru'?'Погода здесь (сейчас)':HOST.lang==='es'?'El tiempo aquí (ahora)':'Weather here (live)'}`, action:()=>{ try{ window.IntMapWeather&&window.IntMapWeather.open(lngLat); }catch(_){} }},
+      {label:`🛬 ${HOST.lang==='jp'?'滑走路検索（ここから）':HOST.lang==='de'?'Start-/Landebahn-Suche (von hier)':HOST.lang==='ru'?'Поиск ВПП (отсюда)':'Runway search (from here)'}`, action:()=>{ try{ window.RunwaySearch&&window.RunwaySearch.open(lngLat); }catch(_){} }},
+      {label:`📡 ${HOST.lang==='jp'?'見通し線解析（レーダー死角）':HOST.lang==='de'?'Sichtlinie (Radarschatten)':HOST.lang==='ru'?'Линия видимости (радиотень)':'Line of sight (radar shadow)'}`, action:()=>{ try{ window.IntMapLOS&&window.IntMapLOS.open(lngLat); }catch(_){} }},
+      {label:`🎯 ${HOST.lang==='jp'?'到達圏（車/徒歩/自転車）':HOST.lang==='de'?'Erreichbarkeit (Auto/Fuß/Rad)':HOST.lang==='ru'?'Зона доступности (авто/пешком/вело)':HOST.lang==='es'?'Área alcanzable (coche/pie/bici)':'Reachable area (drive/walk/cycle)'}`, action:()=>{ try{ window.IntMapIsochrone&&window.IntMapIsochrone.open(lngLat); }catch(_){} }},
+      /* (#R15c) Sea-route feature removed per request — repeatedly mis-routed (shallow endpoints / linear /
+         cut across land). The IntMapRoute engine stays defined but is no longer reachable from the UI. */
+      ...(HOST.userPins.length?[{label:`🗑 ${HOST.t('ctxClearPins')} (${HOST.userPins.length})`, action:HOST.clearAllPins}]:[])
+    ];
+    m.innerHTML=items.map(it=>{
+      if(it.divider) return `<div class="ctx-divider"></div>`;
+      if(it.head) return `<div class="ctx-head">${it.h}</div>`;
+      return `<button data-act="${items.indexOf(it)}">${it.label}</button>`;
+    }).join('');
+    m.querySelectorAll('button[data-act]').forEach(b=>{ b.onclick=()=>{ const i=+b.getAttribute('data-act'); items[i].action(); m.style.display='none'; }; });
+    m.style.display='block';
+    /* (#R17) On mobile the bottom sheet covers the lower map; clamp the menu into the VISIBLE area above it
+       (and cap its height so a long menu scrolls) — it was overflowing behind the sheet / off-screen. */
+    let availBottom=mc.height; try{ const mcEl=document.getElementById('map-container'); const cover=parseFloat(getComputedStyle(mcEl).getPropertyValue('--sheet-cover'))||0; const isM=window.matchMedia&&window.matchMedia('(max-width:768px)').matches; if(isM&&cover>0){ availBottom=mc.height-cover-8; m.style.maxHeight=Math.max(160,availBottom-56)+'px'; m.style.overflowY='auto'; } else { m.style.maxHeight=''; m.style.overflowY=''; } }catch(_){}
+    const rect=m.getBoundingClientRect();
+    let x=point.x, y=point.y;
+    if(x+rect.width>mc.width) x=mc.width-rect.width-8;
+    if(y+rect.height>availBottom) y=availBottom-rect.height-8;
+    m.style.left=Math.max(8,x)+'px'; m.style.top=Math.max(8,y)+'px';
+  }
+
+  /* The names index.html still calls: it keeps a hoisted shim for each (#R168). */
+  return { updateToolPanel, buildToolFeatures, showContextMenu };
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test",
     "test:security": "node --test tests/security-logic.mjs",
     "test:monitor": "node --test tests/monitor-logic.test.mjs",
-    "test:checks": "node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs tests/r149-checks.test.mjs tests/r150-checks.test.mjs tests/r151-checks.test.mjs tests/r152-checks.test.mjs tests/r153-checks.test.mjs tests/r154-checks.test.mjs tests/r155-checks.test.mjs tests/r156-checks.test.mjs tests/r157-checks.test.mjs tests/r158-checks.test.mjs tests/r159-checks.test.mjs tests/r160-checks.test.mjs tests/r161-checks.test.mjs tests/r162-checks.test.mjs tests/r163-checks.test.mjs tests/r164-checks.test.mjs tests/r165-checks.test.mjs tests/r166-checks.test.mjs tests/r167-checks.test.mjs",
+    "test:checks": "node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs tests/r149-checks.test.mjs tests/r150-checks.test.mjs tests/r151-checks.test.mjs tests/r152-checks.test.mjs tests/r153-checks.test.mjs tests/r154-checks.test.mjs tests/r155-checks.test.mjs tests/r156-checks.test.mjs tests/r157-checks.test.mjs tests/r158-checks.test.mjs tests/r159-checks.test.mjs tests/r160-checks.test.mjs tests/r161-checks.test.mjs tests/r162-checks.test.mjs tests/r163-checks.test.mjs tests/r164-checks.test.mjs tests/r165-checks.test.mjs tests/r166-checks.test.mjs tests/r167-checks.test.mjs tests/r168-checks.test.mjs",
     "test": "node scripts/static-checks.mjs && npm run test:checks && playwright test",
     "report": "playwright show-report"
   },

--- a/tests/r152-checks.test.mjs
+++ b/tests/r152-checks.test.mjs
@@ -36,7 +36,10 @@ test('R152 #2 Companies compare dock is the static absolute-overlay (Countries p
   assert.match(html, /\.stats-compare-fixed, \.co-compare-fixed\{ display:none; position:absolute;/, 'shares the Countries dock styling');
   assert.match(html, /\.stats-compare-fixed\.show, \.co-compare-fixed\.show\{ display:block; \}/, 'shown via .show');
   assert.match(html, /function _companiesActive\(\)\{/, 'active-tab test mirrors _countriesActive');
-  assert.match(html, /currentMode!=='info'\)\{ const cof=document\.getElementById\('co-compare-fixed'\)/, 'hidden on tab-switch like Countries');
+  /* (#R168) renderUI moved into js/news-ui.js, where the active tab is read through the host, so the
+     same line now spells it HOST.mode. Both forms are accepted: what is being guarded is that the
+     Companies dock is hidden when the tab is not 'info', not which scope the value came from. */
+  assert.match(html, /(?:currentMode|HOST\.mode)!=='info'\)\{ const cof=document\.getElementById\('co-compare-fixed'\)/, 'hidden on tab-switch like Countries');
   assert.match(html, /\(window\.imShowRank!=='off'\)\?`<span class="stat-rank">/, 'Companies honours the rank setting');
 });
 

--- a/tests/r165-checks.test.mjs
+++ b/tests/r165-checks.test.mjs
@@ -51,22 +51,52 @@ function code(src) {
    satellite controller when World Explorer takes the screen; #R167 added three more for the news
    timeline (moving the clock replaces the news arrays) and the dashboard cache (a cold start assigns
    the IndexedDB copy back). Adding a row here is a deliberate act: the contract is that a module
-   writes closure state ONLY through a member listed below. */
+   writes closure state ONLY through a member listed below.
+
+   (#R168) `owner` became `owners`, a SET. Up to #R167 every RW member happened to have exactly one
+   writing module, and the test hard-coded that. The seventh split moved whole SUBJECTS out, and some
+   state genuinely has two writers — the radius/measure values are set both by an Atlas command and by
+   the tool panel the user drags; a bookmark is added from the news feed and cleared from the account
+   menu; the news pins are replaced both when the clock moves and when the AI geocoder finishes. A
+   single-owner rule could only be satisfied by pretending otherwise. What matters for auditing is
+   unchanged and still enforced: for every member there is an explicit, exhaustive list of the files
+   allowed to write it, every listed file really does write it, and nothing else writes it at all. */
 const RW = {
-  measurePoints:     { v: 'measurePoints',     owner: 'atlas-console.js', oneLinePair: true },
-  radiusColor:       { v: 'radiusColor',       owner: 'atlas-console.js', oneLinePair: true },
-  radiusKm:          { v: 'radiusKm',          owner: 'atlas-console.js', oneLinePair: true },
-  unitMode:          { v: 'unitMode',          owner: 'atlas-console.js', oneLinePair: true },
-  userTheme:         { v: 'userTheme',         owner: 'atlas-console.js', oneLinePair: true },
+  measurePoints:      { v: 'measurePoints',      owners: ['atlas-console.js', 'tool-panel.js'] },
+  radiusColor:        { v: 'radiusColor',        owners: ['atlas-console.js', 'tool-panel.js'] },
+  radiusKm:           { v: 'radiusKm',           owners: ['atlas-console.js', 'tool-panel.js'] },
+  unitMode:           { v: 'unitMode',           owners: ['atlas-console.js'] },
+  userTheme:          { v: 'userTheme',          owners: ['atlas-console.js'] },
   /* `mode`'s getter sits with the other mutable state (it predates the setter), so only the pairing
      over the same closure variable is required — not that both halves share a line. */
-  mode:              { v: 'currentMode',       owner: 'playground.js',    oneLinePair: false },
-  satPanelDismissed: { v: 'satPanelDismissed', owner: 'playground.js',    oneLinePair: true },
+  mode:               { v: 'currentMode',        owners: ['playground.js'], oneLinePair: false },
+  satPanelDismissed:  { v: 'satPanelDismissed',  owners: ['playground.js'] },
   /* Same exception as `mode`: globalData and newsFeatures were already live getters up with the
      other mutable state before #R167 gave them setters. */
-  globalData:        { v: 'globalData',        owner: 'news-timeline.js', oneLinePair: false },
-  newsFeatures:      { v: 'newsFeatures',      owner: 'news-timeline.js', oneLinePair: false },
-  extendedDashDB:    { v: 'extendedDashDB',    owner: 'dash-extended.js', oneLinePair: true },
+  globalData:         { v: 'globalData',         owners: ['news-timeline.js'], oneLinePair: false },
+  newsFeatures:       { v: 'newsFeatures',       owners: ['news-timeline.js', 'news-ui.js'], oneLinePair: false },
+  extendedDashDB:     { v: 'extendedDashDB',     owners: ['dash-extended.js'] },
+  /* ── (#R168) the seventh split. countryGeo / toolMode / user already had live getters up with the
+     rest of the mutable state, so those three are pairs across the object rather than on one line. ── */
+  countryDataLoaded:  { v: 'countryDataLoaded',  owners: ['countries-ui.js'] },
+  countryDataPromise: { v: 'countryDataPromise', owners: ['countries-ui.js'] },
+  countryGeo:         { v: 'countryGeo',         owners: ['countries-ui.js'], oneLinePair: false },
+  bookmarks:          { v: 'bookmarks',          owners: ['auth-ui.js', 'news-ui.js'] },
+  renderedCount:      { v: 'renderedCount',      owners: ['news-ui.js'] },
+  dashFeatures:       { v: 'dashFeatures',       owners: ['companies-ui.js'] },
+  _coTimeDeb:         { v: '_coTimeDeb',         owners: ['companies-ui.js'] },
+  _coTimeWired:       { v: '_coTimeWired',       owners: ['companies-ui.js'] },
+  radiusOpacity:      { v: 'radiusOpacity',      owners: ['tool-panel.js'] },
+  toolMode:           { v: 'toolMode',           owners: ['tool-panel.js'], oneLinePair: false },
+  communityAddArmed:  { v: 'communityAddArmed',  owners: ['community.js', 'tool-panel.js'] },
+  pendingPostLoc:     { v: 'pendingPostLoc',     owners: ['community.js', 'tool-panel.js'] },
+  user:               { v: 'currentUser',        owners: ['auth-ui.js'], oneLinePair: false },
+  geoRaw:             { v: 'geoRaw',             owners: ['auth-ui.js'] },
+  commCatFilter:      { v: 'commCatFilter',      owners: ['community.js'] },
+  commInView:         { v: 'commInView',         owners: ['community.js'] },
+  commSearch:         { v: 'commSearch',         owners: ['community.js'] },
+  communitySort:      { v: 'communitySort',      owners: ['community.js'] },
+  replyingTo:         { v: 'replyingTo',         owners: ['community.js'] },
 };
 const RW_NAMES = Object.keys(RW);
 
@@ -111,10 +141,18 @@ test('R165 #2 THE RW CONTRACT: the setter list is exactly the declared members, 
   for (const [name, spec] of Object.entries(RW)) {
     assert.match(body, new RegExp(`get ${name}\\(\\)\\{ return ${spec.v}; \\}`),
       `IM_HOST.${name} must have a getter over ${spec.v}`);
-    if (spec.oneLinePair) {
+    if (spec.oneLinePair !== false) {
       const pair = new RegExp(`get ${name}\\(\\)\\{ return ${spec.v}; \\},\\s*set ${name}\\(v\\)\\{ ${spec.v}=v; \\}`);
       assert.match(body, pair, `IM_HOST.${name} must be a one-line get+set pair over ${spec.v}`);
     }
+  }
+  // (b2) (#R168) and each accessor is declared exactly ONCE — a member that grows a second getter
+  //      (e.g. re-adding the pair for one that already had a live getter) still parses, and the
+  //      later definition silently wins.
+  for (const kind of ['get', 'set']) {
+    const seen = new Map();
+    for (const m of body.matchAll(new RegExp(`\\b${kind}\\s+([A-Za-z_$][\\w$]*)\\s*\\(`, 'g'))) seen.set(m[1], (seen.get(m[1]) || 0) + 1);
+    assert.deepEqual([...seen].filter(([, n]) => n > 1), [], `IM_HOST declares a duplicate ${kind}ter`);
   }
   // (c) the owning module really writes every RW member through the host — if a write disappears,
   //     the member should be demoted to a plain getter (and this list updated consciously).
@@ -122,17 +160,22 @@ test('R165 #2 THE RW CONTRACT: the setter list is exactly the declared members, 
   //     /[&<>"']/ starts a phantom string and eats the following code — the #R162 lesson), and it
   //     eats exactly the `HOST.measurePoints=` write site. A false positive is impossible here:
   //     the header prose never spells a member as `HOST.<name>=`.
+  //     (#R168) accept every write form, not just `=`: js/news-ui.js advances the lazy-batch counter
+  //     with `HOST.renderedCount+=next.length`, which reads through the getter and writes through the
+  //     setter exactly as a plain assignment would.
   for (const [name, spec] of Object.entries(RW)) {
-    assert.match(rd('js/' + spec.owner), new RegExp(`HOST\\.${name}\\s*=(?!=)`),
-      `js/${spec.owner} must write HOST.${name} somewhere — otherwise demote it to a getter`);
+    for (const owner of spec.owners) {
+      assert.match(rd('js/' + owner), new RegExp(`HOST\\.${name}\\s*(?:=(?!=)|\\+\\+|--|[+\\-*/%&|^]=)`),
+        `js/${owner} must write HOST.${name} somewhere — otherwise drop it from that member's owner list`);
+    }
   }
   // (d) no module writes a host member it does not own: every HOST.* write in every js/ file must
-  //     be an RW member whose declared owner is that same file (the #R164 zero-write contract kept
-  //     explicit for everyone else).
+  //     be an RW member whose declared owner list contains that same file (the #R164 zero-write
+  //     contract kept explicit for everyone else).
   for (const f of readdirSync(new URL('js/', root)).filter((x) => x.endsWith('.js'))) {
     const src = code(rd('js/' + f));
     const writes = [...src.matchAll(/HOST\.([A-Za-z_$][\w$]*)\s*(?:=(?!=)|\+\+|--|[+\-*/%&|^]=)/g)].map((m) => m[1]);
-    const bad = writes.filter((w) => !RW[w] || RW[w].owner !== f);
+    const bad = writes.filter((w) => !RW[w] || !RW[w].owners.includes(f));
     assert.deepEqual(bad, [], `js/${f} writes host member(s) it does not own: ${bad.join(', ')}`);
   }
 });

--- a/tests/r167-checks.test.mjs
+++ b/tests/r167-checks.test.mjs
@@ -19,7 +19,7 @@
 // test #5 keeps it that way.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
 import { checkSplitScope } from '../scripts/check-split-scope.mjs';
@@ -127,36 +127,47 @@ test('R167 #3 THE TABLE CONTRACT: js/tables.js is pure data that index.html neve
   assert.ok(src.includes('window.SEA_LABELS=['),
     'SEA_LABELS keeps its own global — its consumers already read it off window');
 
-  // (a) every table is exported, and index.html rebinds every one of them.
+  // (a) every table is exported, and the app rebinds every one of them. (#R168) the rebinding
+  //     statement is no longer always in index.html: the country tables went into js/countries-ui.js
+  //     with the code that reads them, the company ones into js/companies-ui.js, RADIUS_PRESETS into
+  //     js/tool-panel.js. Which FILE rebinds a table is not what this contract is about — that it is
+  //     rebound from window.IntMapTables exactly once, and never re-declared inline, is.
+  const consumers = ['index.html', 'js/countries-ui.js', 'js/companies-ui.js', 'js/tool-panel.js'].map((p) => [p, rd(p)]);
   const retAt = src.lastIndexOf('return {');
   const ret = src.slice(retAt, src.indexOf('};', retAt) + 2);
   for (const t of TABLES) {
     assert.match(ret, new RegExp(`[{,]${t}[,}]`), `js/tables.js returns ${t}`);
-    assert.match(html, new RegExp(`const \\{[^}]*\\b${t}\\b[^}]*\\}=window\\.IntMapTables;`),
-      `index.html rebinds ${t} from window.IntMapTables`);
-    assert.ok(!new RegExp(`(?:^|\\n)\\s*const ${t}\\s*=`).test(html),
-      `${t} must not be declared inline in index.html again`);
+    const where = consumers.filter(([, s]) => new RegExp(`const \\{[^}]*\\b${t}\\b[^}]*\\}=window\\.IntMapTables;`).test(s)).map(([p]) => p);
+    assert.equal(where.length, 1, `exactly one file must rebind ${t} from window.IntMapTables (found: ${where.join(', ') || 'none'})`);
+    for (const [p, s] of consumers) {
+      assert.ok(!new RegExp(`(?:^|\\n)\\s*const ${t}\\s*=`).test(s), `${t} must not be declared inline in ${p} again`);
+    }
   }
 
   // (b) THE reason a plain value hand-off is safe here: nothing ever writes these objects. A member
-  //     write or a mutating call anywhere in index.html would mean the table is really shared state,
-  //     and it would have to move back or become a host member. Checked with a real parser.
+  //     write or a mutating call anywhere would mean the table is really shared state, and it would
+  //     have to move back or become a host member. Checked with a real parser — over index.html's
+  //     closure AND every js/ module, since #R168 moved consumers of these tables into modules.
   const marker = html.lastIndexOf("window.addEventListener('DOMContentLoaded'");
   const open = html.lastIndexOf('<script>', marker), close = html.indexOf('</script>', marker);
-  const ast = acorn.parse(html.slice(open + '<script>'.length, close), { ecmaVersion: 'latest' });
+  const sources = [['index.html', html.slice(open + '<script>'.length, close)]];
+  for (const f of readdirSync(new URL('js/', root)).filter((x) => x.endsWith('.js')).sort()) sources.push(['js/' + f, rd('js/' + f)]);
   const names = new Set(TABLES);
   const MUT = new Set(['push', 'pop', 'splice', 'sort', 'shift', 'unshift', 'reverse', 'fill', 'copyWithin']);
   const writes = [];
-  walk.full(ast, (n) => {
-    if (n.type === 'AssignmentExpression' && n.left.type === 'MemberExpression'
-        && n.left.object.type === 'Identifier' && names.has(n.left.object.name)) writes.push(n.left.object.name + '.<member>=');
-    if (n.type === 'UnaryExpression' && n.operator === 'delete' && n.argument.type === 'MemberExpression'
-        && n.argument.object.type === 'Identifier' && names.has(n.argument.object.name)) writes.push('delete ' + n.argument.object.name);
-    if (n.type === 'CallExpression' && n.callee.type === 'MemberExpression' && !n.callee.computed
-        && n.callee.object.type === 'Identifier' && names.has(n.callee.object.name) && MUT.has(n.callee.property.name))
-      writes.push(n.callee.object.name + '.' + n.callee.property.name + '()');
-  });
-  assert.deepEqual(writes, [], 'a table in js/tables.js is mutated by index.html: ' + writes.join(', '));
+  for (const [where, js] of sources) {
+    const ast = acorn.parse(js, { ecmaVersion: 'latest' });
+    walk.full(ast, (n) => {
+      if (n.type === 'AssignmentExpression' && n.left.type === 'MemberExpression'
+          && n.left.object.type === 'Identifier' && names.has(n.left.object.name)) writes.push(where + ': ' + n.left.object.name + '.<member>=');
+      if (n.type === 'UnaryExpression' && n.operator === 'delete' && n.argument.type === 'MemberExpression'
+          && n.argument.object.type === 'Identifier' && names.has(n.argument.object.name)) writes.push(where + ': delete ' + n.argument.object.name);
+      if (n.type === 'CallExpression' && n.callee.type === 'MemberExpression' && !n.callee.computed
+          && n.callee.object.type === 'Identifier' && names.has(n.callee.object.name) && MUT.has(n.callee.property.name))
+        writes.push(where + ': ' + n.callee.object.name + '.' + n.callee.property.name + '()');
+    });
+  }
+  assert.deepEqual(writes, [], 'a table in js/tables.js is mutated: ' + writes.join(', '));
 });
 
 test('R167 #4 INVARIANT: every reassigned closure value these blocks touch is a LIVE host member', () => {

--- a/tests/r168-checks.test.mjs
+++ b/tests/r168-checks.test.mjs
@@ -1,0 +1,249 @@
+// R168 source-level regression checks — the seventh index.html split.
+//
+// #R162–#R167 took index.html from 36,955 lines to 9,709 by moving out whole self-contained BLOCKS.
+// #R167 reported that seam exhausted: what remained was one dense core in which no single statement
+// is independent (10–36 free references each). That is true of STATEMENTS. It is not true of
+// SUBJECTS: take a seed function, then absorb every statement whose declared names nothing outside
+// reads, and the private helpers come with it while the external surface shrinks. Six such subjects
+// came out this round — countries, news, companies, the tool panel, auth and community.
+//
+// Two things are genuinely new here, and both are what this file pins down:
+//
+//   1. SHIMS. These are the first modules index.html still calls BY NAME (renderStats, renderUI,
+//      openAuthModal, …). Each exported function therefore keeps a hoisted `function` shim in
+//      index.html that forwards with `.apply(this,arguments)`. A shim must be a function
+//      DECLARATION: the originals were hoisted, so call sites textually above the factory call —
+//      and IM_HOST's own getters, which sit ~1,300 lines earlier — must keep working unchanged.
+//   2. DECLARATION-ONLY FACTORIES. All six are instantiated in one place right after `map` is built,
+//      much earlier than the code they replaced. That is only safe because none of these factories
+//      DOES anything while running: every top-level statement in them is a declaration. Test #4
+//      proves that property rather than trusting it — it is what rules out both a temporal dead zone
+//      (the #R167 trap) and any reordered side effect.
+//
+// The RW contract (now an owner SET — some of this state genuinely has two writers) lives in
+// r165-checks.test.mjs; the real-browser proofs live in r168.spec.js.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import * as acorn from 'acorn';
+import { checkSplitScope } from '../scripts/check-split-scope.mjs';
+
+const root = new URL('../', import.meta.url);
+const rd = (p) => readFileSync(new URL(p, root), 'utf8');
+const html = rd('index.html');
+
+/* Blank comments + string/template literals so identifier scanning reads CODE only. */
+function code(src) {
+  let out = '', i = 0, inBlock = false;
+  while (i < src.length) {
+    const c = src[i], c2 = src[i + 1];
+    if (inBlock) { if (c === '*' && c2 === '/') { inBlock = false; out += '  '; i += 2; } else { out += c === '\n' ? '\n' : ' '; i++; } continue; }
+    if (c === '/' && c2 === '*') { inBlock = true; out += '  '; i += 2; continue; }
+    if (c === '/' && c2 === '/') { while (i < src.length && src[i] !== '\n') { out += ' '; i++; } continue; }
+    if (c === '"' || c === "'" || c === '`') {
+      const q = c; out += ' '; i++;
+      while (i < src.length) {
+        if (src[i] === '\\') { out += '  '; i += 2; continue; }
+        if (src[i] === q) { out += ' '; i++; break; }
+        out += src[i] === '\n' ? '\n' : ' '; i++;
+      }
+      continue;
+    }
+    out += c; i++;
+  }
+  return out;
+}
+
+/* factory -> { file, const, the names index.html keeps a shim for }. The order of this object is the
+   order the six calls must appear in — one block, right after the map is constructed. */
+const MODULES = {
+  countriesUi: { file: 'js/countries-ui.js', k: 'IM_COUNTRIES_UI', exports: ['renderStats', 'showCountryDetail', 'renderCountryDetailBody', 'loadCountryData', 'addCountryLayers'] },
+  newsUi:      { file: 'js/news-ui.js',      k: 'IM_NEWS_UI',      exports: ['renderUI', 'setupIntelLayers', 'appendNewsBatch', 'renderReaderMode', 'aiGeocodeNews', '_spreadDupNewsPins'] },
+  companiesUi: { file: 'js/companies-ui.js', k: 'IM_COMPANIES_UI', exports: ['renderCompanies', 'showCompanyDetail', 'renderDashboard', '_coCmpEnsureCss', '_coCmpRender'] },
+  toolPanel:   { file: 'js/tool-panel.js',   k: 'IM_TOOL_PANEL',   exports: ['updateToolPanel', 'buildToolFeatures', 'showContextMenu'] },
+  authUi:      { file: 'js/auth-ui.js',      k: 'IM_AUTH_UI',      exports: ['bootSupabase', '_openSetPassword', 'openAuthModal'] },
+  community:   { file: 'js/community.js',    k: 'IM_COMMUNITY',    exports: ['renderCommunity', 'wireCommList'] },
+};
+const NAMES = Object.keys(MODULES);
+const shimOf = (m, n) => `function ${n}(){ return ${MODULES[m].k}.${n}.apply(this,arguments); }`;
+const callOf = (m) => `const ${MODULES[m].k}=window.IntMapModules.${m}(map,IM_HOST);`;
+
+/* Closure values these modules read that are REASSIGNED at runtime → live host getters, never a bare
+   identifier inside a js/ file. A captured copy would silently go stale (the #R162 shape). */
+const LIVE = {
+  currentLang: 'lang', currentUser: 'user', currentMode: 'mode', currentMapType: 'mapType',
+  countryGeo: 'countryGeo', countryDataLoaded: 'countryDataLoaded', countryDataPromise: 'countryDataPromise',
+  globalData: 'globalData', newsFeatures: 'newsFeatures', newsFiltered: 'newsFiltered', renderedCount: 'renderedCount',
+  bookmarks: 'bookmarks', dashFeatures: 'dashFeatures', toolMode: 'toolMode', measurePoints: 'measurePoints',
+  radiusItems: 'radiusItems', radiusKm: 'radiusKm', radiusColor: 'radiusColor', radiusOpacity: 'radiusOpacity',
+  geoRaw: 'geoRaw', commCatFilter: 'commCatFilter', commSearch: 'commSearch', communitySort: 'communitySort',
+  communityPosts: 'communityPosts', replyingTo: 'replyingTo', pendingPostLoc: 'pendingPostLoc',
+  communityAddArmed: 'communityAddArmed',
+};
+
+test('R168 #1 all six files are loaded and every factory is declared and instantiated once', () => {
+  for (const m of NAMES) {
+    const { file } = MODULES[m];
+    const src = rd(file);
+    assert.ok(html.includes(`<script src="${file}"></script>`), `index.html loads ${file}`);
+    assert.ok(src.includes('window.IntMapModules=window.IntMapModules||{};'),
+      `${file} extends IntMapModules without clobbering what earlier files put there`);
+    assert.ok(src.includes(`window.IntMapModules.${m}=function(map,HOST){`),
+      `${file} declares the ${m} factory taking (map,HOST)`);
+    assert.ok(!/<style>/.test(code(src)), `${file} must not carry CSS — the stylesheet stays in css/intmap.css`);
+    const calls = html.split(callOf(m)).length - 1;
+    assert.equal(calls, 1, `index.html must instantiate ${m} exactly once (found ${calls})`);
+    const defined = [...src.matchAll(/window\.IntMapModules\.(\w+)\s*=\s*function/g)].map((x) => x[1]);
+    assert.deepEqual(defined, [m], `${file} defines exactly one factory`);
+    assert.match(html, new RegExp(`'${m}'`), `the boot guard names the ${m} factory, so a missing file cannot hide`);
+  }
+});
+
+test('R168 #2 THE SHIM CONTRACT: every exported name is a hoisted forwarding declaration', () => {
+  for (const m of NAMES) {
+    const { file, exports } = MODULES[m];
+    const src = rd(file);
+
+    // (a) the module returns exactly the declared export list.
+    const retAt = src.lastIndexOf('return {');
+    const ret = src.slice(retAt, src.indexOf('};', retAt) + 2);
+    const returned = ret.replace(/^return \{|\};$/g, '').split(',').map((s) => s.trim()).filter(Boolean);
+    assert.deepEqual(returned, exports, `${file} must return exactly its declared exports`);
+
+    for (const n of exports) {
+      // (b) each one really is a function declared INSIDE the module (not, say, re-exported junk).
+      assert.match(src, new RegExp(`(?:^|\\n)\\s*(?:async\\s+)?function ${n}\\(`),
+        `${file} declares function ${n}`);
+
+      // (c) index.html keeps exactly one shim, and it is a hoisted function DECLARATION that
+      //     forwards receiver AND arguments. `const ${n}=…` would break every call site above the
+      //     factory (TDZ) and `(...a)=>` would silently drop `this`.
+      const shim = shimOf(m, n);
+      assert.equal(html.split(shim).length - 1, 1, `index.html holds exactly one shim for ${n}: ${shim}`);
+
+      // (d) and index.html no longer declares the real thing anywhere.
+      const inline = [...code(html).matchAll(new RegExp(`(?:^|[^.\\w$])(?:async\\s+function|function|const|let|var)\\s+${n.replace(/\$/g, '\\$')}(?![\\w$])`, 'g'))];
+      assert.equal(inline.length, 1, `${n} must exist in index.html only as its shim (found ${inline.length} declarations)`);
+    }
+  }
+});
+
+test('R168 #3 POSITION: the six calls sit together after the map is built, before any eager use', () => {
+  // The factories are called much earlier than the statements they replaced, which is only a
+  // question of TWO boundaries: `map` must already exist (it is assigned exactly once, in the
+  // maplibregl.Map try block), and nothing that runs during closure evaluation may have used a
+  // moved name yet. Both are asserted here against real offsets.
+  const mapAssign = html.indexOf('map=new maplibregl.Map({');
+  assert.ok(mapAssign > 0, 'index.html constructs the map exactly where expected');
+  assert.equal(html.split('map=new maplibregl.Map({').length - 1, 1, '`map` is assigned in exactly one place');
+
+  const at = NAMES.map((m) => ({ m, i: html.indexOf(callOf(m)) }));
+  for (const x of at) assert.ok(x.i > mapAssign, `${x.m} is instantiated AFTER the map is constructed`);
+  assert.deepEqual(at.slice().sort((a, b) => a.i - b.i).map((x) => x.m), NAMES, 'the six calls keep their declared order');
+  const last = Math.max(...at.map((x) => x.i));
+
+  // The five places that USE a moved name while the closure is still evaluating (as opposed to
+  // inside a function body that runs later). Every one must come after the last factory call.
+  const eager = [
+    'window.IntMapModules.layerPreviews(',   // takes loadCountryData as an argument
+    'window.renderCompanies=renderCompanies;',
+    'window.showCompanyDetail=showCompanyDetail;',
+    'window._imOpenSetPassword=_openSetPassword;',
+    'setInterval(fetchData,180000); bootSupabase();',   // boot calls it as a bare statement, near the end
+  ];
+  const lf = html.replace(/\r\n/g, '\n');            // index.html is CRLF in the working tree
+  const lastLF = Math.max(...NAMES.map((m) => lf.indexOf(callOf(m))));
+  for (const e of eager) {
+    const i = typeof e === 'string' ? lf.indexOf(e) : lf.search(e);
+    assert.ok(i > 0, `the eager use ${e} still exists`);
+    assert.ok(i > lastLF, `${e} must run after the factories (it evaluates a moved name eagerly)`);
+  }
+  assert.ok(last > 0);
+});
+
+test('R168 #4 DECLARATION-ONLY: a factory body does nothing while it runs', () => {
+  // This is the property that makes calling all six early safe. If any factory body held a
+  // statement that EXECUTES (a call, an assignment, an if), moving the call site would move that
+  // side effect — and reading closure state at factory time is exactly the #R167 dead-zone trap.
+  for (const m of NAMES) {
+    const src = rd(MODULES[m].file);
+    const ast = acorn.parse(src, { ecmaVersion: 'latest', locations: true });
+    let body = null;
+    for (const st of ast.body) {
+      if (st.type !== 'ExpressionStatement' || st.expression.type !== 'AssignmentExpression') continue;
+      const { left, right } = st.expression;
+      if (left.type === 'MemberExpression' && left.property.name === m && /Function/.test(right.type)) body = right.body.body;
+    }
+    assert.ok(body, `${MODULES[m].file}: found the ${m} factory body`);
+    const doers = body.filter((st) => st.type !== 'FunctionDeclaration' && st.type !== 'VariableDeclaration' && st.type !== 'ReturnStatement');
+    assert.deepEqual(doers.map((st) => `${st.type}@${st.loc.start.line}`), [],
+      `${MODULES[m].file} must only DECLARE at factory level — these statements would run: `);
+    assert.equal(body[body.length - 1].type, 'ReturnStatement', `${MODULES[m].file} ends with the export return`);
+
+    // …and no initialiser may CALL anything either (a `const x=f()` runs f at factory time).
+    for (const st of body.filter((s) => s.type === 'VariableDeclaration')) {
+      for (const d of st.declarations) {
+        (function scan(n) {
+          if (!n || typeof n.type !== 'string') return;
+          if (/^(Function|Arrow)/.test(n.type) || n.type === 'FunctionExpression' || n.type === 'ArrowFunctionExpression') return;
+          assert.ok(n.type !== 'CallExpression', `${MODULES[m].file}:${n.loc.start.line} — a factory-level initialiser must not call anything`);
+          for (const k of Object.keys(n)) {
+            if (k === 'type' || k === 'start' || k === 'end' || k === 'loc' || k === 'range') continue;
+            const v = n[k];
+            if (Array.isArray(v)) v.forEach((x) => x && typeof x.type === 'string' && scan(x));
+            else if (v && typeof v.type === 'string') scan(v);
+          }
+        })(d.init);
+      }
+    }
+  }
+});
+
+test('R168 #5 no module reads a live value as a bare identifier', () => {
+  // The rewrite that makes the host contract meaningful (same probe as R165 #4, for the six new
+  // files): inside a module these names must only ever appear as HOST.<prop>. A bare `currentLang`
+  // in js/news-ui.js is the #R162 silent failure — undefined, no error, feature quietly wrong.
+  for (const m of NAMES) {
+    const src = code(rd(MODULES[m].file));
+    for (const [name, prop] of Object.entries(LIVE)) {
+      const hits = (src.match(new RegExp(`(?<![.\\w$])${name}(?![\\w$])`, 'g')) || []).length;
+      assert.equal(hits, 0, `${MODULES[m].file} mentions ${name} as a bare identifier — it must use HOST.${prop} (${hits} hit(s))`);
+    }
+  }
+});
+
+test('R168 #6 every live member really is a getter over a really-reassigned variable', () => {
+  // Prove the classification instead of trusting it: each name is assigned somewhere in index.html
+  // outside its own declaration, so a captured copy would go stale.
+  for (const [name, prop] of Object.entries(LIVE)) {
+    const asg = new RegExp(`(?:^|[^.\\w$=!<>+\\-*/%&|^])${name}\\s*=(?!=)`);
+    const decl = new RegExp(`(?:const|let|var)\\b[^;]*\\b${name}\\s*=`);
+    assert.ok(html.split('\n').some((l) => asg.test(l) && !decl.test(l)),
+      `${name} is reassigned at runtime — if that ever stops being true, revisit why it is a live member`);
+    assert.match(html, new RegExp(`get\\s+${prop}\\(\\)\\{\\s*return\\s+${name};\\s*\\}`),
+      `IM_HOST.${prop} must be a live getter over ${name}`);
+  }
+});
+
+test('R168 #7 the parser-backed split-scope check still passes across all six new files', () => {
+  const problems = checkSplitScope();
+  assert.deepEqual(problems, [], 'split-scope problems:\n' + problems.map((p) => `${p.file}: ${p.msg}`).join('\n'));
+});
+
+test('R168 #8 index.html shrank and no module body came back inline', () => {
+  const lines = html.split('\n').length;
+  assert.ok(lines < 8_200, `index.html should be well under the pre-R168 9,709 lines; it is ${lines}`);
+  assert.ok(!/<style>[\s\S]{4000,}?<\/style>/.test(html), 'the stylesheet stays in css/intmap.css');
+  // A leftover in-page copy of a moved body would WIN over the module (a later function declaration
+  // overwrites an earlier one). Probe with a line from deep inside each of the three biggest bodies,
+  // so the needle cannot accidentally match the one-line shim that legitimately carries the name.
+  const deep = {
+    'js/auth-ui.js': "const settingsBtn=document.getElementById('btn-open-settings')",
+    'js/news-ui.js': "if(!GE.layers.hasSource('news-points')){",
+    'js/countries-ui.js': "const feed=document.getElementById('countries-feed')",
+  };
+  for (const [file, needle] of Object.entries(deep)) {
+    assert.ok(rd(file).includes(needle), `${file} really carries the body this probes for`);
+    assert.ok(!html.includes(needle), `index.html must not still hold an inline copy of ${file}: ${needle}`);
+  }
+});

--- a/tests/r168-checks.test.mjs
+++ b/tests/r168-checks.test.mjs
@@ -65,6 +65,10 @@ const MODULES = {
   community:   { file: 'js/community.js',    k: 'IM_COMMUNITY',    exports: ['renderCommunity', 'wireCommList'] },
 };
 const NAMES = Object.keys(MODULES);
+/* Escape EVERY regex metacharacter, not just `$`. Exported names here are ordinary identifiers, so
+   in practice only `$` can occur — but a partial escape is the kind of thing that is right until the
+   day it isn't, and CodeQL flags it (js/incomplete-sanitization) rather than guess. */
+const rx = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const shimOf = (m, n) => `function ${n}(){ return ${MODULES[m].k}.${n}.apply(this,arguments); }`;
 const callOf = (m) => `const ${MODULES[m].k}=window.IntMapModules.${m}(map,IM_HOST);`;
 
@@ -122,7 +126,7 @@ test('R168 #2 THE SHIM CONTRACT: every exported name is a hoisted forwarding dec
       assert.equal(html.split(shim).length - 1, 1, `index.html holds exactly one shim for ${n}: ${shim}`);
 
       // (d) and index.html no longer declares the real thing anywhere.
-      const inline = [...code(html).matchAll(new RegExp(`(?:^|[^.\\w$])(?:async\\s+function|function|const|let|var)\\s+${n.replace(/\$/g, '\\$')}(?![\\w$])`, 'g'))];
+      const inline = [...code(html).matchAll(new RegExp(`(?:^|[^.\\w$])(?:async\\s+function|function|const|let|var)\\s+${rx(n)}(?![\\w$])`, 'g'))];
       assert.equal(inline.length, 1, `${n} must exist in index.html only as its shim (found ${inline.length} declarations)`);
     }
   }

--- a/tests/r168.spec.js
+++ b/tests/r168.spec.js
@@ -1,0 +1,383 @@
+// R168 behavioural checks in a real browser — the seventh index.html split.
+//
+// WHY a browser test: static analysis cannot see the #R162 failure shape. Soft dependencies in this
+// codebase are `typeof X!=='undefined'` inside try/catch, so a moved subject that lost a binding
+// throws NOTHING — a branch is skipped and the feature quietly disappears.
+//
+// What THIS round has to prove beyond "the globals exist":
+//   1. The six factories ran and each subject really rebuilt its own UI (each of these renderers can
+//      also bail out early on a missing element or an empty dataset, so presence proves nothing).
+//   2. THE SHIMS FORWARD. index.html now calls these functions through hoisted one-line shims. A shim
+//      that reached the wrong object would not throw — it would just do nothing.
+//   3. The host getters are LIVE: a module built while the UI was English follows a runtime switch.
+//   4. WRITE-THROUGH for the new RW members. This needs the most care: a module is a classic script,
+//      so `HOST.x=v` on an object with only a getter is a SILENT no-op, and "no error" proves
+//      nothing. Every assertion below therefore forces index.html's OWN code to re-derive from the
+//      bare closure variable afterwards.
+//
+// What is NOT claimed here, deliberately (#R167's rule: do not pretend to prove what you cannot):
+//   · currentUser / geoRaw. js/auth-ui.js writes both, but only along paths that need a real
+//     Supabase session — a logged-in refreshCurrentUser() and loadGeoFromSupabase(). The hermetic
+//     policy blocks Supabase, and putting real credentials in a test is not an option. Both stay
+//     pinned at source level by r165-checks (setter exists, is paired with its getter over the same
+//     closure variable, and js/auth-ui.js is its declared owner).
+//   · dashFeatures. renderDashboard() has had no on-screen consequence since #R139 (it starts with
+//     `try{ return renderCompanies(); }`), so there is nothing to observe; #R167 reached the same
+//     conclusion about extendedDashDB.
+//   · js/community.js's DOM and its six filter/compose RW members. renderCommunity() is only ever
+//     reached through loadCommunity(), which awaits detectCommCaps() against Supabase — blocked here
+//     — and the community FEED mode has no button of its own (it is opened by clicking a community
+//     map pin, and with no posts there are no pins). Verified this is pre-existing, not a split
+//     artefact: the same probe leaves #community-feed empty on main at 730b401 too. The module's
+//     presence and factory are covered by #1, its scope and RW contract by r168-checks/r165-checks.
+import { test, expect } from '@playwright/test';
+import { installHermeticRouting, collectPageDiagnostics, isBenign } from './helpers/network.js';
+
+test.describe.configure({ mode: 'serial' });
+
+let page, diag;
+
+/* 45 fake headlines (> NEWS_BATCH=30) pre-seeded into the news cache, so the feed is deterministic
+   with no network AND large enough that a second lazy batch really has something to append. */
+const NEWS_SEED = {
+  ts: Date.now(),
+  lang: 'en',
+  data: Array.from({ length: 45 }, (_, i) => ({
+    title: `Test headline number ${i + 1}`,
+    link: `https://example.invalid/item-${i + 1}`,
+    publisher: 'Test Wire',
+    pubDate: new Date().toUTCString(),
+    description: `Test item ${i + 1}`,
+    analysis: { loc: [139.69, 35.69], name: 'Tokyo', country: 'JPN', type: 'city' },
+  })),
+};
+
+/* A two-country stand-in for the 4.7 MB Natural Earth file js/countries-ui.js downloads. Same shape
+   (ISO_A3_EH + POP_EST), so loadCountryData() takes its normal path and finishes in milliseconds. */
+const NE_STUB = {
+  type: 'FeatureCollection',
+  features: [
+    { type: 'Feature', properties: { ISO_A3_EH: 'JPN', ADMIN: 'Japan', NAME: 'Japan', POP_EST: 125000000 },
+      geometry: { type: 'Polygon', coordinates: [[[130, 31], [146, 31], [146, 45], [130, 45], [130, 31]]] } },
+    { type: 'Feature', properties: { ISO_A3_EH: 'FRA', ADMIN: 'France', NAME: 'France', POP_EST: 68000000 },
+      geometry: { type: 'Polygon', coordinates: [[[-5, 42], [8, 42], [8, 51], [-5, 51], [-5, 42]]] } },
+  ],
+};
+
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  await installHermeticRouting(context);
+  /* Registered AFTER the catch-all so it wins (Playwright runs the most recent matching handler
+     first): the Natural Earth boundaries resolve instantly instead of downloading 4.7 MB. */
+  await context.route(/natural-earth-vector.*admin_0_countries\.geojson/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(NE_STUB) }));
+  await context.addInitScript((seed) => {
+    try {
+      localStorage.setItem('intmap_ws4', JSON.stringify({ on: false }));
+      localStorage.setItem('intmap_news_cache', JSON.stringify(seed));
+      localStorage.removeItem('intmap_bookmarks');
+    } catch { /* ignore */ }
+  }, NEWS_SEED);
+  page = await context.newPage();
+  diag = collectPageDiagnostics(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 45_000 });
+  await page.waitForFunction(() => !!window.__imap && !!document.getElementById('map'), null, { timeout: 45_000 });
+  await page.waitForTimeout(2500);
+});
+
+test.afterAll(async () => {
+  await page?.context()?.close();
+});
+
+test('R168 #1 all six files loaded, all six factories ran, and no factory is missing', async () => {
+  const res = await page.evaluate(() => ({
+    check: window.__imModuleCheck,
+    facs: ['countriesUi', 'newsUi', 'companiesUi', 'toolPanel', 'authUi', 'community']
+      .map((f) => [f, typeof (window.IntMapModules || {})[f]]),
+  }));
+  expect(res.check, 'the boot guard ran').toBeTruthy();
+  expect(res.check.missing, 'no required module namespace is missing').toEqual([]);
+  expect(res.check.missingFactories, 'no factory is missing — a js/ file that failed to deploy shows up here').toEqual([]);
+  for (const [f, t] of res.facs) expect(t, `window.IntMapModules.${f} is a function`).toBe('function');
+});
+
+test('R168 #2 THE SHIMS FORWARD: each shim reaches the module and does the real work', async () => {
+  // A shim that resolved to the wrong object would throw nothing useful — it would silently do
+  // nothing. So call through each one and require a real, subject-specific effect.
+  const res = await page.evaluate(async () => {
+    const out = {};
+    // countries — renderStats() fills the Countries feed from the (stubbed) boundary data
+    await window.IntMapModules && null;
+    document.getElementById('btn-stats')?.click();
+    await new Promise((r) => setTimeout(r, 1200));
+    out.countryRows = document.querySelectorAll('#countries-feed .stat-item, #countries-feed .country-row, #countries-feed [data-cid]').length;
+    out.countriesFeedText = (document.getElementById('countries-feed')?.innerText || '').slice(0, 400);
+    // news — setupIntelLayers() created the real map source; the feed rendered the seeded batch
+    out.newsSource = !!window.__imap.getSource('news-points');
+    document.getElementById('btn-news')?.click();
+    await new Promise((r) => setTimeout(r, 1200));
+    out.newsCards = document.querySelectorAll('#live-news-feed .news-item, #live-news-feed .news-card').length;
+    // companies — renderCompanies() fills the Companies feed
+    document.getElementById('btn-info')?.click();
+    await new Promise((r) => setTimeout(r, 1200));
+    out.companyText = (document.getElementById('info-dashboard')?.innerText || '').slice(0, 400);
+    // tool panel — the measure tool builds the panel
+    document.getElementById('btn-tool-measure')?.click();
+    await new Promise((r) => setTimeout(r, 500));
+    out.toolPanel = !!document.getElementById('tool-panel') && document.getElementById('tool-panel').style.display !== 'none';
+    out.toolText = (document.getElementById('tool-panel')?.innerText || '').slice(0, 200);
+    // auth — injectAuthUI() mounted the account control, openAuthModal() opens the modal
+    out.accountBtn = !!document.getElementById("btn-account");
+    return out;
+  });
+  expect(res.newsSource, 'setupIntelLayers() created the news-points source on the real map').toBe(true);
+  expect(res.newsCards, 'the news feed rendered the seeded batch').toBeGreaterThan(10);
+  expect(res.countriesFeedText.length, 'renderStats() wrote into #countries-feed').toBeGreaterThan(10);
+  expect(res.countriesFeedText, 'the Countries feed lists a country from the stubbed boundary file').toMatch(/Japan|France/);
+  expect(res.companyText.length, 'renderCompanies() wrote into #info-dashboard').toBeGreaterThan(10);
+  expect(res.toolPanel, 'the measure tool built #tool-panel').toBe(true);
+  expect(res.accountBtn, 'injectAuthUI() mounted the account control').toBe(true);
+});
+
+test('R168 #3 js/auth-ui.js: the account button it built opens the modal its own openAuthModal() drives', async () => {
+  // Two functions of the module in one chain, neither of them reachable by name from here:
+  // injectAuthUI() creates #btn-account during boot, and clicking it as a guest runs
+  // openAccountMenu() → `if(!currentUser) return openAuthModal();` → the modal is activated.
+  // #auth-modal is in the static markup, so its EXISTENCE proves nothing — `display:flex`, which
+  // only the module's openAuthModal() sets, is the discriminator.
+  const before = await page.evaluate(() => ({
+    btn: !!document.getElementById('btn-account'),
+    display: document.getElementById('auth-modal')?.style.display || '',
+  }));
+  expect(before.btn, 'injectAuthUI() mounted #btn-account during boot').toBe(true);
+  expect(before.display, 'the auth modal starts closed').not.toBe('flex');
+
+  const res = await page.evaluate(async () => {
+    document.getElementById('btn-account').click();
+    await new Promise((r) => setTimeout(r, 800));
+    const m = document.getElementById('auth-modal');
+    return { display: m?.style.display, text: (m?.innerText || '').slice(0, 300) };
+  });
+  expect(res.display, 'openAccountMenu() → openAuthModal() opened the modal through the module').toBe('flex');
+  expect(res.text.length, 'the modal rendered its content').toBeGreaterThan(5);
+
+  await page.evaluate(async () => {
+    const m = document.getElementById('auth-modal'); if (m) m.style.display = 'none';
+    await new Promise((r) => setTimeout(r, 200));
+  });
+});
+
+test('R168 #4 WRITE-THROUGH: the tool panel clears measurePoints and index.html rebuilds the map layer', async () => {
+  // js/tool-panel.js's #tp-clear button sets HOST.measurePoints=[] and then calls HOST.refreshTool().
+  // refreshTool() is index.html code: it feeds map source 'tool-source' from buildToolFeatures(),
+  // which reads the closure array. If the setter write had not reached the closure, the measured
+  // line would still be there afterwards — "no error" would have looked identical.
+  const before = await page.evaluate(async () => {
+    // Start from "no tool armed": the Atlas action calls setTool('measure'), and setTool TOGGLES —
+    // if an earlier test left the measure tool on, it would switch off and draw nothing.
+    const mb = document.getElementById('btn-tool-measure');
+    if (mb && mb.classList.contains('tool-on')) { mb.click(); await new Promise((res) => setTimeout(res, 300)); }
+    const r = await window.IntMapConsole.dispatch({ type: 'measure', from: 'Tokyo', to: 'Osaka' });
+    await new Promise((res) => setTimeout(res, 600));
+    const s = window.__imap.getSource('tool-source');
+    const d = s && ((s.serialize && s.serialize().data) || s._data);   /* MapLibre 5: _data goes stale after setData; serialize() is live */
+    return { ok: !!(r && r.ok), html: String(r && r.html || ''), feats: ((d && d.features) || []).length };
+  });
+  expect(before.ok, 'the measure action reported success').toBe(true);
+  expect(before.html, 'the measure reply names both endpoints').toMatch(/Tokyo[\s\S]*Osaka/i);
+  expect(before.feats, 'the measured line is on the map before clearing').toBeGreaterThan(0);
+
+  const after = await page.evaluate(async () => {
+    const btn = document.querySelector('#tool-panel #tp-clear');
+    if (!btn) return { clicked: false };
+    btn.click();
+    await new Promise((res) => setTimeout(res, 600));
+    const s = window.__imap.getSource('tool-source');
+    const d = s && ((s.serialize && s.serialize().data) || s._data);   /* MapLibre 5: _data goes stale after setData; serialize() is live */
+    return { clicked: true, feats: ((d && d.features) || []).length };
+  });
+  expect(after.clicked, 'the tool panel really rendered its Clear button').toBe(true);
+  expect(after.feats, 'HOST.measurePoints=[] reached the closure — index.html rebuilt tool-source empty').toBe(0);
+});
+
+test('R168 #5 WRITE-THROUGH: the radius slider sets HOST.radiusKm and index.html stamps it into a new circle', async () => {
+  // js/tool-panel.js's radius input runs setR(v) → HOST.radiusKm=v. The proof is a DIFFERENT piece
+  // of code: window._radiusFromPoint() lives in index.html and copies the BARE closure radiusKm into
+  // the new circle, which refreshTool() (also index.html) turns into a disk polygon on the map.
+  // A lost write would leave the default 1000 km and the polygon would be ~6× bigger.
+  const res = await page.evaluate(async () => {
+    document.getElementById('btn-tool-radius')?.click();
+    await new Promise((r) => setTimeout(r, 700));
+    const num = document.querySelector('#tool-panel #radius-num') || document.querySelector('#tool-panel #radius-range');
+    if (!num) return { found: false };
+    window.clearAllRadius && window.clearAllRadius();
+    num.value = '150';
+    num.dispatchEvent(new Event('input', { bubbles: true }));
+    num.dispatchEvent(new Event('change', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 500));
+    window._radiusFromPoint(0, 0);          // index.html — reads the closure radiusKm/color/opacity
+    await new Promise((r) => setTimeout(r, 500));
+    const s = window.__imap.getSource('tool-source');
+    const d = s && ((s.serialize && s.serialize().data) || s._data);   /* MapLibre 5: _data goes stale after setData; serialize() is live */
+    const feats = (d && d.features) || [];
+    // the disk is the polygon; measure its latitude span in degrees (1° lat ≈ 111 km)
+    let span = 0;
+    for (const f of feats) {
+      if (!f.geometry || f.geometry.type !== 'Polygon') continue;
+      const ring = f.geometry.coordinates[0] || [];
+      const lats = ring.map((c) => c[1]);
+      span = Math.max(span, Math.max(...lats) - Math.min(...lats));
+    }
+    return { found: true, span, n: feats.length };
+  });
+  expect(res.found, 'the radius panel rendered its input').toBe(true);
+  expect(res.n, 'a radius circle was created').toBeGreaterThan(0);
+  // 150 km radius → ~300 km diameter → ~2.7° of latitude. The stale default (1000 km) would be ~18°.
+  expect(res.span, 'the circle was drawn at the NEW radius — HOST.radiusKm reached the closure').toBeGreaterThan(1.5);
+  expect(res.span, 'and not at the stale 1000 km default').toBeLessThan(6);
+  await page.evaluate(() => { try { window.clearAllRadius(); } catch { /* ignore */ } });
+});
+
+test('R168 #6 WRITE-THROUGH: bookmarking re-derives the Saved list from the closure array', async () => {
+  // js/news-ui.js's bookmark button ADDS with HOST.bookmarks.push(...) — which would work through a
+  // getter alone, because it mutates the array in place. Removing is the discriminator: it does
+  // HOST.bookmarks=HOST.bookmarks.filter(...), a REASSIGNMENT that only lands if the setter exists.
+  // Both directions are then judged by index.html's computeFilteredNews(), which decides the Saved
+  // tab's contents from the bare closure array.
+  const added = await page.evaluate(async () => {
+    document.getElementById('btn-news')?.click();
+    await new Promise((r) => setTimeout(r, 900));
+    const card = document.querySelector('#live-news-feed .news-item, #live-news-feed .news-card');
+    const bm = card && card.querySelector('.btn-bookmark');
+    if (!bm) return { found: false };
+    bm.click();
+    await new Promise((r) => setTimeout(r, 400));
+    document.getElementById('newsfilter-saved')?.click();
+    await new Promise((r) => setTimeout(r, 900));
+    return { found: true, saved: document.querySelectorAll('#live-news-feed .news-item, #live-news-feed .news-card').length };
+  });
+  expect(added.found, 'the news feed rendered a bookmark button').toBe(true);
+  expect(added.saved, 'the bookmarked article shows in Saved — index.html read the closure array').toBe(1);
+
+  const removed = await page.evaluate(async () => {
+    const bm = document.querySelector('#live-news-feed .btn-bookmark');
+    if (!bm) return { found: false };
+    bm.click();                                   // guest path: HOST.bookmarks = filter(...)
+    await new Promise((r) => setTimeout(r, 900));
+    return { found: true, saved: document.querySelectorAll('#live-news-feed .news-item, #live-news-feed .news-card').length };
+  });
+  expect(removed.found, 'the Saved list rendered its bookmark button').toBe(true);
+  expect(removed.saved, 'the REASSIGNMENT reached the closure — otherwise Saved would still list it').toBe(0);
+  await page.evaluate(() => document.getElementById('newsfilter-all')?.click());
+  await page.waitForTimeout(600);
+});
+
+test('R168 #7 WRITE-THROUGH: appendNewsBatch advances renderedCount (no duplicate second batch)', async () => {
+  // js/news-ui.js does HOST.renderedCount+=next.length and slices the next page from it. index.html
+  // owns the variable and resets it in startNews(). If the compound write were lost, the second call
+  // would slice from 0 again and append the SAME 30 cards — 60 in the DOM, half of them duplicates.
+  // Driven the way a user does it — index.html's own scroll handler on #live-news-feed reads
+  // `renderedCount < newsFiltered.length` off the closure to decide whether to ask for more.
+  const res = await page.evaluate(async () => {
+    // setMode() TOGGLES, so only click when the tab is not already the active one — and the scroll
+    // handler returns early unless currentMode is 'news'/'saved'.
+    const nb = document.getElementById('btn-news');
+    if (nb && !nb.classList.contains('active')) { nb.click(); await new Promise((r) => setTimeout(r, 1400)); }
+    document.getElementById('newsfilter-all')?.click();
+    await new Promise((r) => setTimeout(r, 1200));
+    const feed = document.getElementById('live-news-feed');
+    const count = () => feed.querySelectorAll('.news-item, .news-card').length;
+    const first = count();
+    feed.scrollTop = feed.scrollHeight;
+    feed.dispatchEvent(new Event('scroll', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 900));
+    const links = [...feed.querySelectorAll('.news-item, .news-card')]
+      .map((c) => c.getAttribute('data-link') || c.querySelector('a')?.getAttribute('href') || c.innerText.slice(0, 60));
+    return { first, second: count(), unique: new Set(links).size };
+  });
+  expect(res.first, 'the first batch rendered NEWS_BATCH cards').toBe(30);
+  expect(res.second, 'the second batch appended the remaining 15 of 45 seeded items').toBe(45);
+  expect(res.unique, 'every card is distinct — renderedCount really advanced').toBe(45);
+});
+
+test('R168 #8 WRITE-THROUGH: loadCountryData sets countryGeo/countryDataLoaded and index.html re-adds the layer', async () => {
+  // js/countries-ui.js assigns HOST.countryGeo / HOST.countryDataLoaded / HOST.countryDataPromise.
+  // (Natural Earth is stubbed in beforeAll, so the real 4.7 MB download costs milliseconds here.)
+  // Loaded the way the app does it: setMode('stats') runs `if(!countryDataLoaded) loadCountryData()`
+  // through the shim. The module then does `HOST.countryGeo=gj; window.countryGeo=HOST.countryGeo;`
+  // — reading BACK through the host, so a missing setter would publish null here.
+  const loaded = await page.evaluate(async () => {
+    document.getElementById('btn-stats')?.click();
+    await new Promise((r) => setTimeout(r, 2000));
+    return { geo: !!window.countryGeo, feats: window.countryGeo ? window.countryGeo.features.length : 0 };
+  });
+  expect(loaded.geo, 'the boundary data landed and read back through the host').toBe(true);
+  expect(loaded.feats, 'both stub countries parsed').toBe(2);
+
+  // Second, INDEPENDENT proof, this one re-derived by index.html itself. The #cb-countries change
+  // handler is index.html code:
+  //     if(countryInfoOn && !countryDataLoaded){ loadCountryData().then(ensure); } else ensure();
+  //     ensure = () => { if(countryInfoOn && countryGeo && … && !map.getSource('countries')) addCountryLayers(); … }
+  // Both `countryGeo` and `countryDataLoaded` are read as bare closure variables there. Tear the
+  // source off the map, toggle the checkbox off and on, and it can only come back if both writes
+  // really landed in the closure.
+  const res = await page.evaluate(async () => {
+    const cb = document.getElementById('cb-countries');
+    if (!cb) return { found: false };
+    if (!cb.checked) { cb.checked = true; cb.dispatchEvent(new Event('change', { bubbles: true })); await new Promise((r) => setTimeout(r, 800)); }
+    // every layer bound to the source has to go first, or removeSource() throws
+    for (const l of (window.__imap.getStyle().layers || [])) {
+      if (l.source === 'countries') { try { window.__imap.removeLayer(l.id); } catch { /* ignore */ } }
+    }
+    try { window.__imap.removeSource('countries'); } catch { /* ignore */ }
+    const gone = !window.__imap.getSource('countries');
+    cb.checked = false; cb.dispatchEvent(new Event('change', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 900));
+    cb.checked = true; cb.dispatchEvent(new Event('change', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 2500));
+    return { found: true, gone, back: !!window.__imap.getSource('countries') };
+  });
+  expect(res.found, 'the countries checkbox exists').toBe(true);
+  expect(res.gone, 'the countries source was really removed first').toBe(true);
+  expect(res.back, 'HOST.countryGeo / countryDataLoaded reached the closure — index.html re-added the layer').toBe(true);
+});
+
+test('R168 #9 LIVE getters: four of the modules re-render after a runtime language switch', async () => {
+  // All four were BUILT while the UI was English; every localized string in them reads HOST.lang at
+  // call time. A captured copy of currentLang would keep these panels English forever — the #R162
+  // "silently reads a dead value" shape, invisible to any static check.
+  // (js/auth-ui.js is not probed here: its modal is localized by index.html's data-i18n sweep rather
+  // than by the module, so it would not discriminate. js/community.js cannot be rendered hermetically
+  // — see the header.)
+  const res = await page.evaluate(async () => {
+    document.getElementById('lang-jp')?.click();
+    await new Promise((r) => setTimeout(r, 1400));
+    const out = {};
+    document.getElementById('btn-stats')?.click();
+    await new Promise((r) => setTimeout(r, 1200));
+    out.countries = (document.getElementById('countries-feed')?.innerText || '');
+    document.getElementById('btn-info')?.click();
+    await new Promise((r) => setTimeout(r, 1200));
+    out.companies = (document.getElementById('info-dashboard')?.innerText || '');
+    const nb = document.getElementById('btn-news');
+    if (nb && !nb.classList.contains('active')) nb.click();
+    await new Promise((r) => setTimeout(r, 1400));
+    out.news = (document.getElementById('live-news-feed')?.innerText || '');
+    document.getElementById('btn-tool-measure')?.click();
+    await new Promise((r) => setTimeout(r, 700));
+    out.tool = (document.getElementById('tool-panel')?.innerText || '');
+    return out;
+  });
+  const cjk = /[぀-ヿ一-鿿]/;
+  expect(cjk.test(res.countries), 'js/countries-ui.js re-rendered in Japanese').toBe(true);
+  expect(cjk.test(res.companies), 'js/companies-ui.js re-rendered in Japanese').toBe(true);
+  expect(cjk.test(res.news), 'js/news-ui.js re-rendered in Japanese').toBe(true);
+  expect(cjk.test(res.tool), 'js/tool-panel.js re-rendered in Japanese').toBe(true);
+  await page.evaluate(() => document.getElementById('lang-en')?.click());
+  await page.waitForTimeout(800);
+});
+
+test('R168 #10 no IntMap-originated console error or uncaught exception during the exercise', () => {
+  const real = [...diag.pageErrors, ...diag.consoleErrors].filter((t) => !isBenign(t));
+  expect(real, 'IntMap-originated errors:\n' + real.join('\n')).toEqual([]);
+});


### PR DESCRIPTION
#R167 reported the "self-contained block" seam exhausted, and for **statements** that was true: the remaining 929 top-level statements have 10–36 free references each, so none can leave on its own. The unit that *is* independent is a **subject** — start from a seed function and absorb every statement whose declared names nothing outside reads. The set grows while its external surface shrinks.

Six subjects came out: **102 statements / 224 KB / 2,018 lines**. They are pairwise disjoint and — measured, not assumed — every member is a declaration, with no side-effecting statement anywhere.

| file | subject | size |
|---|---|---|
| `js/countries-ui.js` | Countries tab, boundary/stat loader, country card | 38 KB |
| `js/news-ui.js` | news map layers, feed, lazy batches, reader | 49 KB |
| `js/companies-ui.js` | Companies tab, compare sheet, dashboard | 55 KB |
| `js/tool-panel.js` | measure/radius tool panel, map context menu | 30 KB |
| `js/auth-ui.js` | auth modal, account menu, passkeys, `bootSupabase` | 59 KB |
| `js/community.js` | community feed, list wiring, comment/vote mutations | 12 KB |

`index.html` **9,709 → 7,691 lines, 0.89 → 0.64 MB**. R162–R168: **−79 %** from 36,955 lines.

## Two new mechanisms, both pinned by CI

**1. Hoisted shims.** These are the first modules `index.html` still calls *by name*, so each exported function keeps a one-liner:

```js
function renderStats(){ return IM_COUNTRIES_UI.renderStats.apply(this,arguments); }
```

A function **declaration** specifically: the originals were hoisted, so call sites above the factory — including `IM_HOST`'s getters ~1,300 lines earlier — behave exactly as before, and `.apply` preserves receiver and arguments. A side benefit is that cross-module references become trivially safe, since they all funnel through the one shim.

**2. Declaration-only factories**, instantiated together right after `map` is built rather than where their statements used to sit. Safe because:
- `r168-checks #4` proves with acorn that **no factory body executes anything** (statements are declarations plus the export return, and no initialiser calls anything) — so #R167's TDZ trap cannot arise;
- `r168-checks #3` proves `map` is assigned **exactly once**, and pins that the only **five** statements evaluating a moved name during closure evaluation all come after the block.

## RW contract: `owner` → `owners`

Up to #R167 every RW member happened to have one writer. Subjects don't work that way — the radius/measure values are set both by an Atlas command and by the tool panel the user drags, a bookmark is added from the news feed and cleared from the account menu, the news pins are replaced both when the clock moves and when the AI geocoder finishes. A single-owner rule could only be kept by pretending otherwise. The audit property is unchanged and still enforced: an explicit, exhaustive list per member, every listed file really writes it, nothing else writes it at all.

RW **10 → 29**; `IM_HOST` **123 → 230** accessors; **duplicate-accessor detection added** (a second `get x()` still parses and silently wins — this actually caught a mistake during generation).

## Write-through is proved by re-derivation, never by "no error"

A missing setter is a **silent no-op** in a classic script. Every assertion forces `index.html`'s own code to recompute from the bare closure variable: `refreshTool()` rebuilds `tool-source` after Clear; `window._radiusFromPoint()` stamps the new `radiusKm` into a circle (150 km ≈ 2.7° of latitude vs the stale 1000 km default ≈ 18°); `computeFilteredNews()` decides the Saved tab (the **removal** is the discriminator — adding uses `push`, which a getter alone would satisfy); the feed's scroll handler advances through `renderedCount`; the `#cb-countries` handler re-adds the country layer from `countryGeo`/`countryDataLoaded`.

## Not claimed, deliberately

`currentUser`/`geoRaw` are only written along paths needing a real Supabase session; `dashFeatures` has had no on-screen consequence since #R139; `js/community.js`'s DOM cannot render hermetically — the community feed mode has no button of its own, only a community map pin opens it. All three are stated with reasons at the top of the spec and pinned at source level. The empty community feed was confirmed **pre-existing** by running the same probe on `main` at 730b401.

## Extraction

Done by script: acorn ranges (including the leading comment block and the line indent), free references rewritten to `HOST.x`, then **reversed and compared byte-for-byte** with the original text. Two guards earned their keep — a monkey-patch check stopped on `renderUI` (its only reassignment sits in a dead `return;`-first IIFE from #R22, *and* nothing inside the cluster calls it — safe on both counts), and a variable-export check kept `extendedDashDB`'s declaration in `index.html`.

## Also fixed in passing

- `r167-checks #3` now asserts exactly one file rebinds each table, and scans `js/` for mutation too (the consumers moved, so the check got stronger).
- `r152-checks #2` accepts `HOST.mode` alongside `currentMode`.
- `r165-checks #2(c)` accepts `+=`/`++` writes (`HOST.renderedCount+=n`).

## Tests

`npm test` = static-checks + **233** node checks (new `tests/r168-checks.test.mjs`) + **151** Playwright (new `tests/r168.spec.js`) — all green at the CI worker count (2).

Note on local flakes: at *unbounded* parallelism this machine saturates and `r159 #4` flakes. Measured both trees — `main` at 730b401 fails **9** tests under the same conditions vs **1** on this branch, and `r159 #4` passes 4/4 on repeat here. `playwright.config.js` pins CI to 2 workers, where the branch is 151/151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
