### PR TITLE
R169: refactor index.html — cut along DECLARE vs RUN (-1,947 lines / -155 KB), and tidy Architecture/DEV-NOTES

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -5,9 +5,19 @@
 > 時系列の経緯・根本原因の記録は `DEV-NOTES.md`、標準指示（やってはいけないこと等）は `CONSTITUTION.md` を参照。
 > 実装を変えたら、この仕様書も更新すること。
 >
-> Last reviewed: 2026-07-21 (R151 — Companies空比較ヒント＋株価バッチ化(spark)＋全史キャッシュ／Atlasトグル拡充(globe・compare)／**ケッペンは全区分表示で停止＋行幅固定(scrollbar-gutter)**／通常モードMeasure・Share集約／Atlasタイポ(独立太字→見出し)／**モニター削除でハイライト消去**／衛星3D飛行プリフェッチ強化＋3D手動move先読み／**SVオンでcoverage自動**／**Atlas出典からSNS/短縮/動画除去**／Terra本番検証(analyzed_by=ai 354)。DEV-NOTES R151 参照)
+> Last reviewed: 2026-07-25 (R169)
 >
-> **R41 の要点**：`whenStyleReady()` が永久ハングし得た問題を修正（idle/loadのみ待機→ポーリング＋ハード解決）＋自己修復をハートビート化（「チェックしても出ない／消したのに残る・再読込で治る」の真因）。相関/散布図の残差マップを再実装（先にモーダルを閉じる＋RdBu連続配色＋指標33→51）。ウェブカムを**実装**（検証済みの24時間ライブYouTube配信25件をポップアップ内に埋め込み再生。検索リンクのハリボテを廃止）。**タイムゾーンレイヤー**新設（Natural Earth境界＋各ゾーンの現在時刻を毎分更新）。GIBSラスターに色スケール凡例。鉄道線を濃色＋白枕木で視認性向上。水域/地形ラベルを別チェック（`cb-geolabels`）化＋河川ラベルを `waterway` 由来に修正（位置ズレ解消）。天気ポップアップの華氏完全対応＋移動可能化。ウィジェット36→41。i18n：RUのレイヤーグループ見出し欠落＋国詳細(Stats)のES欠落を修正、非AIニュース地点辞書を多言語強化。
+> ### この文書の読み方 (#R169 で整理)
+>
+> - **§1–§18 は「今どうなっているか」だけ**を書く。過去の経緯・根本原因・ラウンドごとの差分は
+>   `DEV-NOTES.md` の担当であり、ここには**変更ログを書かない**。
+> - 本文中の `(#Rxxx)` は「**いつその事実になったか**」を示す出典タグであって、変更ログではない。
+>   詳細を追いたいときは `DEV-NOTES.md` の同じラウンド番号を読む。
+> - **§19 はラウンド別補足**。過去のラウンドで「仕様として残す価値がある」と判断した長い注記を、
+>   §1–§18 の流れを壊さないようにここへ集めてある（**新しい順**）。
+> - 数字（行数・KB・レイヤー行数など）を書くときは**その場で実測した値**にする。#R169 の時点で
+>   古い数字が3か所（§1 の「約15,000行」・§3 の内訳・§14 の「レイヤー行≈72個」）残っていた。
+> - 実装を変えたら、この仕様書も同じコミットで更新すること。
 
 ---
 
@@ -16,7 +26,8 @@
 IntMap は、世界のニュース・気候・人口・経済・地政学データを一枚の地図に重ねて表示する、
 **単一HTMLファイルのWebアプリ**（フロントエンド全部入り）です。
 
-- **本体は `index.html`（公開用、約15,000行・約1.4MB）一枚。** ビルド工程なし。ブラウザでそのまま動く。
+- **本体は `index.html`（公開用、5,744行・0.49MB）一枚。** ビルド工程なし。ブラウザでそのまま動く。
+  （#R162〜#R169 で `css/` と `js/` へ分離した結果。分割前は 36,955行/4.3MB。手順と規約は §3.1）
 - 地図エンジンは **MapLibre GL JS**（Mercator 平面 + Globe 投影）。**#R152 で薄い抽象層 `IntMapGeoEngine`（第1段階）を導入**——将来 Google-Earth 級 Earth Mode を差し込めるよう MapLibre 依存を段階的に隔離。現時点の実装アダプタは MapLibre のみ・挙動は完全同一。Cesium は**過去の全面移行は廃止**だが、**capabilities/contract のみ宣言**（SDK・キーは未導入）。詳細は §7.1 と末尾 #R152 補足。**#R161 で第3段階＝ニュースピン・オーバーレイを丸ごと engine 経由へ移行**（生 `map` 非参照のサブシステム第1号）。
 - バックエンドは **Supabase**（DB・認証・ホスティング・Edge Functions）。
 - 配信は OneDrive 上の静的ファイルを直接ホスト（`index.html` / `admin.html`）。
@@ -661,14 +672,14 @@ IntMap は、世界のニュース・気候・人口・経済・地政学デー�
 
 ```
 index.html                      公開用SPA本体（UI・地図・レイヤー・ニュース・AI呼び出し）。**ビルド無し**は不変。
-                                (#R168) 7,691行 / 0.64MB（#R167時点は 9,709行/0.89MB、#R166時点は 11,810行/1.14MB、
-                                #R165時点は 16,740行/1.73MB、#R164時点は 22,930行/2.65MB、#R163時点は 27,936行/3.20MB、
-                                #R162時点は 32,883行/3.77MB。R162〜R168 で 36,955行から **−79%**）。
+                                (#R169) 5,744行 / 0.49MB（#R168時点は 7,691行/0.64MB、#R167時点は 9,709行/0.89MB、
+                                #R166時点は 11,810行/1.14MB、#R165時点は 16,740行/1.73MB、#R164時点は 22,930行/2.65MB、
+                                #R163時点は 27,936行/3.20MB、#R162時点は 32,883行/3.77MB。R162〜R169 で 36,955行から **−84%**）。
                                 **自己完結が証明できた部分は css/ と js/ に分離済み**（§3.1）。
-                                #R167 までで「自己完結したブロック」は尽き、#R168 からは**主題（SUBJECT）**単位で切る
-                                ＝種になる関数から「外部が誰も読まない私有ヘルパー」を吸収した集合（§3.1 #R168）。
-                                残るのは真の中核（状態宣言・ブート・地図構築・ニュース取得/キャッシュ/絞り込み・
-                                レイヤー配線・IntMapOS・セッション永続化・描画ツリー）。
+                                #R167 までで「自己完結したブロック」は尽き、#R168 は**主題（SUBJECT）**単位、
+                                #R169 は**宣言か実行か**という軸で切った（§3.1 #R168 / #R169）。
+                                残るのは**実際に走る文**だけ＝状態宣言・ブート・地図構築・DOM配線・
+                                `map.on()` ハンドラ・IntMapOS・セッション永続化・`IM_HOST`・約90本の巻き上げシム。
 css/
   intmap.css                        (#R162) アプリのスタイルシート全体（旧 index.html の `<style>` を**逐語**移設）。
                                     JS は `document.styleSheets`/`cssRules` を一切触らないため挙動は完全に同一。
@@ -806,6 +817,31 @@ js/
   community.js                      (#R168) コミュニティフィードの描画とリスト配線＋コメント/投票/通報のミューテーション。
                                     12KB／11文。シム2本。RW 7（commCatFilter/commInView/commSearch/communitySort/
                                     replyingTo と、tool-panel と**共同所有**の communityAddArmed/pendingPostLoc）
+
+  ── 以下 (#R169) の11本（第8弾・192KB／index.html から −1,947行・−155KB）。**切り口が違う**：主題ではなく
+     「**宣言だけの文**（関数・表）」を集めた＝ファクトリは何も実行しないので、11本まとめて
+     `map` 生成直後に生成でき、index.html には巻き上げシムだけが残る（§3.1 #R169）─────────────
+  satellite.js                      (#R169) 衛星画像のコントローラ（プロバイダ表・BYOK鍵・日付ステップ・
+                                    二重バッファのクロスフェード・タイル/認証エラー時の自動フォールバック）。19KB
+  ai-core.js                        (#R169) Atlas AI のトランスポート層（`aiCallServerFull`＝ai-proxy 呼び出し・
+                                    プロバイダエラー分類・1日上限とその表示・AI設定パネル・`askAI`/`askAIJSON`）。24KB
+  place-labels.js                   (#R169) 地名/海洋ラベル（`ensurePlaceLabels`＝`ofm-*` シンボル群の生成・
+                                    安定ラベルの収穫・`applyLabelLang`＝`name:<lang>` 切替・地理レイヤー）。28KB
+  window-manager.js                 (#R169) フローティングパネルの共通機構（`makeDraggable`／`addEdgeResize`／
+                                    `registerWindow`／`bringToFront`）。11KB
+  search-geocode.js                 (#R169) 検索ボックス（自然文の前処理・ローカル地名のあいまい一致・
+                                    2ジオコーダ並列＋ハードタイムアウト・結果カード・`gotoPlace`）。15KB
+  news-context.js                   (#R169) 記事→地点/媒体の解決（`analyzeContext`＝IntMapNewsGeo 優先＋
+                                    レガシー辞書フォールバック・`rebuildGeoIndex`・媒体マッチャ）。16KB
+  news-feed.js                      (#R169) ニュース取得（版・RSS取り込み・キャッシュ・Supabase高速経路・
+                                    タイトル翻訳）。18KB
+  article-reader.js                 (#R169) サイドバー内リーダー。**#R11 以降どこからも呼ばれていない**
+                                    （ファイル冒頭に所見を明記。再配線するか削除するかは製品判断）。8KB
+  community-board.js                (#R169) コミュニティ板の中身（カード/スレッド/コメントのHTML・投稿モーダル・
+                                    地図レイヤー・Supabase 読み書き）。21KB
+  map-readout.js                    (#R169) 地図の読み出し系（座標/標高/レイヤー値/コンパスの表示・DEMサンプラ・
+                                    グリッド（経緯線）・計測チップ・`handleMapClick`）。27KB
+  elevation-profile.js              (#R169) 標高断面パネル（Draw ツールから開く）。7KB
   newsgeo.js                        (#R161) **非AIニュース地点解析エンジン `IntMapNewsGeo`**（決定論・単一の真実の源）。
                                     index.html から `<script src="js/newsgeo.js">` で読み込み、同一ファイルを
                                     `supabase/functions/_shared/newsgeo.js` にミラー（`scripts/sync-newsgeo.mjs`／
@@ -827,7 +863,7 @@ supabase/
 ## 3.1 index.html の分割方式 (#R162) — **今後の分割はこの手順に従うこと**
 
 **前提（これが全ての難しさの源）**: index.html のアプリコードは
-`window.addEventListener('DOMContentLoaded', () => { …分割前は約33,000行／#R167 時点で約9,000行… })`
+`window.addEventListener('DOMContentLoaded', () => { …分割前は約33,000行／#R169 時点で約4,900行… })`
 という**ひとつのクロージャの中**にある。
 したがって最上位の `let`/`const`/`function` は**グローバルではなくクロージャ変数**であり、`window` には載っていない。
 ファイルを js/ に出すと、その変数は**ただ消える**。
@@ -911,6 +947,41 @@ Playwright の monitors テストが拾わなければ本番に出ていた。
 - (#R166) `js/map-ui.js` の `opacities` / `setLayerOpacity` … 同じく layers IIFE の中。**レイヤープリセットの
   不透明度保存は分割前から一度も動いていない**（try/catch が ReferenceError を握り潰し、空の `ops` を保存）。
   修正は挙動変更になるので別ラウンド。
+
+### (#R169) 第8弾 — **「宣言」と「実行」で切る**／11本まとめて生成／90本の巻き上げシム
+
+#R168 で「主題」も出し切り、残った 6,894行・857文のクロージャは**どの文も他の文と絡んでいる**。
+そこで切り口を変えた。**どの文が一緒にいるか**ではなく、**その文は走るのか、宣言するだけなのか**で切る。
+
+- 857文をパーサで分類すると **277KB が純粋な宣言**（関数宣言／リテラル・関数だけで初期化される
+  `const`・`let`）で、**208KB が実行する文**（DOM配線・`map.on()`・ブート手順）だった。
+- **宣言は「いつ評価しても観測できる違いが無い」**。だから 11本のファクトリを**まとめて `map` 生成直後に
+  生成**してよく、`(#R167)` で踏んだ TDZ も、`(#R166)` で気にした呼び出し順も、原理的に発生しない。
+- **実行する文は1文も動かしていない。** 位置も順序もそのまま index.html に残る。
+  → **このラウンドは副作用を1つも並べ替えていない**、というのが最大の安全性の根拠。
+
+**この切り口で新たに必要になったもの**
+
+1. **巻き上げシムが約90本に増える。** 出した関数のうち index.html がまだ名前で呼ぶものは
+   `function n(){ return IM_X.n.apply(this,arguments); }` を残す（`const` は TDZ、アローは `this` 落ち。#R168 と同じ理由）。
+2. **`IM_HOST` が 201→253メンバー**（うち read-write は 29→52）。
+   RW が増えたのは「**主題の私有状態でも、宣言だけを出すと変数の宣言文は index.html に残る**」ため
+   （例: `let elevTimer, lastElev, _elevSeq, _crLng, _crLat, lastLayerVal;` は1文で6名前を宣言していて、
+   そのうち2つは index.html 側の `map.on()` ハンドラも書く。文は分割しない方針なので、
+   宣言は残して RW メンバーで書き通す）。
+3. **検証（tests/r169-checks.test.mjs）**
+   - **#4 宣言だけであることをパーサで証明**：ファクトリ直下に実行文が無い＋初期化子が何も呼ばない。
+   - **#3 位置**：11本の呼び出しが `map` 生成後に1ブロックで並ぶ＋**呼び出しより前に走る文から、
+     出した名前へ到達する呼び出し経路が無い**ことを**コールグラフを辿って**確認（直接呼び出しだけ見ると
+     1段挟んだ経路を見落とす）。
+   - **#2 シム契約**：エクスポート名ごとに index.html のシムはちょうど1つ・本体はもう index.html に無い。
+   - **#5 バレ識別子ゼロ**／**#7 `check-split-scope.mjs`**（#R162 以来の必須ゲート）。
+   - r165-checks の RW 契約に **prefix `++HOST.x` も書き込みとして数える**修正を入れた
+     （`++HOST._elevSeq` が今まで「所有者でないモジュールの書き込み」検査をすり抜けていた）。
+
+**このラウンドで見つけた事実（コードは変えていない）**: `openArticleInSidebar`（サイドバー内リーダー）は
+**#R11 の「Read を外部リンクに戻す」以降、どこからも呼ばれていない**。削除も再配線も製品判断なので、
+`js/article-reader.js` の冒頭に所見を書いて**そのまま**出した。DEV-NOTES R169 参照。
 
 ### (#R168) 第7弾 — **主題（SUBJECT）で切る**／巻き上げシム／RW所有者は集合へ
 
@@ -1229,16 +1300,11 @@ acorn で対象文の範囲（**直前のコメント塊を含む**）を確定 
     Web付き呼び出しは90秒（タイムアウト時はツール無し40秒で1回再試行）、空応答（reasoningが予算を食い切る）は予算増で1回再試行、
     `insufficient_quota`/支出上限は `provider_quota`（ハード）扱い。**リクエスト形の拒否がAI機能全体を殺せない**構造。
     比較（compareStats）は `metrics` パラメータをSYSカタログに明記＋5言語シノニム解決（defense→軍事費$等）で**指名指標どおり**開く。
-    **#R117 Luna性能引き出し**: ①**リペアパス**＝プランの一部アクションが実行失敗すると、失敗内容(type+params)を添えて別アプローチの再プラン→同じ返信に追記実行（**#R118で最大2巡**・試行済みコールの再発行禁止）。②**複雑度適応**＝長文/多節リクエストはクライアントが `effortHint:"high"` を送り、プロキシは **atlas_plan/analysis に限り** reasoning effort を high へ（出力予算+5000）。旧実装は effort≠medium を一律 low に潰していたバグも修正。③水域クエリ（…湾/…海/Bay/Sea等）は実ポリゴン再試行の上で**AIトレース輪郭へ絶対に落ちない**（誤った場所への幻覚ハイライト根絶、正直な「見つかりません」優先）。④Atlas返信のMarkdown見出しが階層サイズ（#15px/##13.5px/###12.5px、本文サイズ不変）。
-    **#R119 レイヤーデータ契約 = `window.IntMapLayers`**（Atlasを操作コンソールから**分析エンジン**へ）: 全レイヤー共通の register/state/**sampleAt(lng,lat)**/featuresIn(bounds)/legend/time/source。登録13（temp/sst/wind/precip/snow/aod/no2/co=Open-Meteoライブ実値・climate=Köppenピクセル・elevation=DEM・webcams/news/volcanoes=表示中フィーチャ抽出）。消費側: stateContextの実データ行＋**`layerData`アクション**＋**analyzeへの自動証拠注入**。新レイヤーは追加と同時にここへ登録すること。関連: analyze `scope:"drawn-area"`（範囲内ニュース+レイヤー実値+WorldPop人口）、`satelliteCompare`アクション（衛星2日付比較をスレッド内で）、`IntMapConsole.runDirect(label,acts)`（外部機能→Atlasスレッド）、生成系アクションの`objectIds`→`_wctx.lastObjects`、IntMapOSカーネル**29コマンド**（layer.on/off・compare.open・flightsim.setup・workspace.enter/exit等）。
-    **#R120 レイヤーデータ契約の拡張（登録13→30）**: ①**GIBSラスタのピクセル→物理値逆引き**＝表示タイルと同じURLの実タイルをcanvasで読み、ピクセル色をR42実測のカラーマップ勾配（SCALES）へ線分射影→凡例レンジの実値に逆変換（LST 46°C/海氷90%/SSTアノマリー±/NDVI等14ラスタ。透明=データ無し・勾配から遠い色=null＝正直）。②**aircraft/ships**＝表示中のADS-B機・AIS船のfeaturesIn+件数summary（コールサイン/船名も返る）。③**choropleth**＝表示中の国別コロプレス（コア7種=choroValueAt、WBベータ5種=フィーチャproperties直読み）の地点値。SYSのlayerData記述も拡張済み。④**objectIds対象拡大**: drawPolygonのポリゴン（`_imHlPolys`にid付与・IntMapObjectsに kind:'poly' として列挙=改名/色変更/削除/フォーカス可）、outline（kind:'outline'、IntMapOutline.current/focus新設）、GeoJSONアップロード（`window._imNoteObjects`フック→`_wctx.lastObjects`）。objectアクションのkindに poly/outline 追加。
-    **#R122 大量要望バッチ（FS開発一時停止）**: Atlas＝メッセージ別トグル所有権(`_ovlOwn`+`_refreshMapChips`)で各返信のオンオフ独立化・入力改行保持(pre-wrap)・返答時にユーザーメッセージを上端へ自動スクロール・リペア3巡・近似輪郭(`aiRegionPoly`40-90頂点+`_cleanAiRing`検証+退化リトライ)。**状態永続化**=`intmap_session2`(レイヤー/タブ/年代/base/3D)をリロード復元(座標はhash)。**経路根治**=破綻したOSM線路グラフ`railRoute`を無効化しMOTIS実GTFS非対応地域は正直に経路なし(OSRM道路は存続)。**地形移動/isolate**=`IntMapMoveShape`(メルカトル面積保存ドラッグ="true size")+非国isolate(enterGeom)+moveボタン、地名ハイライトはアクセント色。**Compare**=Countries選択時`previewOnMap`即ハイライト・時系列の開始/終了年セレクタ(mChart窓クリップ+署名にtsFrom/tsTo)・旅行中の地図クリックは`resolveHist`で歴史エンティティ選択。**Countries**=指標しきい値フィルタ(≥/≤・複数AND)。**範囲人口**にLOS方式進行バー。**レイヤー**=FSU+Historical borders(β)削除・Aurora凡例に予測時刻・Köppenデフォルト100%+ラベルクリック貫通防止・新βWB6種(R&D/観光/難民/CO₂/特許/女性議員)・ws起動時ニュース点滅解消(隠れ窓onWrapスキップ)。**UI**=右上バー通常モードもws幾何+ダーク選択白背景・地名ポップアップ不透過・分類名の全大文字廃止・タブ4文字自動フィット(モバイルAtlasグラデ維持)・左パネル展開時の検索バー位置・通常モードにws移動ボタン(デスクトップのみ)・ログイン配色/Google実ロゴ・Support文字・ニュースピン同一地点分散・FS開始時レイヤー退避。**プライバシー**=OpenAIコンテンツ共有条項(§4, LEGAL_DATE 2026-07-17)。
-    **#R123 UI/バグ一括**: モバイルのレイヤー名選択時太字除去・分類名拡大・右上バー縦gap一致・**サイドバー見出し2行固定**(1行目IntMap+言語/2行目WS/Login/Feedback/Settings)。isolate/moveは**領域あり地名のみ**(山/川/海は非表示)、Moveのメルカトル補正はflatのみ。**Aurora radius幾何級数**(→R124で不足判明)。**ニュースピン領域内分散**(place TYPEをgazetteer→pin伝播、country=国ポリ棄却サンプリング/city=型別ディスク)。範囲人口=WorldPopポーリング延長+Draw対応。**Compare昔年代クリック**=`TB.currentFC()`PIP(描画非依存)+データ無しera正直報告。**Compare時系列=利用可能年のみ**(serMap実在年を蓄積)。**ユーゴ一括ハイライト**=`regionGroup`が末尾集合接尾辞strip。**Others(beta)+8**(PM2.5/クリーン調理/女性労働/高等教育/農村/GNI/栄養不足/ハイテク)。
-    **#R124 再報告根治+新規**: **タブ文字揺れ**=`_fitTabFont`をfonts.ready後1回のみ。**Move on Globe**=剛体大円回転(Rodrigues)で真形状保存(flatはメルカトル面積補正)。**Auroraズーム消失**=ヒートマップをズームでフェードout+**密度非依存ソフト円グロー(l9-aurora-glow)**へハンドオフ。**ニュースピン実配線**=サーバ経路でsubject名から国型導出(_isCountrySubject)+ヒューリスティックを最大リング重心化。**範囲人口大面積**=WorldPop 100,000km²上限を`turf.bboxClip`でタイル分割+合算(実測380k km²→56.4M/6タイル)+実Progress。**Objects popup不透過**(--card-bg)。モバイル分類名16px/700。**Compare国追加ts同期**=`toggleCountry`差分適用(トレイ↔開いた比較ビュー)。**地図クリック国選択トグル化**(再クリック解除)。**Others(beta)+6**(固定BB/65歳以上/思春期出生/病床/研究者/過体重)。据置=Atlasトグル独立化(共有canvas→メッセージ別層の専用ラウンド)・era植民地resolveHist・あいまい地域/AI輪郭(ai-proxy検証制約)・経路10-10(GTFS収録依存)。
-    **#R125 再報告根治+経路優先**: **Move on Globe傾き**=大円回転後に到着点鉛直軸まわり北整列ツイストを追加(tilt 1.15°→0.01°・辺長不変)+**右ドラッグで図形回転**(globe=鉛直軸スピン/flat=計量フレーム回転・5言語ピル)。**Compare昔年代クリック完全化**=era名の宗主接尾辞strip照合("India (UK)"→British Raj)+PIPがhidden国に当たると**吸収中の旧国家に解決**(Korea 1914→大日本帝国)+沿岸PIPミスは最近接eraリング≤0.7°スナップ(Istanbul 1914→Ottoman)。**Atlasトグル真の独立共存**=所有者がいる種別は奪わず**メッセージ別クローン層(atlm<n>-*)**へ描画(feature-state nlq/choroVもスナップショット捕捉→クローンに再適用、_ovlAdoptは元ソースとモジュール状態(_hl/_choroState)も復元、styledata再構築+LRU上限14)。**Others(beta)+6**(都市人口/観光客/送金/自殺率/飲酒量/殺人率)。**経路(ユーザー優先指示)**=都市間日本レール・ブリッジ(上記#R125詳細)。据置=ICBM第一段階以降・物理シミュ5種・経路10-10の残段階(大型指示書)。
-    **#R126 経路10-10コア+タイムマシン国境根治**: **経路**=RouteStore(routeSetId・共有グローバル廃止・Atlasカードはdata-rset/data-rctxで過去メッセージも独立動作)+requestId/Abortプール(古い応答はcancelledで描画しない)+計算/描画分離(_paintスタッシュ+styledata再描画)+エラー型8種を5言語別文言+破損transit形状の直線代替廃止(shapeGapノート)+死んだrailRoute削除+**経路経由CORSプロキシ全廃**+**OSRM偽経路ガード**(waypoint snap>30km→no_route+距離表示。実測Lisbon→NYが5,534km先Cascaisへスナップし"Ok"を返していた)+入力編集で旧座標無効化+日付変更線fitBounds+**出発/到着時刻UI**(arriveBy)+地図クリック逆ジオコード+**同名地名の近接優先**(Potsdam根治、ビュー近傍≤300km→人口順)。**タイムマシン国境が出ないことがある**=apply()がソース存在だけで早期return（レイヤー欠損だとensure()に永遠に到達せず不可視）→imtb-line存在も確認+取得失敗時4s再試行。**Others(beta)+6**(軍事費%GDP/出生率/人口密度/教育支出/喫煙率/農業就業率、160行)。
-    **#R121 レイヤーデータ契約の完成度上げ（登録30→34）**: ①**choropleth画面外サンプリング**＝共有PIP（`window._imPipGeo`、穴あきPolygon/MultiPolygon対応）で、コア7種=countryGeo→countryStats直読み・WBベータ5種=ソースデータPIP・**bx系約40種のWBコロプレスを新規統合**（`window._imBxChoroValueAt/_imBxChoroOn`、所有モジュール側で公開＝契約規約どおり）。表示中の全コロプレス系統の値を「 | 」連結で返す（実測: 日本オフスクリーンで HDI 0.920 | 寿命84.0 | ジニ32.3）。②**earthquakes/datacenters/pharma** を featuresIn+summary で登録（地震は件数+最大M、名前は M{mag}+place）。③**thermal（火災）実ピクセル検出**＝FIRMS/GIBS WMS GetMap を**製品別に**取得し α>60 を和集合マスクで計数→「N fire pixels within ~15 km」/「none detected」（実測: 北豪アーネムランド29px・アンゴラ212px・海上0）。④**thermalレイヤー本体の根本修正**: 合成LAYERS=のWMSは**1製品でも当日データ欠損だと全体がServiceExceptionで空になる**（実測: SNPP欠損で当該レイヤーが全滅していた）→ 日別に小さなGetMapでプローブし、失敗製品を例外メッセージから除外した実描画可能サブセットでソース構築。⑤`window.__imBuild` ビルドマーカー（file://リロードのキャッシュ滞留診断用）。
-    **#R118 Atlas文脈・UI・ブリッジ**: ①**メッセージ別オーバーレイ・スナップショット**＝各返信の「地図に表示中」トグルは**その返信が描いた内容**を復元（`__ovlSnap`+`_ovlAdopt`＝モジュール状態へ採用。旧仕様は常に最新描画を開閉していた）。②入力欄=textarea（Enter送信/Shift+Enter改行/5行自動拡張）。③解体組織ハイライトに**年代基底**を明記・記憶（`_GROUP_META`→`_wctx.highlight`。「それは何年のもの？」にタイムトラベル日付を答えない）＋明確化質問は1回まで＋空の「使用データ:」非表示。④**逆同期ブリッジ第1弾**: `IntMapStatsCompare.state()`／`IntMapObjects.list/get/remove`＋`object`アクション（id/kind+indexで削除・フォーカス・改名）／開いている記事の**本文**が `_imReader.body` 経由でAtlasに届く／旧IntMapAIResearchはmoduleCatalogから除外。⑤**`population`アクション**＝WorldPop 100mグリッド(2020)で描画範囲・円・地名境界・place+radiusKmの人口を正確集計（`IntMapPopArea`、測定ツールにもボタン、出典・プライバシー記載）。
+    **#R117 以降の各ラウンドの差分は `DEV-NOTES.md` に集約 (#R169)。** ここには#R117〜#R126の
+    ラウンド別変更ログが10段落ぶら下がっていた（Atlasだけでなく経路・Compare・レイヤー・UIの話まで、
+    しかも R117→R119→R118→R120→R122→R123→R124→R125→R126→R121→R118 という順で）。
+    仕様として残す価値があった `window.IntMapLayers`（レイヤー・データ契約）は **§7 へ移設**、
+    残りは DEV-NOTES R117〜R126 に同じ内容がある。
 - **ニュース地点解析AI** — `refresh-news` が**同じ鍵・同じ AI_PROVIDER 規約**でサーバー側実行（ユーザー枠は消費しない＝運用者の鍵）。
 - フロントに見えるのは結果だけ。鍵・モデル選択UIはユーザーに見せない。
 
@@ -1296,6 +1362,16 @@ acorn で対象文の範囲（**直前のコメント塊を含む**）を確定 
 - **Active layers**：`_refreshActiveLayers()` がオン中のレイヤーをチップ表示。常に上部。トグル時はスクロールを補正して**行が動かない**ようにする。
 - **Globe専用**：`updateOcclusion()` で裏面ピンを隠す。
 - **ウィジェット**：サイドバーのカード群（`intmap_widgets3` に定義保存）。FX・ランダム国など。「Add widget」で追加。
+- **レイヤー・データ契約 `window.IntMapLayers`**（#R119 導入 / #R120・#R121 拡張。#R169 で §5 からここへ移設）
+  ——Atlas を「操作コンソール」から「分析エンジン」へ変えるための、全レイヤー共通のインターフェース。
+  - API＝`register` / `state` / **`sampleAt(lng,lat)`** / `featuresIn(bounds)` / `legend` / `time` / `source`。
+  - **新しいレイヤーを足したら、同じ変更の中でここへ登録すること**（これが契約の本体）。登録は約34系統：
+    Open-Meteo のライブ実値（temp/sst/wind/precip/snow/aod/no2/co）、Köppen のピクセル、DEM 標高、
+    表示中フィーチャの抽出（webcams/news/volcanoes/aircraft/ships/earthquakes/datacenters/pharma）、
+    **GIBSラスタのピクセル→物理値逆引き**（表示中と同じタイルを canvas で読み、色をカラーマップ勾配へ
+    線分射影して凡例レンジの実値に戻す。透明＝データ無し・勾配から遠い色＝`null`＝正直に「不明」）、
+    **コロプレスの画面外サンプリング**（共有PIP `window._imPipGeo`。コア7種＋WBベータ＋bx系約40種）。
+  - 消費側＝Atlas の stateContext に入る実データ行・`layerData` アクション・`analyze` への自動証拠注入。
 
 ---
 
@@ -1409,264 +1485,9 @@ acorn で対象文の範囲（**直前のコメント塊を含む**）を確定 
    初回は手動で1回 POST して `current_news` を埋める。
 7. **静的ホスティング**：`index.html` / `admin.html` / `data/` / `koppen_*.png` / `sw.js` を静的配信（OneDrive 直配信 or 任意の静的ホスト）。
 8. **OAuth/メール認証**：Supabase 認証で Google/Apple/メールを設定（任意）。
-9. **動作確認**：ページを開き、(a) レイヤー行≈72個、(b) コンソールエラー0、(c) News タブでピンが即表示、
-   (d) ログイン→AI機能が動く、を確認。
-
----
-
-## #R127 補足（再報告根治・上記各モジュールの現状）
-
-- **範囲人口 `IntMapPopArea`**: WorldPop 100m グリッド集計。95,000km² 超は `turf.bboxClip` でサブ上限セルにタイル分割→合算。**#R127**: 旧80セル上限を **340**（≈30M km²＝どの単一国も収容）に引き上げ（米本土48州=189/東南アジア海域=195セルは旧コードで throw していた）。各タイルは `_tileWithRetry`（60s×2回）で一過性のレート制限/タイムアウトを再試行し、**失敗タイルを0として黙殺しない**＝全失敗は throw、一部失敗は `partial:true`（件数明示・キャッシュしない）。実測: 欧州451k km²→8/8タイル・87,805,246人。
-- **Atlas 地図オーバーレイのメッセージ別トグル**: 種別ごとに共有 `nlq-*` キャンバスを1メッセージが所有（`_ovlOwn`）。**#R127**: 新描画が共有キャンバスを奪う **`runActions` の描画経路**で、所有権再設定の前に**旧所有者をそのスナップショットから自前のクローン層（`atlm<n>-*`）へ退避**（`_ovlCloneShow`＝R125で手動クリック経路が検証済の同一機構）。→ 新旧が共存し両チップともON（「新規追加で古いものが勝手にオフ」を根治）。
-- **ニュースピンの重複分散 `_spreadDupNewsPins`**: 同一アンカーに積み重なるピンを領域内に散布。**#R127**: `regionFor` が**最大リング（本土）のbbox+ポリゴン**も返し、全体bbox幅>180°（日付変更線アーティファクト＝米/露/フィジー/NZ）なら**本土リングでサンプル**（旧: 全体bbox=幅358.9°で44回中2回しかヒットせず0.12°の点に退化）。各ピンの原座標を `__oc` に保持して散布を**冪等化**し、`countryGeo` ロード完了時に `_respreadNews()` で再散布（コールドロード競合を根治）。実測: 米本土リングで30/30配置・経度41.5°×緯度17.5°。
-- **モバイル通常モードのレイヤー分類名**: `.m-sheet .lyr-head`。**#R127**: 16px（行15.5pxとの差+0.5px）で埋没していたため **18.5px/700**（行比+3px）に、上下マージン27/11pxで明快なセクションヘッダに。
-
-## #R128 補足（再報告4件の根治・上記各モジュールの現状）
-
-- **範囲人口 `IntMapPopArea`（大面積失敗の根治）**: 真の失敗モードは**`fetch()`にタイムアウトが無い**こと＝WorldPop公開APIが負荷時に接続をストールさせると`Promise.all`バッチ全体が数分凍結し「失敗」。**#R128**: `_fetchT`＝AbortController付きfetch（create 30s/poll 18s中断）、固定バッチ→**staggered worker pool**、**CONC 4→2**（多タイルの持続負荷でレート制限されるため）、retry 2→4・長バックオフ、単一ポリゴンもリトライ経由、極小クリップ片(<0.05km²)スキップ。正直partialは維持。実測: 290,851km²→6/6タイル・25,316,807人・64秒（ハング根治）。
-- **昔年代クリックの決定論解決 `IntMapTimeBorders.resolveHist`**: 全CShapes era featureは`properties._gw`（Gleditsch-Wardコード）を持つが両呼出元で捨てられていた。**#R128**: `data/cshapes.js`由来の**`_GW2ISO`表（235件・単一継承コードのみ）**を追加し、step2.4＝`_gw`→現代キャリアを**境界/名前非依存**で直接解決（step1帝国・`_VANISHED`の後、BEC/PIPの前）。改名/**領土変化**国の長い尾（独帝国のポズナン/アルザス→DEU、植民地→現代後継）をPIPフォールバックに頼らず根治。多継承帝国(A-H 300/CSK 315/YUG 345)とTibet(711)は非収載でstep1/`_VANISHED`優先、`_histHidden`ガードで能動的帝国下の後継はstep3bへ委譲。実測: ポズナン→DEU（PIP=POL）。
-- **レイヤー分類名（通常モード）**: 通常/デスクトップ`.lyr-head`・`.layer-group-title`。**#R128**: 12.5px/600/muted（配下の行`.layer-option`13px/500/text-mainより小さく薄く、見出しが下位に見えた）→**15.5px/700/text-main**・上マージン14pxで明快なヘッダに（モバイル18.5px `!important`は不変）。
-- **歴史データ拡充（継続）**: (旗) `_VANISHED`の3消滅国（Tibet/East Turkestan/Manchukuo）にインラインSVG旗を追加し`resolveHist` step2b が`out.flag`を渡すよう配線（従来は旗皆無）。`IntMapHistId`のHUNに戴冠紋章旗`F_HUNK`。(統計) `IntMapHistStates` JEM（大日本帝国）に`popEst:105M/gdpEst:230/estSrc`（pre-1945後継sum崩壊の帝国推計override）。(Wiki) `_ERA_WIKI` +14（残ソ連構成共和国9＋AFG/YEM/ERI/PSE、全て実在確認）。(名) `IntMapHistId`にKOR（大韓帝国）/ETH（エチオピア帝国・帝政三色旗）の年代identity。
-
-## #R129 補足（範囲人口Progress・戦間期ユーゴ・モバイル分類名・Countriesクリック国選択・歴史拡充）
-
-- **範囲人口 Progress バー（数十%→0%再スタートの根治）**: `IntMapPopArea` のコア（`done/cells.length`）は単調で正しい。UIの2ドライバ（時間ベースの漸近ランプ Driver A ／ 実タイル進捗 onProg Driver B）の**引き継ぎが非単調**だったのが原因＝大面積で最初のタイル完了に5-30秒かかる間にランプが数十%まで登り、onProg発火時に`1/タイル数`(≈3%)へ**逆戻り**していた。**#R129**: 表示フラクションの最大値を保持する `_sp`（`Math.max(shown, …)`）で単調化し、実進捗をランプ引き継ぎ点より**上の帯 `[hand,1]` に再マップ**。measure/area パネル(`#tp-pop-btn`)と自由描画パネル(`_estimateDrawPop`)の両方。実測（ロジック検証）: ランプ51.6%→引き継ぎ後52.5→…→100%、逆戻り0回。
-- **戦間期ユーゴスラビア王国 `IntMapHistStates`（クリック国選択の断片化を根治）**: CShapesは戦間期ユーゴを1ポリゴン「Yugoslavia」(gwcode 345)で描くが registry が SFRY(1945+)のみで**戦間期にエントリ無し**→クリックが現代の Serbia/Croatia/Slovenia… に**断片化**（オーストリア=ハンガリー/チェコスロバキアは単一エンティティに解決されるのに、である）。**#R129**: **Kingdom of Yugoslavia**（`code:'YGK'`, 1918-12-01〜1945-11-28, 5言語名・王国旗`F_YUGK`・`wiki:'Kingdom of Yugoslavia'`）を追加。`madCode:'YUG'` で Maddison の連続YUG系列を再利用（後継国に戦前データが無いため）。SFRYと時間的に不重複＝`activeAt()`が同時に両方を返さないので同一名衝突なし。`agg` に `madCode` サポート、`_eraLocName` は**存続期間一致を優先**（1925ラベルがSFRY名に化けない）。実測: ベオグラード/ザグレブ/リュブリャナ/サラエボ/スコピエ 1925 → すべて **Kingdom of Yugoslavia**（データ 1925=13.4M/$23.5B・1938=16.1M/$32B, Maddison実値）。SFRY(1960)・A-H(1914)・チェコスロバキア(1925)は不変。
-- **Compare クリック国選択の当時ポリゴン優先（`_pickResolve` ／ 新Countries picker）**: **#R129**: era PIP を**最小面積の内包地物**に（簡略化された当時ポリゴンが国境で重なるケースで大きな隣国を誤取得しない＝ポーランド東部Kresy→USSR誤判定を防止）。従来は最初の内包地物を採用していた。
-- **Countries 初期画面のクリック国選択ボタン**: 検索欄の右にクロスヘア（`#csearch-pick`／ws-mode `#csearch-pick-ws`、5言語 `pickCountryMap`、`flex:0 0 auto`で改行なし）。従来は開いた比較ウィンドウ内の◎のみで、初期画面のマップクリックは**現代ポリゴンの `showCountryDetail`**＝タイムトラベル中も現代国を選んでいた。**#R129**: 新picker は `resolveHist` で**era対応**解決（王国・植民地・帝国）→`_toggleCompare` で比較セットへ。`window.__scpPick` を立てて既定の country-fill / handleMapClick を抑止、ESC/再クリック/タブ離脱で解除。`renderUI` が Countries タブ時のみ `.on-tab` 表示。
-- **歴史データ拡充（継続）**: (名/旗/統計) 上記 Kingdom of Yugoslavia（王国旗・5言語名・Maddison実データ）。(Wiki) `_ERA_WIKI` にアルバニア(共和国1925-28/王国1928-39/社会主義人民共和国1946-91)・アイスランド王国・モンテネグロ王国・ネパール王国・スウェーデン=ノルウェー連合・ラオス王国を追加（全て en.wikipedia 実在をAPI確認）。
-- **#R130 素のマップクリックのera対応化（昔年代クリックの真の根治）**: R122〜R129はクロスヘアpicker/`resolveHist`（既に正しかった）を直していたが、ユーザーの実ジェスチャー＝**素のマップクリック**は era非対応の `country-fill` click ハンドラ（`resolveCountryId`→現代countryGeo）が処理していた。→タイムトラベル中は picker と同一の `TB.currentFC()` 最小面積PIP→`resolveHist` を通し**現代ポリゴンに絶対フォールバックしない**（都市ラベル下は場所優先、コードあれば `showCountryDetail(era)`、コードなし実在エンティティは `_imPlacePopup`）。hover も旅行中は現代国の強調/情報を出さない。実測: 1925 ルヴフ/ヴィリニュス/ポズナン→**POL**、ヴロツワフ→DEU(Weimar)、ダンツィヒ→Free City of Danzig。
-- **#R130 消滅国4件を `_VANISHED` に昇格（wrong-carrier根治）**: `_GW2ISO`（step2.4）が East Germany(gw265)/South Vietnam(817)/South Yemen(680)/Danzig(291) を現代キャリアに畳み、クリックで**現代旗＋間違ったera記事**になっていた（東独→西独記事等）。`_VANISHED`（step2b, gwcodeより先発火）に4件＋インラインSVG旗（F_DDR/F_RVN/F_PDRY/F_DANZIG）を追加し identity/旗/Wikipedia を正す。`IntMapHistId` に West Germany(1949-90)・Pahlavi Iran(F_IRPAHL, Persia を to:1925短縮)・Francoist Spain(F_ESPF)。`agg()` が空欄だった capital/currency/languages を `_STINFO`（15カ国）でマージ。`_ERA_WIKI` に Cambodia/Oman/Trucial States、`_ERA_LOC` に南北ベトナム/南北イエメン。
-- **#R130 Atlasハイライトのweb検索検証**: ラダーは Nominatim importance と web盲目AIトレースを無検証で信頼し「塗れば✦成功」だった。ai-proxy に `geo_verify` タスク（webMode:required・JSON・低予算）追加→**デプロイ済**。client `geoVerify(name)` が権威座標を取得（9sタイムアウト・キャッシュ・**fail-open**）→`_nomExtent(place,anchor)` の近接ボーナスで8候補から検証点に最近を選抜（同名語撃退）＋未信頼ラング（Nominatim水域/adminポリ・AIトレース・codeAtPoint）で `_geoAgrees` により明白な位置不一致を棄却（`_gvStrong`=webUsed必須でなければ棄却せず既存挙動維持）。報告に「✓ location web-verified」。
-- **#R130 その他UI**: Objectsボタンを左下FAB→右上ツールバー `#btn-tool-objects`（`objectsBtn` 5言語、`tickFab`が配線・カウント同期・オブジェクト有時のみ表示、FABはモバイル限定）。サイドバーAtlasの`addEdgeResize`辺リサイズを `_inWsWin2` に `atl-tab` skip追加で無効化（width:100%と競合しての「変なことになる」を根治）。Atlas thinking を `stageDots/setStage/_STAGE_OF` で実作業表示（Thinking/Searching/Analyzing/Mapping/Writing・5言語）。通常モード Measure/Radius の使用中(`#…​.tool-on`)を白背景黒文字（Grid/Draw不変）。左タブ News/Info/Countries active=白背景黒文字・Atlas active=`.atl-b.u`と同じアクセントグラデ。地図の国名ラベル3層（ofm-country/imtb-lbl/imtb-lbl2）の `text-transform:uppercase` 撤去で全大文字廃止。位置情報許可ボタン=1回grantで全ウィジェット再描画＋太字解除。
-
-## #R131 補足（`analyze` の鮮度検証・日付/証拠の意味づけ・多国カバレッジ・Web検証引用）
-
-「中央アジア直近72時間の監視判断」誤答（対象期間外の7/7事件を直接的証拠に使用・記事公開日を事件発生日と混同・見出しから国家間衝突と断定・燃料報道の過剰解釈・5か国中3か国のみで結論）を、**推論処理を増やさず**（AI呼び出しは従来どおり 1回・reasoning effort は medium 据置）、既存の Hosted Web Search / meta.webUsed / 引用annotation / 並列検索を**正しく接続**して根治。
-
-- **鮮度重要質問の Web検証強制（`_analyzeFreshness`）**: `analyze` は常に `webMode:"auto"`（検索は任意）だった。明示的時間窓（`_FRESH_NUM`＝「72時間/48h/直近N日」等）・最新/現在/直近（`_FRESH_NOW`）・監視/警戒/脅威度（`_FRESH_MON`）・ファクトチェック（`_FRESH_FC`）・直接的証拠/確認済（`_FRESH_DIRECT`）を5言語で検出し、`freshness.critical` なら `webMode:"required"`（検索を強制）。安定知識質問（文化/歴史/科学）は `false`＝従来どおり `auto`（応答時間・回数不変）。実測: 監視/最新/現職/FC/N時間=critical、文化/歴史/GDP比較=非critical。
-- **実クロック＋要求ウィンドウ（`_nowContext`）**: 旧プロンプトは `toISOString()` の**UTC日付のみ**（JST 0-8時は前日）で時刻もウィンドウも無し。`Intl.DateTimeFormat('sv-SE', {timeZone})` で**ローカル現在時刻＋タイムゾーン**を渡し、明示窓があれば `Requested evidence window: <now−窓> through <now>` を `[TIME CONTEXT]` に付す（テスト用に nowMs 注入可）。
-- **日付種別を明示した構造化証拠（`_analyzeEvidence`/`_evidenceBlock`）**: 3つの無日付見出しダンプ（loaded/GDELT/Google News）を、**1つの `[NEWS EVIDENCE]`**（新着順・`[eN]`ID・`article_date`＋`date_type`（publication_date／gdelt_seen_date）＋`event_date: unknown`）へ統合。各フェッチャ（`_gdeltNews`/`_gnewsNews`/`_newsData`）の srcSink push に `dateType`/`origin` を付与。モデルは**記事日付を事件日と誤認できない**。
-- **多国検索が最初の国へ縮まない**: 旧コードは `topicEn` を `codes[0]` の英名で上書き＝「中央アジア(5か国)」が Kazakhstan のみ検索。→**地域**GDELT＋**要求国のOR**GDELT（`("Kazakhstan" OR … OR "Uzbekistan")`）＋ユーザー言語Google News の3系統（GDELT2件はGDELT自IPレート配慮でジョブ内直列）。`[REQUESTED COVERAGE]` で要求国一覧を渡し、証拠が無い国は明示させる（単一国は従来挙動不変）。
-- **分析プロンプト全面改訂（`_analysisSystemPrompt`）**: 公開日/GDELT seen date ≠ 事件日／見出しは lead であり当事者・因果・国内 vs 国家間・分類を推定しない／深刻な見出し=escalationの証拠ではない／「問題を報じる記事」≠「危機が発生」／監視判断は対象窓内に確認済み事件が無ければ**低アラート（維持）を優先**／定例外交会合は短期リスクの**弱い反証**／直接的証拠・未確認兆候・背景・反証を**分離**／多国は情報不足国を明示／**ユーザー指定の出力形式を語数制限（~230語目安）より優先**／誤った "sorted newest-first" 記述を撤去。
-- **webUsed で暫定表示（最優先2）**: `freshness.critical && !meta.webUsed`（検索が走らなかった／タイムアウトでtool-free fallback）なら回答下に**暫定評価バナー**（5言語）＝見出し中心の暫定評価で確認済み直接証拠ではない旨。`webUsed` 実行時のみ「使用データ」に「ライブWeb検証」を加える（未実行を検証済みと偽らない）。
-- **ai-proxy: Web検索引用の保持＋返却（最優先3・デプロイ済）**: `callOpenAI` が Responses API の `output_text.annotations`（`url_citation`）を捨てていた。`{url,title,startIndex,endIndex}` を抽出（重複除去）→ callOpenAI 返却値＋成功レスポンス top-level `citations` に追加。client `aiCallServer` が `window._aiLastCitations` へ格納。`analyze` のソースカードは **①Web検証済み（url_citation）→②モデルが引用した収集記事→③その他の収集記事** に分離表示（収集しただけを回答根拠と同列に並べない）。
-- **プランナー**: `analyze` 説明に「名前付き多国地域／明示国セットは `place` に加え `countries` に**実際の構成国**（英名・地理知識）を入れ、`question` は完全な質問を保持」を追加（中央アジア専用コードは足さない）。
-- **回帰テスト（`window.IntMapAtlasQA`）**: 時計（2026-07-18 05:00 JST）と3見出し fixture（Kyrgyz-Uzbek国境27名拘束=seen 07-16／Kyrgyz-Tajik燃料=07-15／EU-中央アジア定例対話=07-16）を固定し、freshnessCritical・webMode=required・72h窓算出・全項目 event_date:unknown・date_type種別・国境記事がlead扱い・5か国カバレッジ明示・プロンプト各規則・単一AI呼び出しを**19項目全PASS**でヘッドレス検証。
-
-## #R132 補足（汎用地域解決基盤 `IntMapRegionResolver`・Atlasタブ色・Objects直下ポップアップ・昔年代クリック・FS中ハイライト非表示・歴史Wiki拡充）
-
-- **汎用地域解決基盤 `window.IntMapRegionResolver`**: 未登録の自然/非公式/歴史/経済地域名（East European Plain・関東平野・パンノニア平原・チベット高原・レバント・ドンバス・サヘル・肥沃な三日月地帯…）を、**AIに境界座標を書かせず**実データで解決する汎用基盤。`resolveHlTarget` の**fuzzyテール**（旧 `aiRegionUnits`/`aiRegionPoly` の幻覚経路）をログイン時のみ本基盤へ置換（ログアウトは従来経路へ fail-open）。
-  - **サーバ**: `ai-proxy` に `geo_resolve` タスク（`JSON_TASKS`・`reasoning:"medium"`・`max_output:1800`・`webMode:required`強制）。**構造化メタデータのみ**を返す（`canonicalName/aliases/featureType/ambiguous+candidates/expectedCountries/representativePoint/expectedBbox/geometryStrategy/osmName/adminUnits/mustInclude/mustExclude/boundaryAnchors(時計回り)/confidence/sources`）。最終ポリゴンの頂点列は返さない。
-  - **クライアント配管**: `aiCallServerFull()`＝呼び出し単位の `{text,meta,citations}` エンベロープ＋`opts.signal`（実Abort）。`askAIEnvelope`/`askAIJSONEnvelope`。`aiCallServer` は薄いラッパで全既存呼び出し不変。`geoVerify` は 9秒 Promise.race を廃止し**本物の AbortController**（タイムアウトで fetch 中断・`meta.webUsed` はエンベロープから）。
-  - **解決ラダー（実データ最優先）**: `country`→`admin_union`（`composeRegion`）→`osm_polygon`（`_nomExtent` を representativePoint でアンカー）→`derived_anchors`（Web検証済みアンカーの順序リング→`turf.kinks`自己交差check→凸包、expectedBbox クリップ、`webUsed`必須）。**bboxを境界として塗る処理は撤去**（bboxは検索/選別/fit/検証のみ）。
-  - **検証ゲート `_rrValidate`（fail-closed）**: Polygon/MultiPolygon・座標有効・全世界blob棄却・面積下限・expectedBbox重なり≥0.12・mustInclude内包≥60%・mustExclude侵入≤15%・expectedCountries一致（`codeAtPoint`）。R130の中心距離方式（巨大ポリゴンほど許容も巨大）を置換。通らなければ描画せず正直に失敗。
-  - **曖昧性**: `ambiguous+candidates` を返し、ハイライトdispatchが候補提示（`lastCountry` 一致時のみ自動確定）。
-  - **キャッシュ**: セッション `Map` ＋ IndexedDB `intmap_regionresolver`（`_RR_ALGO`＋TTL 成功90日/否定7日）。
-  - **AI回数**: fuzzyテール=`geo_verify`（安価）＋`geo_resolve`（medium）各1回・以降キャッシュ0。
-  - **Atlas表示**: 「実際のOSM境界データから描画」「N行政区画の実境界を合成」「⬡ Web検証済み境界アンカーから構築した近似範囲」「曖昧なため未描画—候補提示」を返答に明示。
-  - **デバッグ/テスト**: `window.IntMapRegionResolverDebug.last`／`window.IntMapRegionResolverTest.run()`（純粋関数13項目・**実測13/13 PASS**）。
-- **Atlasタブ色（`#R114/#R130`再修正）**: 共有トークン `--atlas-grad = linear-gradient(135deg, var(--primary-color), #5e5ce6 56%, #bf5af2)`（アクセント先頭の3ストップ）で**デフォルトアクセントでも単色化しない**＆任意アクセント追随。アクティブタブ・非アクティブ枠(`::before`)・ユーザー吹き出し `.atl-b.u`・モバイルを統一。
-- **Objectsポップアップ直下化**: `IntMapObjects.open()` に `_placePanel()`＝`#btn-tool-objects` の rect に右揃え＋直下(+8px)。モバイルFAB時はFAB直上。`data-dragged` 尊重・画面内クランプ。
-- **昔年代クリック（再々報告）**: `IntMapTime.setYear()`実ロードで 1919〜1938 全年 Poznań→Poland（Warsaw/Kraków/上シレジア/回廊も POL）を turf-PIP+`resolveHist` で**実測＝正答**。Wrocław/Szczecin→Germany・Danzig→Free City は**史実どおり正しい**（1920年代独領）。残る理論的穴＝era解決失敗時の現代 `countryGeo` フォールバックを封鎖し、**旅行中はフォールバックせず** `{eraLoading}`/`{code:''}`＋「読込中—もう一度」トースト（`resolveAt`・`_pickResolve` 両ピッカー）。
-- **FS中ハイライト非表示**: `_fsStashLayers` の `typeof clearHl==='function'` は別クロージャの関数で恒久 no-op だった。`_fsHideHl`/`_fsShowHl` で overlay 群（`place-hl-*/nlq-fill/nlq-line/nlq-poly-*/nlq-choro/pl-outline-*`）を `visibility:none` 退避→着陸で復元（start/stop の stash/restore へ結線）。
-- **歴史Wiki拡充**: `_ERA_WIKI` に HRV(独立国1941-45)・SGP/BLZ/GUY/SUR/ZMB/MWI/BWA/LSO/SWZ/UGA の植民地期実記事（全て新規キー・ポップアップが存在プローブ）。実測: 1943 Zagreb→`Independent_State_of_Croatia`。
-
----
-
-## #R157 補足（Atlas 自然言語処理の全面再設計＝「GPTが意味を理解する層」と「コードが安全に実行する層」の明確な分離）
-
-**設計原則（現状仕様）**: Atlas のハイライト系ターゲットは **意味の解釈をGPTが担い、コードは検証・実行のみを担う**。ユーザーの自然言語は意味を保持した原文のまま最初にプランナー（GPT）へ渡る。`localPlan`/`regionGroup`/`GROUP_ALIASES`/`REGION_ALIASES`/正規表現が**GPTより先に概念の意味を決定・改変・拒否する経路は存在しない**。既存の ISO/UN M49/国境 GeoJSON/組織加盟国データは**意味推測辞書ではなく**、GPT出力を検証して実地理形状へ結び付ける**決定論的データ**として残る。
-
-- **① localPlan からハイライト・ターゲットの解釈を撤去**: 旧 `^(.+?)をハイライト` → `{highlight,countries:'<生概念>'}` `confident:true`（GPTを一度も呼ばず dispatch へ生概念を渡していた単一真因）を廃止。localPlan に残る highlight ショートカットは**意味解釈を伴わない2つのみ**＝現ハイライトの色変更（`parseColor` ゲート・ターゲット無し）と解除。あらゆる「…をハイライト」は必ず GPT プランナーへ。
-- **② GPT主導のターゲット契約**: SYS の highlight スキーマ＝`{"type":"highlight","interpretation":str,"targets":[{"name":"<English>","iso3":"<ISO3>"},…]}`。GPTが概念（文化圏/言語圏/政治・歴史的分類/曖昧な国集合＝ゲルマン諸国・スラブ諸国・英語圏・旧植民地・主要産油国・OPEC・G7 等）を**自分で実ISO3集合へ展開**する（「IntMapに概念辞書は無い」と明示）。複数集合を別色＝`groups:[{label,targets}]`。国集合でない**具体的単一地物**（行政区画/河川/流域/自然地域）＝`query:"<地名>"` で従来の `resolveHlTarget` ラダー（＝概念でなく確定地名のみ・GPTの後段でのみ稼働）。
-- **③ コード側実行層（`_hlReadGptGroups`/`_hlValidCodeSet`・dispatch highlight 冒頭）**: GPTの targets/groups/iso3/codes を読み、各ISO3を **`_hlValidCodeSet`（`window.countryGeo` 由来の実在コード集合）で検証**（不正コードは拒否・氏名があれば `resolveCountrySync` で救済＝正確な国名→コードの決定論マッチ）、重複除去、`_codesGeo` で**実国境 MultiPolygon** 構築、`_validGeo` で形状検証、`paintPolys` 描画、`_verifyPolyPaint` で実状態検証、**採用した解釈を凡例＋注記で明示**、無効コードは「スキップ」正直報告、全無効は `ok:false`。`regionGroup` はこの経路を通らない。`countries`（文字列/名前配列）経路は**legacy fallback として温存**（R143 直接 dispatch テスト無回帰。`_hlReadGptGroups` は生ISO3配列のみ targets 扱い＝名前配列/概念文字列は null で legacy へ）。
-- **④ 画像のみ送信で架空ユーザー文を生成しない**: `run()` の `if(!q&&imgs.length) q=L('Read and analyze…')`（既定文をユーザーバブル/履歴へ露出させていた真因）を撤去。`q` は空のまま＝ユーザーバブルはサムネイルのみ・履歴は空。既定指示は `_visionPrompt` 内でユーザー未入力時のみ付与＝**API境界の非表示システム指示に限定**。ペースト/ドロップ/添付が textarea を変更しないのは既存挙動（`_atlAddFiles`＝`_atlImgs` に push のみ）。R156 の Vision/数式/検算/非地理ゲートは無変更。
-- **公開/テストAPI**: `IntMapAtlasDebug.{hlReadGroups,validCodeSet,hlState}` 追加（純関数＝mapなしでCI検証可）。データソース変更なし（`window.countryGeo`/`countryStats` 再利用）。Edge Function 変更なし。テスト: `tests/r157.spec.js`（Playwright 8）＋ `tests/r157-checks.test.mjs`（source 5）。**罠**: Browserペインは `document.hidden`＝`isStyleLoaded()` 未完了で `paintPolys` が false→dispatch ok:false（legacy `東西南北欧` も同ペインで同挙動＝環境要因）。描画真偽は WebGL 可能な Playwright で検証、ペインでは `polyState()`/`hlReadGroups` の**パイプライン出力**で検証（R143/R156 と同一の罠）。
-
----
-
-## #R154 補足（UX/機能バッチ10件）
-
-`index.html` のみ（Edge Function 変更なし）。テスト＝`tests/r154-checks.test.mjs`(node 10)＋自変更で壊れた r149/r150/r152/r153 assert 更新。`npm test` 緑（static＋node **109**＋Playwright **80**・pageerror 0）。主要修正をハーネス実測で検証（クリーンポートで Playwright 80/80、汚染ポートの11失敗は同時実行セッションとの資源競合と確認）。
-
-- **① ケッペン幅（7回目・真因＝固定幅）**: 264px 固定は日本語（最長行~137px）で **~80px 死に幅**（「テキスト以上に横幅伸ばして…行の幅変わってない」）、独語で数語クリップ（「狭すぎる」）。→**内容ハグ**: `_fitKoppenLegend` がオフスクリーンspanで最長行を実測し、行クローム＋予約gutter を加えた px 幅を直接セット（clamp 176–324・右余白内）。CSS 固定ロックを `width:210px(fallback);min-width:172px;max-width:340px` に。実測 border-box: JP 207/EN 276/DE 317/RU 307/ES 303px・**全言語クリップ0**。幅は build/表示/リサイズ時のみ決定論再計算＝縦ドラッグで不変。下端マージン 12→8px。モバイルは既存 `!important` 幅で保護。
-- **② Atlasタイポ（色分け廃止＋捏造停止）**: (a) mdMini 全見出しの `color:var(--primary-color)` を撤廃＝**`--text-main`＋サイズ(# 1.6/## 1.34/### 1.12/行全体太字 1.16em)＋余白のみ**で階層化（「目次を色分けするのはやめる／サイズと配置で勝負」）。(b) `_atlStanza` の**見出し捏造を全廃**（先頭文→太字リード・文頭 `Label:`→`##` を削除＝「大きくする箇所がおかしい／判定がおかしい」の真因）。拡大は**モデルが書いた `##`／行全体太字のみ**。整形は安全なもの（長 run-on の~2文stanza分割・list正規化・段落余白）のみ。プロンプトに「見出しは真の節タイトルのみ・普通の文を拡大するな」。
-- **③ SV Coverage 線（4回目）**: 画面ストローク≈nativeStroke×(tileSize/256)なので **`tileSize:128→64`**（z+3 fetch・~4×縮小＝**~0.9px ヘアライン**・native/overzoom いずれでも単調に細い）＋ `raster-opacity 0.9→0.62`。maxzoom は据置。
-- **④ Atls出典（「全くない」の真因）**: `_atlCleanUrl` が**復号不能 Google News リダイレクトを丸ごと drop**（近年の不透明RSS→ニュース1バッチ全滅→出典ゼロ）。→ **リンク保持**（クリックで実記事へ）し `linkCards` は**発行元名（`src`）でドメイン表示**（"news.google.com" 表記回避）。SNS/短縮/動画 drop・関連度・異script保持は不変。
-- **⑤ Draw で Elevation profile**: `_elevationProfile`（measure/area＋`measurePoints` 固定）から**再利用コア `_profileFromCoords([lng,lat][])`** を抽出（measure/area は委譲＝挙動不変）。DrawTool `renderPanel()` に `📈` ボタン（`simplified.length>=2`）→ 描いた線を同一 DEM パイプラインで断面化。5言語 `elevProfile` 既存。
-- **⑥ AQI/UVI iOS再構築**: カード全体をカテゴリ色グラデで塗り（`_wgtColor` が inline `!important` でガラス上書き制圧）、**輝度で文字色分岐**（淡色→暗文字/濃色→白）＝全段コントラスト確保。数値36px。**AQI 6段階**（4→6・Very unhealthy/Hazardous 追加）。カテゴリ名5言語（`_WL`）。データ源不変。
-- **⑦ Atls音声入力**: `.atl-inbar` に `.atl-mic`＋Web Speech API。認識言語=UI言語、結果は入力欄に挿入（確認後送信）、録音中赤パルス、非対応で非表示。5言語タイトル。
-- **⑧ Layerパネル既定=右**: `window.imLayerPanel 'classic'→'right'`（保存済み classic は優先）。
-- **⑨ 右サイドバー左右調整＋既定縮小**: 左 `#sb-resizer` 鏡写しの**左端ハンドル `.lsr-resizer`**（左移動で拡大）＋`localStorage 'intmap_lsr_w'` 永続。`open()` は**保存幅優先**（従来は毎回上書き＝ドラッグ無効化）。既定幅 **430→380px**。地図 ≥320px。
-- **⑩ オフレイヤー残存表示**: 真因＝**OFF→hide 自己修復が自動学習レイヤーに欠落**（`.setStyle` 皆無・reconcile は ON 再発火のみ）。`_auditLearned` を**両方向対応**（`!cb.checked` 早期return撤廃）＝OFF かつ painted なら hide（`_ownedByCheckedOther` で他 checked が正当に描くidは除外）。二次＝ECMWF ロード失敗で `state[id].on=false` も戻す（styledata 再attach 復活を防止）。
-
----
-
-## #R153 補足（UX/機能バッチ8件・再報告の根本原因）
-
-`index.html` のみ（Edge Function 変更なし）。テスト＝`tests/r153-checks.test.mjs`(node 9)＋自変更で壊れた r149/r150/r151/r152 assert 更新。`npm test` 緑（static＋node 99＋Playwright 80・pageerror 0）。全修正をハーネス実測で検証。
-
-- **① ケッペン凡例（6回目）**: R152 の `nowrap`+200px+ellipsis が **EN30区分中11名をクリップ**（実測: EN名は幅216px要）＋自然高519pxが768ノート可用~514pxを5px超過＝EF到達不能。修正: 幅 **200→264px**（EN/JP/RU/ES全収・独語最長2-3のみ hover）／行 `padding:0.5px→0`＋`line-height:1.2` で**自然高489px**（全区分既定表示・EF到達）／**RU/ES 気候名を KNAME に追加**（従来 en フォールバック）。`_fitKoppenLegend`(min(内容高,vp)) は無変更＝内容高を下げるのが真因。
-- **② Measure/Share ポップアップ**: 「無条件透過するな」+「無条件不透過するな」＝**条件付き要求**。`background:var(--card-bg)`(常時不透過) → **`var(--glass-fill)`＋標準blur**＝外観設定(#R33)に従い Solid で不透過(--card-bg)・glass で frost。他ポップアップと同型。
-- **③ Atlasタイポ（3回目・描画側の真因）**: `_atlStanza` の **`>1改行→return raw`** が最頻ケース(複数段落フラット散文)を素通り。→**全面再構造化**: 段落分割・文単位 `Label:`/`背景：`→`## 見出し`・先頭文→太字リード・段落は空行 join(余白)・長連続文は~2文stanza・**CJK加重**。既 `##` 構造化済は不介入。リード 1.22→1.3em、余白 1.05→1.2em。決定論的＝IntMapAtlasDebug。
-- **④ SV Coverage 線（3回目）**: Google svv は各ネイティブzoomで一定幅描画→z19超で拡大肥大。**`tileSize:256→128`**（全zoomで~2×ダウンスケール→細線）＋**`maxzoom:19→21`**（z20/z21タイル実在をpixel実測で確認）。
-- **⑤ Companies 深い履歴**: Yahoo keyless 床は銘柄依存 1962-1985（R152到達済）・Stooqは PoW化で不可＝捏造せず。上積み＝比較 Time-series 既定 **10→20年**（深い履歴を即表示）。ピッカーは1962床維持。
-- **⑥ Atlas出典（両面再報告）**: (a) mapReport/events の**インライン `記事↗` が生URL**（アグリゲータ/SNS）＝フィルタ迂回。(b) **planner `answer` が出典を一切描画しない**（「全くない」主因）。修正: **単一 `_atlCleanUrl`** を linkCards＋両インラインリンクで共通使用／linkCards は **host-clean→関連度** の順（空バグ解消）／`answer` に web-verified 出典追加／関連度は**異script保持**。
-- **⑦ Companies 真パリティ**: 最大の手抜き＝**TS指標ピッカーが無効**（常に株価指数）。→**{Market cap 絶対$ / Share price 指数} トグルがチャート駆動**＋十字ツールチップ、generic ピッカーはTSで非表示。`/8`→`/10`（2箇所）。**ws窓に検索欄**（`#info-search-bar`＋`_companiesSearchVal`＋`#co-compare-fixed`バンドル・5言語 `filterCompaniesPh`）。**詳細に実株価スパークライン**（`priceSeriesFine`）。HQ地図/Focusは企業＝非地理のため意図的非採用。
-- **⑧ ワークスペース地図ポップアップ**: `_inWsWin()` の `panel.closest('.ws-win')` が、ws-modeで地図窓へ移設された `#map-container` 内の全ポップアップを誤判定→ドラッグkill。**`panel.parentElement` が `.ws-body`（窓の直接コンテンツ）か**に変更＝本体パネルは保護・地図ポップアップは復活。`_inWsWin2`(resize)も同修正。
-
----
-
-## #R152 補足（UX/機能バッチ13件＋**地図エンジン抽象層 第1段階**）
-
-### §7.1 `IntMapGeoEngine` — レンダラー抽象層（第1段階＝#R152 / 第2段階＝#R160 / 第3段階＝#R161）
-`window.__imap=map` の直後（`map.on('load')` 内）に定義する**薄い facade**。目的＝将来 Google-Earth 級 Earth Mode を差し込めるよう MapLibre 依存を隔離すること。**純粋 additive・挙動/性能/モバイル完全同一**。
-
-- **構造**: `IntMapGeoEngine`（facade）→ `_adapter`（現状 `MapLibreAdapter` のみ）。`MapLibreAdapter` は全メソッドが現行 `map` への 1:1 委譲。`use(adapter)` で将来別レンダラーに差替。`capabilities()`／`contracts()`／`can(feat)`。`raw()`＝MapLibre 実体を返すエスケープハッチ（未一般化コード用）。
-- **抽象済み（安全に共通化した処理のみ）**: `camera`（flyTo/easeTo/jumpTo/fitBounds/setPadding/get/setProjection＋**#R160**: getZoom/getCenter/getBearing/getPitch/getBounds/zoomTo/zoomIn/zoomOut/stop）・`coords`（project/unproject/terrainElevation/queryRenderedFeatures）・`layers`（addSource/setSourceData/removeSource/add/remove/setVisible/isVisible/setPaint/setLayout/**setOpacity**＝レイヤ型からopacity paint名を解決＋**#R160**: setFeatureState/removeFeatureState）・**`render`（#R160: resize/triggerRepaint/canvas＋**#R161**: container/size/setCursor）**・`events`（on/off/once＋**#R161**: onLayer/offLayer＝**レイヤ単位のポインタイベント**）＋**#R161**: `ready()`（描画準備完了）・`layers.getPaint()`（paint 読み戻し）。
-- **Cesium**: `CESIUM_CONTRACT`＝capabilities 宣言のみ（`implemented:false`）。**SDK・API キーは未導入**。将来は Cesium 版 Adapter を実装し `use()` するだけ。
-- **#R161 第3段階＝自己完結サブシステムの丸ごと移行（ニュースピン・オーバーレイ）**: 契約を「オーバーレイが必要とするもの一式」（`ready`／`render.container/size/setCursor`／`events.onLayer/offLayer`／`layers.getPaint`）まで広げ、**`setupIntelLayers()` のニュース＋ダッシュのソース/レイヤ生成、`_declutterNewsBands()` の projection＋surface サイズ＋feature-state、帯のテーマ配色、ニュースの hover/click/leave 全6ハンドラ**を engine 経由へ移行。**生 `map` を一切参照しないサブシステムの第1号**＝別レンダラーのアダプタはこの契約を実装するだけでニュースピンを継承できる。
-  - **検証の壁と突破**: hermetic な Playwright ではベースマップの vector source（`tiles.openfreemap.org`）が遮断され `isStyleLoaded()` が永久に false → レイヤが作られず**レイヤ単位の検証が不可能**だった（R143/R130 の既知事象）。`tests/r161.spec.js` はその**1ソースだけを空の TileJSON でスタブ**してスタイルを完了させ、アプリ本来の経路でオーバーレイを作らせて実検証する。
-- **Atlas 配線**: アクション形式は不変。実行部のみ抽象層経由の実証として **Atlas カメラ制御 3ケース（`zoom`/`bearing`/`pitch`）を `const GE=IntMapGeoEngine.camera` で読み取りも駆動もエンジン経由へ**（#R152 で `pitch`/`bearing` の easeTo、#R160 で getter＋`zoom` ケースを追加）。複雑な `flyTo` ケースは誤移行リスクのため据え置き（将来段階）。
-- **未対応（次段階の移行対象）**: `addSource`≈343・`addLayer`≈426・`setPaint/LayoutProperty`≈120・`flyTo`/`fitBounds` の**大量呼出は段階移行**（一括書換えは禁止）。`queryTerrainElevation`／`setSky`／`setTerrain`／`setMaxPitch`／3D地形など **MapLibre 固有機能は当面 `raw()` 経由**（無理に一般化しない）。副次地図（gmap/cmap/minimap）も現状は直接。
-- **次にやること**: ①新規の共通機能は必ず `IntMapGeoEngine` 経由にする（`map` 直呼び禁止の徐々な徹底）、②**次のサブシステム移行**は同じ形の `dash`/`user-pin`/`grid` オーバーレイ（#R161 と同型で低リスク）、③`markers`（`maplibregl.Marker`）名前空間の追加、④`flyTo`/`fitBounds` 系ディスパッチの移行、⑤別レンダラーの capabilities で分岐する UI（Earth Mode トグル）、⑥Cesium Adapter の骨子。
-- **検証**: 契約テスト＝`tests/r152-checks.test.mjs`＋`tests/r160-checks.test.mjs`＋**`tests/r161-checks.test.mjs`#16**（拡幅契約・ニュース6ハンドラの移行・生 `map` へのニュースハンドラ残存ゼロ）＋**`tests/r161.spec.js`（実ブラウザ：facade がレンダラーと数値一致、オーバーレイが実際に engine 経由で生成される）**＋既存スモーク。
-
-### その他12件（要点）
-①ケッペン**行折返し撲滅で単一行化**（真因は自然高777px・14行折返し／`_fitKoppenLegend`無変更）。②Companies を静的下端オーバーレイ ドックで**Countries完全同一化**。③Atlasタイポ＝フラット文の先頭文をリード太字へ昇格＋見出し拡大。④出典＝ブロックリスト拡張＋`_atlRelevantCards` 関連度ゲート＋未引用を「関連記事」表記。⑤トグル＝全画面＋汎用control。⑥衛星＝**実測(curl)で Esri z19 が keyless 上限**（z20は東京すら灰色2521B）→画質のコード変更なし。⑦SV線細く（glow paint撤去）。⑨Measure/Share 不透過（card-bg）。⑩方位磁針 右クリック数値入力。⑪フライトシム 海面フロア(countryGeo判別)＋水面 fill。⑫等高線 密度スライダー（凡例内）。⑧Companies 月次高精度＋歴史floor 1962。
-
-**重大教訓**: static-checks は**同一スコープ重複 `const` を検出不能**（`_ATL_STOP` 二重宣言でアプリ全体ブート不能＝全Playwright timeout）。**commit前に実 chromium で critical globals を必ず確認**。
-
----
-
-## #R151 補足（UX/機能バッチ11件：ケッペン全区分停止＋行幅固定／Measure・Share集約／SV coverage自動／モニター削除でハイライト消去／Companies株価バッチ＋全史キャッシュ／Atlas出典SNS除去／Atlasトグル拡充／Terra本番検証）
-
-- **ケッペン凡例（#3・R150を上書き）**: `_fitKoppenLegend` を **`min(自然内容高, ビューポート上限)`** に（内容高は inline `height`/`max-height` を一時中和して `getBoundingClientRect` で実測→復元）。**内容<画面＝最終区分で停止**（空白ゼロ＝「すべて表示されたら止まる」）、**内容>画面＝画面下端で停止＋内側 `.kl-scroll`**。行幅固定＝`.kl-scroll{ scrollbar-gutter:stable }`（スクロールバー出没で~15px 揺れ→行 reflow が真因）。R150 の「ビューポート基準で必ず下端」は空白を生む＝要求転換で上書き。r149/r150 の #3 テストを二挙動（短vp下端／高vp内容停止）へ更新。
-- **通常モード Measure/Share 集約（#4）**: Radius を `#measure-dropdown` 内へ（Distance/area・Draw・Radius）。Screenshot＋リンクを新 `.share-menu-container`（🔗 Share ▾＝Screenshot・共有/リンク・`right:0`）へ。**ID温存**（`btn-tool-radius`/`btn-screenshot`/`btn-share`）で既存ハンドラ・モバイル `data-proxy` 不変。`shareMenuBtn`/`shareLinkBtn`/`coCompareEmpty` を5言語追加。
-- **SV coverage 自動（#8）**: `IntMapStreetView.open()` が coverage OFF 時に `coverage(true)`＋`_covAuto`（手動状態温存）、`close()`（✕も集約）で自動分のみ OFF。パノラマを開くと水色の実カバレッジ線が即表示。
-- **モニター削除でハイライト消去（#6）**: `showOnMap(area,points,monId)` に `_shownMonId` 記録（全呼出元に id）、`remove()` 成功時 `_shownMonId===id`（or 未追跡）で `clearMap()`。UI/Atlas 両経路が同一 `remove` を通る。
-- **Companies 深い歴史＋低遅延（#10）**: `_spark(syms,range,interval)` で Yahoo `v8/finance/spark` を~40銘柄バッチ（旧＝1銘柄1req）→ `loadPrices` 即着色＋未解決のみ従来チャートfallback。`_histAll()` が `spark range=max 1mo` を一度取得し `{tk:{year:年末終値}}` キャッシュ→ `setYear` 年スクラブをネット無し即時（未網羅のみ per-year fallback）・`priceSeries` も同キャッシュ。両response shape対応。
-- **Atlas出典の信頼性（#11）**: `_atlBadSourceHost`（`_SNS_RE`＝X/Twitter/FB/IG/Threads/TikTok/Reddit/YouTube/t.me/bit.ly…）で全出典カード経路（`linkCards`＝analyze/answer/mapReport）から SNS/UGC/短縮/動画を除外。`_analysisSystemPrompt` に「SNS等は出典にしない・各URLは主張を直接支持する具体ページのみ」明記。`IntMapAtlasDebug.badSourceHost/linkCards` 公開。
-- **Atlasトグル拡充（#2）**: 既存(layer/base/grid/3D/国情報/SV/borders/labels/roads/ticker)に **globe（地球儀 on/off）・compare** を `_FEAT_TOG` 追加＋projection/compare dispatch に `_featTogHtml`。
-- **タイポ（#5）**: mdMini で**行全体が `**太字**` の行を実見出し**へ（モデルは `##` より太字を多用＝モデル非依存の階層）＋段落余白 .72→.85em。answer/analysis プロンプトの FORMAT指示は既存。
-- **衛星（#7）**: `predictivePrefetch(aggressive)`＝飛行で RING 3→7・斜め角先読み・傾斜時は横一段浅も warm、飛行ループ 380→300ms＋aggressive。**3D手動 pan/rotate（pitch>25）でも `move` ごとにスロットル先読み**（従来 moveend のみ＝連続移動で先読み皆無）。既存最適化(2/5ホスト分散・native-max DEM z15・fade0・8192キャッシュ・pixelRatio上限)温存。
-- **Companies 空比較ヒント（#1）**: Countries同型は既存＋**空状態ヒント**「Tap company rows to select and compare.」（`coCompareEmpty` 5言語・`renderCoCompareFixed` が `scf-empty`）。
-- **Terra（#9）**: `AI_MODEL` secret＋`OPENAI_DEFAULT_MODEL=gpt-5.6-terra`（コメント整合・再deploy）・Luna は model_not_found のみ。**本番検証＝`current_news.analyzed_by='ai'` が 354 件**（refresh-news cron は fallback無でTerra直呼び＝ai>0 が到達の実証）。
-- テスト: `tests/r151-checks.test.mjs`(node 11) ＋ `tests/r151.spec.js`(Playwright 6)。r149/r150 のケッペン#3を R151 仕様へ、r149/r150-checks の exact-string を .85em/prefetch cadence へ更新。`npm test` 緑（node 79・Playwright 80・pageerror 0）。
-
-## #R150 補足（UX/機能バッチ10件：モニター保存の真因user_id欠落／ケッペン下端伸縮／Atlas曖昧性ゲート統一／調査回答マッピングのコード側検証／Terra採用／衛星飛行プリフェッチ）
-
-- **モニター保存（#6）**: `IntMapMonitors.create()` の挿入行が `user_id` を欠落（`area_monitors.user_id` は `not null`＋insert RLS `user_id=auth.uid()`）→ UIからの作成は毎回失敗し「Could not save the monitor.」。修正＝client が `row.user_id=currentUser.id`（他の user-owned insert と同型）＋ migration `20260721140000` で `alter column user_id set default auth.uid()`（本番適用済み・冪等）。**この機能は service_role 経由でしか検証されておらず、ログインclientの挿入経路は未検証だった**のが盲点。
-- **ケッペン凡例（#3）**: `_fitKoppenLegend` の `maxHeight` を**ビューポート基準**(`innerHeight - top - 12`、content-box分減算)に。従来の**内容高クランプは伸縮を阻害**（背の高い画面/区分少で画面下端まで引けない＝「一番下まで伸ばせない」）。CSS `max-height:calc(100dvh - 84px)` は温存、内側 `.kl-scroll` が全区分を担保。
-- **Atlas地理対象の曖昧性ゲート（#7）**: 共有 `_hlAmbigConfirm` で**単一の確認**を生成し、multi-region/single 両経路が**描画前にゲート**（曖昧が1つでもあれば `R(false,…,{meta:{partial:true}})` で停止＝何も塗らない・planner say 抑止）。従来は塗った成功の隣に `gAmbig`/`ambig` を警告として追記＝「候補確認・部分実行・成功報告・失敗警告」の同時表示が真因。個別地名ハードコード無し＝`resolveHlTarget` の `ambiguous` 判定に駆動。
-- **調査回答マッピングのコード側検証（#10）**: PURE基盤（`IntMapAtlasDebug` 公開でhermeticテスト可）＝`_atlExtractPlaces`(本文抽出=省略時安全網)／`_atlAuditSources`＋`_atlRegDomain`＋`_atlIsOfficial`(出典正規化・単一集中検出・官公庁/一次優先)／`_atlMappingVerdict`(mapped/unplaced/ambiguous)／`_atlGeocodeStrict`(同名≥2でambiguous・place型＋名称一致のみ・座標推測なし)。orchestrator `_pinReplyPlaces` は**既存ピンとMERGE**(clearしない・スキップ廃止・空catch廃止→console.warn＋正直な注記)。
-- **Atlas使用モデル（#9）**: `refresh-news`（同キー・同AI_MODEL・**モデルfallback無**）で `AI_MODEL=gpt-5.6-terra` → ai 61/63(en)・104/116(jp)成功＝**Terra再検証で到達可**。`AI_MODEL` secret=terra・ai-proxy default=terra・`FALLBACK_MODEL=luna`。
-- **タイポ（#4）**: `_atlStanza`(改行無し長塊を~2文stanzaへ)＋mdMiniで文末＋単一改行→ソフト段落余白。構造化済みは不介入。
-- **衛星3D飛行（#8）**: `predictivePrefetch` が `moveend` のみ発火→**飛行中(連続移動)は先読み皆無**が真因。`window._imPredictivePrefetch` 公開＋飛行ループで~2.6回/秒スロットル呼出。`sat-labels` を Esri 2ホストでラウンドロビン。既存最適化(2/5ホスト分散・native-max DEM・fade0・8192キャッシュ)温存。
-- **停止四角(#5)** rect 17.5→15.5。**Companies(#1)** は既に Countries 同型・`.co-logo-box` 32→30px で国旗枠と画素一致。**SVオフ(#2)** にも `_featTogHtml('streetview')`。
-- テスト: `tests/r150-checks.test.mjs`(node 12・ソース保証) ＋ `tests/r150.spec.js`(Playwright 7・業務委託の全ケースを純関数でruntime検証)。r147/r149-checksをR150差分へ更新。PR #23。
-
-## #R143 補足（Atlas地理対象解決の汎用基盤：UN M49国集合＝実国境／多地域＝グループ別色＋凡例／描画前ジオメトリ検証／実状態検証／正直返答）
-
-「東西南北欧をハイライトして」で **西欧未描画・4地域同色・南欧が巨大な三角形・国境でなく雑な近似図形・未完了なのに完了報告・曖昧性の長文説明が地図操作を妨害** が同時発生。**真因＝ヨーロッパのサブ地域（西欧/東欧/南欧/北欧）が「国集合」なのにコードは `REGION_BBOX` の粗い矩形/AIポリゴンでしか解決できず**、多地域の色分け・凡例・描画前検証も無かったこと。Europe専用ハックではなく**Atlas全体の汎用基盤**として、パイプラインを **解釈→地理対象解決→実行計画→描画→実状態検証→返答** に統一。全て `index.html` 加算（単一HTML温存）。`npm test` 緑（静的＋security/monitor logic＋**Playwright 44/44**、内 `IntMapRegionResolverTest` に純検証~30件・新 `tests/r143.spec.js` 10件）。
-
-- **① UN M49 国集合（地理対象解決）**: `REGION_GROUPS` に **UN M49 のサブ地域を実 ISO3 リストで追加**（western/eastern/southern/northern europe＝**互いに素な4分割**、north/south america・caribbean・north/west/east/central/southern africa・western asia・oceania サブ地域…）＋ `europe`/`oceania` は下位の和。`regionGroup` は既存の `GROUP_ALIASES` に加え **5言語 `REGION_ALIASES` も参照**（西欧/Westeuropa/западная европа… が自動で国集合へ。国集合でない自然地域＝Sahara/Alps 等は null で従来のポリゴン経路へ）。→ `resolveHlTarget` の**グループ段（国コード）で確定**し、Nominatim/AI/矩形の不安定経路を回避＝**正式な国境 GeoJSON で描画**。標準定義があるので**不要な確認をしない**（曖昧性の壁は出ない）。
-- **② 複数地域＝グループ別色＋凡例**: highlight dispatch に**多地域分岐**（2つ以上の対象・明示単色なし・河川/流域でない・かつ少なくとも1つが国集合/地域）。各対象を**カテゴリ配色 `_HL_PALETTE` の別色**で `nlq-poly-src` に描画（国集合は `_codesGeo(codes)` で **`window.countryGeo` の実国境から MultiPolygon** 構築・内部境界は `comp:1` で淡く）、返信に**色スウォッチ凡例**（`_hlLegendHtml`：地域名＋か国数＋根拠）。単一対象/単色指定/純国リストは従来の単色 feature-state 経路（無変更）。表示名は **`M49_LABELS`（5言語）で localize**（`_hlPolys` 内部名は正準英語キー＝安定・テスト可）。
-- **③ 描画前ジオメトリ検証（ハリボテ拒否）**: `_validGeo(geo,{trusted})` が **未閉リング・退化した少頂点「巨大三角形」・異常な長辺・自己交差・全世界blob・極小スライバー・非ポリゴン**を描画前に拒否。実国境/OSM/構成境界は `trusted` で粗近似ヒューリスティックを免除、AI/派生/ソフト箱は全検査。多地域・単地域の**両経路**で適用（拒否は正直に「不正な形状のため未描画」）。`_bboxSoftPoly` も**厳密閉リング化**（`sin(2π)≠0` の隙間を解消）。
-- **④ 実状態検証＋正直返答**: 描画後に `_verifyPolyPaint(n)` で **source/layer/feature数** を確認。返信は**実行結果から合成**＝描画できた対象（凡例＋根拠）と **失敗（見つからず／不正形状で拒否／曖昧）を明確に分離**、部分失敗は `meta.partial` で**プランナーの実行前 `say` を抑止**（R140/R142 の say-gate）。
-- **④' (#R158) Terra＝意味/対象/方法の最高意思決定者、IntMap＝忠実な実行装置**: コード側の**自動補正・対象除外・意味推測を廃止**。`_hlReadGptGroups` は Terra の識別子をそのまま実行し、無効/空ISO3は**補正せず**（`resolveCountrySync` 救済を撤去）`unresolved:[{name,iso3,reason,availableIdentifiers}]` として返す（候補は**報告のみ・適用しない**）。dispatch は**構造化実行結果** `{status,action,resolved,unresolved,renderState,capabilities}`（委託書JSONスキーマ）を `R(ok,html,{meta,exec})` で返し（`cg.miss`/`_validGeo` 失敗も unresolved に観測記録）、`runActions` が `a.__exec` に保存、run() の**既存2周repairループ**が `partial_or_failed` を `pending` に投入＋`[EXECUTION RESULT …]` を repair プロンプトに添付＝**Terra自身が**修正/再検索/確認/部分採用を決める。スキーマ/型/セキュリティ/描画検証は**Terraの意味判断を覆さない観測層**として維持。`regionGroup`/legacy `countries` 経路は無改変（R143無回帰）。全アクション共通の契約（highlight が第一実装）。
-- **⑤ 堅牢性（style待機・遅延上書き・再描画）**: 世代トークン `_hlGen`＝**新しいハイライトが古い非同期解決の上書きを阻止**、描画は最大 8×0.7s のバウンド再試行、`styledata` 再描画は既存の `paintPolys` ハンドラが継続。
-- **⑥ 複合展開（頑健化）**: `_expandRegionCompound` が **「東西南北欧」→4 M49 キー**、「南北アメリカ」→2、を決定的に展開。さらに**方向欧の2語以上の共起時は M49 に正準化**（＝「北欧」は単独では北欧5国だが、四方位欧の集合内では M49 Northern Europe＝隙間なし4分割）。
-- **公開/テストAPI**: `IntMapAtlasDebug.{regionGroup,validGeo,codesGeo,expandCompound,paletteColor,legendHtml,polyState}`（純関数＝mapなしでCI検証可）。データソース変更なし（既存 `window.countryGeo` の再利用）。
-
----
-
-## #R142 補足（UX/正直化バッチ17件：SV実Coverage再修正／Atlas正直化・全幅・Stop／シート同期／Companies順位・時間・比較・拡充／WS読込・レイヤー復帰／東西独国境／Radius整理／News媒体Wikipedia）
-
-ユーザー指摘**17件**を根本原因から修正（`index.html`＋データ `data/cshapes.js`・加算的/微修正・単一HTML温存）。着手前に並列サブエージェント6本で実地調査。`npm test` 緑（静的+security-logic+monitor-logic+**Playwright 26/26**・pageerror 0）。DOM/データ/純関数は localhost プレビューで実測。詳細は DEV-NOTES R142。
-
-- **SV実Coverage再修正（#1）**: `_nearestCoverage` の `null`（タイル遮断＝プライバシー堅牢環境）で無言のクリック点配置＝R140前と同症状→`_loadTile` に **CORSプロキシ・フォールバック**、探索半径 40→115px・z≥14、null は正直トースト（偽マーカー無し）。実測 Times Square 実スナップ。
-- **Atlas正直化（#2/#3/#9/#17）**: プランナー実行前 `say` を **視覚/状態アクション失敗 or `meta.partial/unverified` で抑止**（say-gate 拡張）。`highlight()` は feature 未ロード時 `false` 返却、highlight dispatch は部分ミスで `meta.partial`、layer dispatch は無描画で `meta.unverified`。`OVL_OF.missile` に `'blast'`、layer インライン再トグルを OFF 分岐でも出力。`toggleLayer` が **`cb` 返却**→インライン操作は `r.cb` 再利用（曖昧再解決廃止＝既定状態が実 checkbox 値）。
-- **Atlas UI（#8/#15）**: `.atl-chat` 側 padding 14→8px 等で**サイドバー全幅**。送信ボタンは応答中**赤 Stop スクエア**＝`_setGoBusy`/`_stopRun`（`_runGen++`＋`AbortController`・planner/repair の `askAIJSON` に `signal`）、`run()` を try/finally で全終了経路復帰。
-- **モバイルシート同期（#4）**: `setDetent` の settle `easeTo({padding})` 直前で **残存 `_padRAF` を cancel**（v5 `setPadding`=`jumpTo`→`stop()` が settle を中断していた）。
-- **Companies（#5/#6/#7/#13）**: 順位＝**現在指標のVALUE順位（方向非依存・最大=1）**（両レンダラ・名前ソートは正準指標フォールバック）。**タイムマシン対応**＝`IntMapCompanies.setYear(year)`（keyless v8 chart 月次年末終値→`c.hp`・`mcap()`/`priceOf()` 歴史化・`_coWireTime` 購読・正直バナー・設立前—）。**比較**＝`coCompareSet`＋行シングルクリック選択/ダブルで詳細＋sticky トレイ＋`showCoCompare`（6指標×N社横バー・時間対応）。**拡充**＝US上場27社追加（→147社・123 live）＋**TSMC(TSM) live 化**（25.93B÷5=5.186B ADS）。手法＝安定な**株数×取得価格=snapshot** 自己整合（±5×ガード通過）。新 window.*: `_coToggleCompare/_coClearCompare/_coShowCompare`。新 API: `IntMapCompanies.{setYear,priceOf,histYear}`。
-- **ワークスペース（#10/#11）**: `enable()` に**ローディングオーバーレイ**（`_wsLoadingOn/Off`・2×rAF後に重いビルド・finally 消灯）。`disable()` で**レイヤーパネルを通常復帰**（インライン幾何クリア＋`apply()`＋`_placeActiveSection`）。**副次真因修正**＝R141 Monitors 窓が `defRects()` 未登録→`clampRect(undefined)` throw（毎デスクトップ ws 起動で握り潰し破損）→`monitors:flo(3)` 追加＋`clampRect` に `r=r||[]` ガード。
-- **東西独国境（#12）**: `data/cshapes.js` の内独国境が両側独立簡略化で重なり→**西独=difference(統一 788, 東独 789)**（`polygon-clipping` で offline 再生成・overlap 0・共有頂点60・新 ring1991）。西独era を再ポイント。ビルドツール `polygon-clipping`（非コミット）。
-- **Radius整理（#14）**: プリセット＋色/透明度を `<details>`「Style & presets」開示（既定折畳・全ID温存）、スライダー＋統計は常時表示。
-- **News媒体Wikipedia（#16）**: `.news-pub` を `role="link"` 化→`<lang>.wikipedia.org/.../Special:Search&go=Go`（jp→ja・404回避・`IntMapSafe.url`）。
-
----
-
-## #R140 補足（既知バグ6件バッチ根本修正：SV透過＋実Coverage／タイムマシン国境の間欠不表示／Atlas嘘ハイライト／モバイル・ボトムシート同期）
-
-ユーザー指摘の既知問題**全6件**を根本原因から修正。全て `index.html` の加算的/微修正（単一HTML・ビルド無し温存）。`npm test` 緑（静的89＋security-logic 10＋Playwright 18/18・pageerror 0）。詳細は DEV-NOTES R140。
-
-- **① SVポップアップを無条件で不透明化**: `#streetview-panel` の base を `var(--popup-bg)`（rgba 0.72/0.74・backdrop-filter無し＝地図が透ける）→完全不透明 `var(--card-bg)` へ。head/nav の半透明はこの不透明ベースに合成される。
-- **② SV Coverage を実データで考慮**（前身の「⑤SVカバレッジ＝ベースマップ道路を水色化」を置換）: `open()` が素のクリック点に置くだけでGoogleの実パノラマ位置を偽っていた真因を修正。Googleの**実SVカバレッジ・タイル** `mts{0-3}.google.com/vt?…lyrs=svv&style=40,18`（ACAO:*・キー/UA/Referer不要・空域=68B）を(a)Coverageモードの**実オーバーレイ**に、(b)新 `IntMapStreetView.nearestCoverage()`＝現在ズームで3×3タイルを画素サンプリング（canvas getImageData・プロキシ不要）し**最寄coverage画素へスナップ**、無ければ正直に「ここにSV無し」（`imToast`5言語）、読取不能は素点フォールバック、(c)マーカーのドラッグ終了も同スナップ。実測: Times Sq 27m・Westminster 15m吸着、Pacific/Sahara=covered:false。出典・プライバシー（JP/EN）にカバレッジ・タイル追記。
-- **③④ タイムマシン国境の間欠不表示/不更新**: `IntMapTimeBorders.apply(fc)` の style未ロード時フォールバックがワンショット `map.once('idle')`（busyマップで永久未発火＝R41で潰した同型バグの残存）→ **`whenStyleReady()`（poll＋~6s hard-resolve）＋seqガード**へ。年変更ショートサーキット2箇所にも ensure()失敗時の一回リトライ。
-- **⑤ Atlas嘘ハイライト**: 返信が**実行前プランナの `say`**（過去形「ハイライトしました」）を無条件先頭表示していた→**全滅時 or 視覚アクション（highlight/outline/draw）失敗時は `say` 抑止**し既存の正直な警告を先頭化（`runActions`）。
-- **⑥ モバイル・ボトムシート同期＝R139修正がno-op**: maplibre 5.24.0 で `setPadding(e,t)=jumpTo({padding:e},t)`＝**瞬時**（第2引数はeventData）→R139の `{duration,easing}` は黙殺され padding が跳んでいた。**`map.easeTo({padding,460ms,同cubic-bezier})`** でロックステップ化、ライブは最新値rAF＋`dragStart`で `map.stop()`。デスクトップ・サイドバーの同型no-opも `easeTo` 化。実ソースで `setPadding=jumpTo`／`easeTo`のpadding対応を確認。
-
----
-
-## #R139 補足（Companiesタブ新設＝Information廃止／モバイル描画・レイヤーFAB・ボトムシート同期／範囲人口の進行バー正直化／現在地ボタン・時刻タブ精緻化）
-
-ユーザー要望11件。全て `index.html` の追加/微修正（既存機能削除は明示指示の Information タブのみ・単一HTML温存）。`npm test` 緑（静的91＋security-logic＋Playwright 18/18）。詳細は DEV-NOTES R139。R138（IntMapSafe 等）の上に stack。
-
-- **Companies タブ（Information 廃止→置換）**: `window.IntMapCompanies`＝**厳選120社**（`ticker,name,nJp,cc,sector,domain,founded,employees,revB,niB,sharesB,mcapSnapB` の配列）。**時価総額はライブ**＝米国上場銘柄は `shares×live price`（下部ティッカーと同じ keyless Yahoo v8 chart＋CORSプロキシラダー・並行5・5分キャッシュ・進捗で再描画）、非米上場は報告値スナップショット。**サニティガード**＝ライブ mcap がスナップショットの0.2〜5倍を外れたら誤取得（銘柄取り違え/通貨/株数誤り）とみなしスナップショットへフォールバック（ランキングを壊さない）。`renderCompanies` は Countries と同形式（`.stats-toolbar` ソートプルダウン＝時価総額/売上/純利益/P-E/従業員/株価/設立/名称＋数値フィルタ＋`.stat-rank` 順位）を `#info-dashboard` に描画。**国旗のあった位置にロゴ**＝`logo.clearbit.com`→Google favicon→モノグラムの `onerror` カスケード。行クリックで `showCompanyDetail` オーバーレイ（全指標＋サイトリンク）。`renderDashboard()` は先頭で `renderCompanies()` に委譲（全呼出元＝タブ/ws窓/検索/Supabase/キャッシュが Companies を描画・旧ダッシュボードは dead code 化）。タブ `#btn-info`（id温存・mode文字列 `'info'` 温存）を `tabCompanies` へ改称（5言語）。Atlas＝`IntMapOS 'tab.info'` ラベル改称＋NL `companies/company/企業→tab.info`。CO_SECTORS/CO_CC は5言語。出典・プライバシーに Yahoo（企業株価）・Clearbit/Google（ロゴ）を追記。
-- **範囲人口の進行バー正直化（`window._imProgCtl`）**: 真因＝WorldPop 単一リクエストは進捗%が無い（task=created/finished のみ）のに、UIは**指数イーズアウト `0.92*(1-exp(-el/9))`＝100%手前で減速し無意味**だった。修正＝共有 `_imProgCtl(box)`＝`busy()` で**不定形アニメsweep（%非表示）**、実分数が判明した瞬間 `set(f)` で**実線形（単調）**（大面積のタイル分割は tiles-done/total、radius は circles-done/N・各円の内部タイルは帯へマップ）。measure/radius/Draw の3ドライバの偽ランプ＋`_setProg` を撤去。CSS `.tp-prog.indet .tp-prog-fill`（`imProgSweep` キーフレーム）。
-- **モバイル描画（`DrawTool`）**: 真因＝(1) MapLibre がタップから合成する `click` が開始直後のストロークを `finish()` して1点で終了、(2) ヒントが「タップ」なのに実装は press-drag 必須。修正＝`_touchTs` で touch 直後の合成 click を無視、bare tap は `armed` に**再arm**（死んだ1点stateを残さない）、ヒントを coarse pointer 判定で「押したままなぞる／指を離して確定」に（5言語）。
-- **モバイル レイヤーFAB着色（task5）**: `m-fab-map` の `.on` を**衛星ベースマップ→アクティブ層有無**へ。`_refreshActiveLayers` が `window._imActiveLayerCount` を publish し変化時に `window._imSyncMobile()`。`syncControls` は `(window._imActiveLayerCount||0)>0` で着色。
-- **現在地ボタン着色（task7）**: `IntMapLocate` の `.on` を**「追跡中」→「地図中心が現在地に一致」**へ。`_mapCenterAtFix`＝`map.project` の**画面ピクセル距離≤44px**（ズーム非依存）。`move`/`moveend` と各fix・start/stop で `_syncFab`。
-- **ボトムシート↔地図同期（task8）**: スナップ時の `map.setPadding` を **300ms/既定イージング → 460ms＋シートCSSと同一 cubic-bezier(0.32,0.72,0,1)**（新 `_cubicBezier` Newton-Raphson評価器）でロックステップ。ドラッグ中のライブ padding ゲートを **5px→2px**（中心が指を追従）。
-- **タイムマシン時刻タブ精緻化（task9）**: `_applyTimeOfDay` は **Year/Date で選んだ日付**に時刻を載せ、**今日は現在時刻以降を選べない**（`allowFuture:false`＋`_timeMaxMins`＝今日は now分・過去日は1439）。スライダ max と `#ntl-time` の max を `applyMode('time')`/`refreshUI` で追従（実測: 今日=727分キャップ、1990年=1439）。
-- **Countries順位デフォルトON＋iOS風数字（task3）**: `_showRank` を `!=='off'`（既定表示）、設定既定 'on'、`.stat-rank` を `ui-rounded/SF Pro Rounded`・weight600・tabular-nums。**Companies は順位を常時表示**（時価総額ランキングのため）。
-- **ニュース白黒ボタン・地点ピルaccent（task1/2）**: R137で既済を実測再確認（`.btn-read` `#fff`/`#000`、`.loc-chip` accent）。
-- 新 window.*: `IntMapCompanies`, `renderCompanies`, `showCompanyDetail`, `setCoSort`, `toggleCoSortDir`, `_coSf*`, `_imProgCtl`, `_imActiveLayerCount`, `_imLocSyncFab`。
-
----
-
-## #R137 補足（モバイルUI微調整／Countries順位表示／現在地ライブマーカー／タイムマシン時刻タブ／Atlas逐語重複除去）
-
-ユーザー要望10件。全て `index.html` の追加/微修正のみ（既存機能削除なし・単一HTML温存）。詳細は DEV-NOTES R137。
-
-- **モバイル選択タブ = 白/黒**: `@media(max-width:768px) .mode-btn.active` を accent 塗り→`#fff`/`#000`（デスクトップ R130 と統一）。Atlas タブは高特異度ルールで accent グラデ維持。
-- **ニュースカード**: `.btn-read`（記事を読む）＝白背景/黒文字（`.mnp-read` も）、`.loc-chip`（地点ピル）＝`var(--primary-color)`（旧ハードコード青グラデ→accent 追従）。`.unmapped`/`.publisher` の状態色は据置。
-- **Countries カード**: モバイル `.stat-row` 縦 padding 15→8px。左端に順位番号 `.stat-rank`（19px・tabular-nums・行の最左）＝`renderStats` が `window.imShowRank==='on'` 時に `i+1`（現ソート/フィルタ順）を先頭差込。設定 `#setting-showrank`（Layout & panels・既定 off）→`window.imShowRank`（load/save/open/apply・`intmap_settings` 同期）・5言語 i18n。
-- **現在地 FAB＋ライブマーカー**: `#m-fab-locate`（`.m-fab`＝Map/Tools/Compass と同一UI・compass 直下）→ `window.IntMapLocate`。MapLibre レイヤー `imloc-dot`(accent 点+白縁)/`imloc-dot-halo`/`imloc-acc-fill`+`imloc-acc-line`（`turf.circle` 精度円）を `watchPosition` で毎fix更新＝**点も円もユーザー移動に追従**。accent は `getComputedStyle('--primary-color')` を都度読取、style スワップに `styledata` で再アサート。Atlas `locate` も成功時に `IntMapLocate.start({fly:false})` 併発。新 window.*: `IntMapLocate`。
-- **タイムマシン コンパクト（モバイル）**: `@media(max-width:768px)` 拡張＝`.news-timeline .ntl-body` 幅 314→`min(290px,100vw-20)`・gap 5px、`.ntl-bigval` 26→20px、mode/now/inputs/scale/synced/chip 縮小。
-- **タイムマシン 時刻タブ**: `.ntl-modes` に `#ntl-mode-time`（時刻/Time/Zeit/Время/Hora）＋`#ntl-time`。`.ntl-mode.on` を accent→**白/黒**。`applyMode('time')`＝スライダ `0..1439`(分)・時刻ピッカー。書込 `_applyTimeOfDay`＝現在選択日（ライブなら今日）に時刻を載せ `IntMapTime.set(base,{allowFuture:true})`。**時刻依存の利用可能データ＝昼夜ターミネータ**が同期（Earth-Replay `_terminatorFC` 流用の `imtm-night` レイヤーを Time タブ表示中のみ描画）。iso(日)不変でニュース再取得スパム無し。
-- **Atlas 逐語重複除去**: 全AI自然文整形 `mdMini` 冒頭に純関数 `_dedupText`（段落＋文を正規化キー・長さ閾値15で去重・末尾空白保持で再結合＝略語/小数を壊さない）。node で10ケース実測。
-- **検証**: `npm test` 緑（静的83＋Playwright 11/11）。DOM/計算スタイル/純関数をヘッドレス実測（map は `document.hidden`/WebGL未init）。**新教訓: hidden ペインは CSS トランジション未進行 → 既存要素に class 後付け→`getComputedStyle` は遷移開始値を読む。ルール検証は fresh 要素生成で。媒体クエリは特異度を上げない（`.ntl-body` 後方グローバルに負けるので `.news-timeline` 前置で勝たせた）。**
-
----
-
-## #R136 補足（昔年代クリックの塗り不一致／Atlasハイライト精度／歴史データ拡充）
-
-- **昔年代クリックの Compare ハイライトが誤国**（「1920sポーランドをクリック→ポーランド判定なのにドイツがハイライト」）: 真因は**検出と塗りが別ロジック**だったこと。検出 `resolveHist` は era feature の `_gw`（Gleditsch-Ward, 1925 Poland=290→POL）で正しく解決するが、Compare の塗り `IntMapTimeBorders.geomForCode(code)` は `_gw` を使わず **MODERN 国外形の内部点を多数決**しており、1925 の modern ポーランド西部（当時 Weimar ドイツ）に票が集まって **Germany のポリゴンを返していた**。修正＝`geomForCode` を**検出と同一解決に統一**（新 `_eraCodeIndex`＝各 era feature を `resolveHist` で解決した `code→features` マップ／`_unionGeom` で合成）。ただし**被覆ガード** `_bbCoverFrac`＝index結果が modern 国 bbox の30%未満なら「吸収された国の断片」（1925 RUS=Karafuto 欠片）として従来の多数決へフォールバック（RUS→ソ連全域を維持）。実測: 1925/1914/1938 で POL→ポーランド・DEU→ドイツ・RUS→ソ連 extent、SUN 等の多継承 former state は hbRe 早期パスで不変。
-- **Atlas「○○をハイライト」の見当違い**（ログアウト時の Nominatim 経路＝Web検証なしの欠陥を `IntMapAtlasDebug.resolveHl` プローブで実測特定）: `_nomExtent` に (a)`accept-language`（UI言語+en＝英語exonym「Tuscany/Persia」が地域のローカル名と突き合う） (b)**完全名一致ボーナスを重要度でゲート**（上位重要度から0.25以内でのみ0.5・下は0.08＝低重要度の同名村が Iran/伊トスカーナを食わない・大阪湾の近接タイブレークは温存） (c)**微小集落ガード**（anchor無しで hamlet/suburb 等かつ重要度<0.35 は正直な miss）。`resolveCountrySync` は**非主権ミクロ地物（`sov===false`）をゆるい部分一致で拾わない**（「Patagonia」→氷原コードSPIを解消）。`resolveHlTarget` に **curated macro-region ガード `_curatedOk`**（curated 名は範囲外の同名／範囲15%未満の微小sub-feature を棄却し gazetteer 箱へ＝Patagonia→南米、Sahel→ベルト全体）。`REGION_BBOX`＋Manchuria/Anatolia(Asia Minor)/the Levant 等＋5言語エイリアス。
-- **歴史データ拡充**: 1943 CShapes 全169 feature を `resolveHist` 監査→植民地/自治領の**modern記事フォールバック**を特定し、**en.wikipedia API で実在検証**した上で `_ERA_WIKI` に植民地期記事12件（GMB/SLE/MUS/MDV/FJI/CPV/GNB/GNQ/TLS/SLB/PNG/KWT・各独立年で終端）を追加。**`_VANISHED` に Dominion of Newfoundland**（`_GW2ISO(21)=CAN` に畳まれていた自治領）を独立identity化＝5言語名＋Union Jack 旗（新 `F_UNIONJACK`）＋`Dominion_of_Newfoundland` wiki（統計なし＝code=null の正直表示、Danzig型）。
-- **検証**: ヘッドレスでデータ層を全項目実測（地図描画は `document.hidden`/WebGL未initで不可＝R129〜R132と同様データ層で担保）。`npm test` 緑（静的83＋Playwright 11/11・AtlasQA 40/40・RegionResolver 13/13）。
-
----
-
-## #R135 補足（Atlas 時間軸リサーチ・マッピング＝`researchMap`／Request Profile／能力レジストリ／意味的リトライ）
-
-**直接原因**: `mapReport` はプランナー上「調査結果を地図に出す汎用アクション」に見えるが、実装は **GDELT/Google News/読込済みニュースから現在の具体的事件を抽出する“ライブニュース専用”機能**。表示年1900で「当時のオホーツク海はどんな状況？地図で教えて」が `mapReport` に送られ、ライブニュース不在で失敗→repairが**表記だけ変えた再試行**（オホーツク海→Sea of Okhotsk→Okhotsk Sea）→**世界全体の1900年同盟地図へ範囲拡張**→ライブ不足警告の反復、という連鎖を起こした。これを**特定地名のハードコードではなく汎用の仕組み**で防止。
-
-- **Request Profile（`_requestProfile(q)`・純粋関数）**: プランナー呼出前に軽量な構造を生成＝`{temporalMode:historical|current|mixed|unspecified, targetYear, temporalSource:explicit|map-state|conversation|none, geoKind:water|region|city|historical-entity|unknown, evidenceMode:historical|live|mixed|none, outputs:{explanation,map,comparison}}`。**時間軸の優先順位**＝①入力内の明示年 ②「当時／この時代／そのころ」＋タイムマシン有効なら**表示年（`IntMapTime.year()`）** ③会話年（`_wctx.year`） ④表示年（非明示・非現在語） ⑤なし。**「今／最新／current」等は表示年より優先**して current に落とす（1900表示中でも「今のニュース」はライブへ）。`buildPrompt()` に **`[REQUEST PROFILE]` ブロック**（機械可読ヒント＋強制ルール）を `[CURRENT MAP STATE]` に続けて注入。
-- **`mapReport` の責務明確化**: 実装は不変（後方互換）。SYSでの意味を **「current/recent・dated・ライブニュース裏付けの事件のみ」** に限定し、過去年代・歴史背景・当時の勢力/交易/戦略的重要性・現在ニュースを要求しない安定知識には**使わない**ことを明記。
-- **`researchMap`（新アクション・historical/current/mixed）**: `{type:"researchMap",topic,place,temporalMode,year,evidenceMode}`。**文章と地図を独立生成**（§11）＝地図描画に失敗しても説明は返す。証拠は**モードで切替**（§6）＝historical は確立された歴史知識＋Wikipedia（**ライブニュース不使用**）、current はGDELT/Google News/読込済み、mixed は両方を明確に分離。`ai-proxy` の新タスク **`research_map`**（`JSON_TASKS`・`reasoning:medium`・`max_output:2600`・webMode は Profile 由来＝historical は topic の任意Web検証のみで現在ニュース非注入）が `{title,explanation,temporalBasis,items[],limitations[]}` を返す。**AIに座標を書かせない**＝`locationName+country` をクライアントで geocode。地図フォールバック（§8）＝実extent/bbox→中心→関連地点ピン。海域はポリゴン取得を成功条件にしない（`placeExtent`＋既存 `IntMapRegionResolver` を再利用）。
-- **能力レジストリ `ATLAS_ACTION_CAPABILITIES`（§7）**: 各アクションの本来能力（temporalModes/evidenceModes/outputs/geoKinds/topics）を小さく定義。
-- **実行前プラン検証 `_validatePlan(acts,profile,q)`（§7）**: 実行前に不適合アクションを**書換／追加**（repairで事後修復しない）＝①historical質問がライブ専用 `mapReport` へ→`researchMap`(historical, year保持) ②海域/地域/都市の局所質問が世界同盟地図(`historicalMap`, 非alliance)へ→`researchMap` ③説明要求なのにナビのみ→`researchMap` を追加。同盟/大戦/冷戦などの真の勢力図 `historicalMap` は温存。
-- **意味的リトライ制御（§10・§13）**: repair を **JSON完全一致でなく意味キー**で制御。`_researchFamKey`＝family+temporalMode（target非依存）で **翻訳だけの再試行を1回に畳む**。repair アクションも `_validatePlan` を通す（historical→live や 局所→世界 を禁止）。`_isWorldExpansion` で世界/大陸への範囲拡張を拒否。repair は **最大2巡**（旧3）、「近くの著名地／粗い対象」誘導を撤去し**元対象を保持したまま一段だけ拡張**に限定。地図描画失敗を回答失敗として扱わない。
-- **構造化結果 meta（§9）**: `R(ok,html,{meta})` に `{code(NO_LIVE_EVIDENCE/NO_HISTORICAL_EVIDENCE/PLACE_NOT_FOUND/NO_MAPPABLE_ITEMS…), category, retryable, semanticTarget, temporalMode, produced[], userGoalSatisfied}`。`runActions` が各アクションの結果を `_atlasOutcomes` へ収集。
-- **事後 Goal Validation（§12）**: `_goalValidation(profile,outcomes)`＝`{actionSucceeded,mapRendered,explanationProduced,geographicRelevance,temporalMatch,userGoalSatisfied}`。**「世界同盟地図の描画に成功＝オホーツク海の状況説明に成功」とは判定しない**。
-- **複合回答の統合（#R159・`runActions`／`_atlCompose`）**: `runActions` は各アクション結果を無条件連結せず **`ai.__atlResults` に記録**し、`_atlCompose(ai)` が **`_atlGoalKey`（回答系を正規化トピックで grouping・repair答は `__goalKey` 継承）＋`_atlGoalScore`（ok＋userGoalSatisfied＋produced explanation/map・partial減点）で目的単位に最良の1件だけ確定表示**。repairループは**破線dividerの別 `div` を廃止**し `runActions(ai,…)` で同一バブルへ再実行＝**成功した修復が失敗した元回答を置換**（「最初の分析＋修復後の分析の矛盾併存」を解消）。fail サマリから `actLabel`（`mapReport "Taiwan"` 等の内部名/コード/repair回数）露出を撤去。地図描画のみの失敗は分析本文を失敗扱いにしない（`researchMap` は text成功時 `ok:true`＋`produced:['explanation']`＋「地図表示のみ更新不可」を返す）。
-- **Atlas返答タイポ（#R159）**: `mdMini` は本文に**太字を出さない**（インライン `**`＋表セル→プレーン、見出し `#/##/###`＋lead は 750/800→**600 semibold**、`.atl-md-table thead th` 700→600）＋**`##` の上罫線 divider を撤去**（横線ゼロ）。色は `--text-main` のまま（R154）。
-- **デバッグ（§17）**: `window.IntMapAtlasDebug.lastPlan()`＝`{requestProfile,originalPlan,validatedPlan,rejectedActions,actionOutcomes,semanticRetries,scopeChanges,finalGoalValidation}`（通常UI非表示）。
-- **テスト**: `window.IntMapAtlasQA.run()` に R135 の純関数テスト21件を追加（**実測40/40 PASS**・従来19＋新21）＝時間軸判定（当時/1900、今→current、比較→mixed、明示1750、会話年）・地理kind・プラン検証（mapReport historical→researchMap／海域 historicalMap→researchMap／WWI同盟図温存／current mapReport温存／ナビのみ→researchMap追加）・翻訳リトライキー畳込・世界拡張ブロック・レジストリ・profileブロック・goal validation。実サイト（1900表示）で「当時のオホーツク海…」の Profile＝`historical/1900/map-state/water/explanation+map`、検証で `mapReport→researchMap(year=1900)` を実測確認。
+9. **動作確認**：ページを開き、(a) レイヤー行（`.lyr-row`）が100個以上（#R169 実測 143個）、(b) コンソールエラー0、
+   (c) News タブでピンが即表示、(d) ログイン→AI機能が動く、を確認。
+   （(a) と (b) は `npm run test:smoke` が同じことを自動で確かめる。§15）
 
 ---
 
@@ -1786,5 +1607,272 @@ hash）はすべて敵性入力として扱う。詳細は **`docs/SECURITY-ARCH
 - **定期実行**＝pg_cron（refresh-news 同型・`net.http_post` でヘッダに秘密・`docs/AREA-MONITORS.md` にSQL）。
 - **UI/Atlas**（`index.html` 加算）＝**Monitorsタブ**（通常/モバイル/Workspace・5言語）、`window.IntMapMonitors`（一覧/作成ダイアログ/詳細/レポート＝結論・主な変化→evidence chip・数値比較・根拠一覧(出典リンク)・変化地点を地図表示・取得できなかったデータ・制約・日時/status）。Atlas `{"type":"monitor","op":…}`＝**返信は実DB結果のみ**（偽の成功報告なし）。全描画 `IntMapSafe`（XSS-inert 実証）。
 - **コスト制御**＝変化なしはAI非呼出／新規のみAIへ送信（履歴dedup）／run毎cap（evidence60・AI入力40・110s wall-clock・55s AI timeout）／plan別monitor上限・最短間隔30分・手動クールダウン30s／保持（run 100・evidence 12run）。
+
+
+---
+
+## 19. ラウンド別補足 (Round appendices)
+
+> #R169 で整理: これらは §1–§18 の間に**バラバラの順序で挟まっていた**（R127→R128→R129→R131→R132→
+> R157→R154→R153→R152→R151→R150→R143→R142→R140→R139→R137→R136→R135）。内容は残す価値があるので
+> 消さずにここへ集め、**新しい順**に並べ直した。各ラウンドの完全な記録は `DEV-NOTES.md` にある。
+
+### #R157 補足（Atlas 自然言語処理の全面再設計＝「GPTが意味を理解する層」と「コードが安全に実行する層」の明確な分離）
+
+**設計原則（現状仕様）**: Atlas のハイライト系ターゲットは **意味の解釈をGPTが担い、コードは検証・実行のみを担う**。ユーザーの自然言語は意味を保持した原文のまま最初にプランナー（GPT）へ渡る。`localPlan`/`regionGroup`/`GROUP_ALIASES`/`REGION_ALIASES`/正規表現が**GPTより先に概念の意味を決定・改変・拒否する経路は存在しない**。既存の ISO/UN M49/国境 GeoJSON/組織加盟国データは**意味推測辞書ではなく**、GPT出力を検証して実地理形状へ結び付ける**決定論的データ**として残る。
+
+- **① localPlan からハイライト・ターゲットの解釈を撤去**: 旧 `^(.+?)をハイライト` → `{highlight,countries:'<生概念>'}` `confident:true`（GPTを一度も呼ばず dispatch へ生概念を渡していた単一真因）を廃止。localPlan に残る highlight ショートカットは**意味解釈を伴わない2つのみ**＝現ハイライトの色変更（`parseColor` ゲート・ターゲット無し）と解除。あらゆる「…をハイライト」は必ず GPT プランナーへ。
+- **② GPT主導のターゲット契約**: SYS の highlight スキーマ＝`{"type":"highlight","interpretation":str,"targets":[{"name":"<English>","iso3":"<ISO3>"},…]}`。GPTが概念（文化圏/言語圏/政治・歴史的分類/曖昧な国集合＝ゲルマン諸国・スラブ諸国・英語圏・旧植民地・主要産油国・OPEC・G7 等）を**自分で実ISO3集合へ展開**する（「IntMapに概念辞書は無い」と明示）。複数集合を別色＝`groups:[{label,targets}]`。国集合でない**具体的単一地物**（行政区画/河川/流域/自然地域）＝`query:"<地名>"` で従来の `resolveHlTarget` ラダー（＝概念でなく確定地名のみ・GPTの後段でのみ稼働）。
+- **③ コード側実行層（`_hlReadGptGroups`/`_hlValidCodeSet`・dispatch highlight 冒頭）**: GPTの targets/groups/iso3/codes を読み、各ISO3を **`_hlValidCodeSet`（`window.countryGeo` 由来の実在コード集合）で検証**（不正コードは拒否・氏名があれば `resolveCountrySync` で救済＝正確な国名→コードの決定論マッチ）、重複除去、`_codesGeo` で**実国境 MultiPolygon** 構築、`_validGeo` で形状検証、`paintPolys` 描画、`_verifyPolyPaint` で実状態検証、**採用した解釈を凡例＋注記で明示**、無効コードは「スキップ」正直報告、全無効は `ok:false`。`regionGroup` はこの経路を通らない。`countries`（文字列/名前配列）経路は**legacy fallback として温存**（R143 直接 dispatch テスト無回帰。`_hlReadGptGroups` は生ISO3配列のみ targets 扱い＝名前配列/概念文字列は null で legacy へ）。
+- **④ 画像のみ送信で架空ユーザー文を生成しない**: `run()` の `if(!q&&imgs.length) q=L('Read and analyze…')`（既定文をユーザーバブル/履歴へ露出させていた真因）を撤去。`q` は空のまま＝ユーザーバブルはサムネイルのみ・履歴は空。既定指示は `_visionPrompt` 内でユーザー未入力時のみ付与＝**API境界の非表示システム指示に限定**。ペースト/ドロップ/添付が textarea を変更しないのは既存挙動（`_atlAddFiles`＝`_atlImgs` に push のみ）。R156 の Vision/数式/検算/非地理ゲートは無変更。
+- **公開/テストAPI**: `IntMapAtlasDebug.{hlReadGroups,validCodeSet,hlState}` 追加（純関数＝mapなしでCI検証可）。データソース変更なし（`window.countryGeo`/`countryStats` 再利用）。Edge Function 変更なし。テスト: `tests/r157.spec.js`（Playwright 8）＋ `tests/r157-checks.test.mjs`（source 5）。**罠**: Browserペインは `document.hidden`＝`isStyleLoaded()` 未完了で `paintPolys` が false→dispatch ok:false（legacy `東西南北欧` も同ペインで同挙動＝環境要因）。描画真偽は WebGL 可能な Playwright で検証、ペインでは `polyState()`/`hlReadGroups` の**パイプライン出力**で検証（R143/R156 と同一の罠）。
+
+---
+
+### #R154 補足（UX/機能バッチ10件）
+
+`index.html` のみ（Edge Function 変更なし）。テスト＝`tests/r154-checks.test.mjs`(node 10)＋自変更で壊れた r149/r150/r152/r153 assert 更新。`npm test` 緑（static＋node **109**＋Playwright **80**・pageerror 0）。主要修正をハーネス実測で検証（クリーンポートで Playwright 80/80、汚染ポートの11失敗は同時実行セッションとの資源競合と確認）。
+
+- **① ケッペン幅（7回目・真因＝固定幅）**: 264px 固定は日本語（最長行~137px）で **~80px 死に幅**（「テキスト以上に横幅伸ばして…行の幅変わってない」）、独語で数語クリップ（「狭すぎる」）。→**内容ハグ**: `_fitKoppenLegend` がオフスクリーンspanで最長行を実測し、行クローム＋予約gutter を加えた px 幅を直接セット（clamp 176–324・右余白内）。CSS 固定ロックを `width:210px(fallback);min-width:172px;max-width:340px` に。実測 border-box: JP 207/EN 276/DE 317/RU 307/ES 303px・**全言語クリップ0**。幅は build/表示/リサイズ時のみ決定論再計算＝縦ドラッグで不変。下端マージン 12→8px。モバイルは既存 `!important` 幅で保護。
+- **② Atlasタイポ（色分け廃止＋捏造停止）**: (a) mdMini 全見出しの `color:var(--primary-color)` を撤廃＝**`--text-main`＋サイズ(# 1.6/## 1.34/### 1.12/行全体太字 1.16em)＋余白のみ**で階層化（「目次を色分けするのはやめる／サイズと配置で勝負」）。(b) `_atlStanza` の**見出し捏造を全廃**（先頭文→太字リード・文頭 `Label:`→`##` を削除＝「大きくする箇所がおかしい／判定がおかしい」の真因）。拡大は**モデルが書いた `##`／行全体太字のみ**。整形は安全なもの（長 run-on の~2文stanza分割・list正規化・段落余白）のみ。プロンプトに「見出しは真の節タイトルのみ・普通の文を拡大するな」。
+- **③ SV Coverage 線（4回目）**: 画面ストローク≈nativeStroke×(tileSize/256)なので **`tileSize:128→64`**（z+3 fetch・~4×縮小＝**~0.9px ヘアライン**・native/overzoom いずれでも単調に細い）＋ `raster-opacity 0.9→0.62`。maxzoom は据置。
+- **④ Atls出典（「全くない」の真因）**: `_atlCleanUrl` が**復号不能 Google News リダイレクトを丸ごと drop**（近年の不透明RSS→ニュース1バッチ全滅→出典ゼロ）。→ **リンク保持**（クリックで実記事へ）し `linkCards` は**発行元名（`src`）でドメイン表示**（"news.google.com" 表記回避）。SNS/短縮/動画 drop・関連度・異script保持は不変。
+- **⑤ Draw で Elevation profile**: `_elevationProfile`（measure/area＋`measurePoints` 固定）から**再利用コア `_profileFromCoords([lng,lat][])`** を抽出（measure/area は委譲＝挙動不変）。DrawTool `renderPanel()` に `📈` ボタン（`simplified.length>=2`）→ 描いた線を同一 DEM パイプラインで断面化。5言語 `elevProfile` 既存。
+- **⑥ AQI/UVI iOS再構築**: カード全体をカテゴリ色グラデで塗り（`_wgtColor` が inline `!important` でガラス上書き制圧）、**輝度で文字色分岐**（淡色→暗文字/濃色→白）＝全段コントラスト確保。数値36px。**AQI 6段階**（4→6・Very unhealthy/Hazardous 追加）。カテゴリ名5言語（`_WL`）。データ源不変。
+- **⑦ Atls音声入力**: `.atl-inbar` に `.atl-mic`＋Web Speech API。認識言語=UI言語、結果は入力欄に挿入（確認後送信）、録音中赤パルス、非対応で非表示。5言語タイトル。
+- **⑧ Layerパネル既定=右**: `window.imLayerPanel 'classic'→'right'`（保存済み classic は優先）。
+- **⑨ 右サイドバー左右調整＋既定縮小**: 左 `#sb-resizer` 鏡写しの**左端ハンドル `.lsr-resizer`**（左移動で拡大）＋`localStorage 'intmap_lsr_w'` 永続。`open()` は**保存幅優先**（従来は毎回上書き＝ドラッグ無効化）。既定幅 **430→380px**。地図 ≥320px。
+- **⑩ オフレイヤー残存表示**: 真因＝**OFF→hide 自己修復が自動学習レイヤーに欠落**（`.setStyle` 皆無・reconcile は ON 再発火のみ）。`_auditLearned` を**両方向対応**（`!cb.checked` 早期return撤廃）＝OFF かつ painted なら hide（`_ownedByCheckedOther` で他 checked が正当に描くidは除外）。二次＝ECMWF ロード失敗で `state[id].on=false` も戻す（styledata 再attach 復活を防止）。
+
+---
+
+### #R153 補足（UX/機能バッチ8件・再報告の根本原因）
+
+`index.html` のみ（Edge Function 変更なし）。テスト＝`tests/r153-checks.test.mjs`(node 9)＋自変更で壊れた r149/r150/r151/r152 assert 更新。`npm test` 緑（static＋node 99＋Playwright 80・pageerror 0）。全修正をハーネス実測で検証。
+
+- **① ケッペン凡例（6回目）**: R152 の `nowrap`+200px+ellipsis が **EN30区分中11名をクリップ**（実測: EN名は幅216px要）＋自然高519pxが768ノート可用~514pxを5px超過＝EF到達不能。修正: 幅 **200→264px**（EN/JP/RU/ES全収・独語最長2-3のみ hover）／行 `padding:0.5px→0`＋`line-height:1.2` で**自然高489px**（全区分既定表示・EF到達）／**RU/ES 気候名を KNAME に追加**（従来 en フォールバック）。`_fitKoppenLegend`(min(内容高,vp)) は無変更＝内容高を下げるのが真因。
+- **② Measure/Share ポップアップ**: 「無条件透過するな」+「無条件不透過するな」＝**条件付き要求**。`background:var(--card-bg)`(常時不透過) → **`var(--glass-fill)`＋標準blur**＝外観設定(#R33)に従い Solid で不透過(--card-bg)・glass で frost。他ポップアップと同型。
+- **③ Atlasタイポ（3回目・描画側の真因）**: `_atlStanza` の **`>1改行→return raw`** が最頻ケース(複数段落フラット散文)を素通り。→**全面再構造化**: 段落分割・文単位 `Label:`/`背景：`→`## 見出し`・先頭文→太字リード・段落は空行 join(余白)・長連続文は~2文stanza・**CJK加重**。既 `##` 構造化済は不介入。リード 1.22→1.3em、余白 1.05→1.2em。決定論的＝IntMapAtlasDebug。
+- **④ SV Coverage 線（3回目）**: Google svv は各ネイティブzoomで一定幅描画→z19超で拡大肥大。**`tileSize:256→128`**（全zoomで~2×ダウンスケール→細線）＋**`maxzoom:19→21`**（z20/z21タイル実在をpixel実測で確認）。
+- **⑤ Companies 深い履歴**: Yahoo keyless 床は銘柄依存 1962-1985（R152到達済）・Stooqは PoW化で不可＝捏造せず。上積み＝比較 Time-series 既定 **10→20年**（深い履歴を即表示）。ピッカーは1962床維持。
+- **⑥ Atlas出典（両面再報告）**: (a) mapReport/events の**インライン `記事↗` が生URL**（アグリゲータ/SNS）＝フィルタ迂回。(b) **planner `answer` が出典を一切描画しない**（「全くない」主因）。修正: **単一 `_atlCleanUrl`** を linkCards＋両インラインリンクで共通使用／linkCards は **host-clean→関連度** の順（空バグ解消）／`answer` に web-verified 出典追加／関連度は**異script保持**。
+- **⑦ Companies 真パリティ**: 最大の手抜き＝**TS指標ピッカーが無効**（常に株価指数）。→**{Market cap 絶対$ / Share price 指数} トグルがチャート駆動**＋十字ツールチップ、generic ピッカーはTSで非表示。`/8`→`/10`（2箇所）。**ws窓に検索欄**（`#info-search-bar`＋`_companiesSearchVal`＋`#co-compare-fixed`バンドル・5言語 `filterCompaniesPh`）。**詳細に実株価スパークライン**（`priceSeriesFine`）。HQ地図/Focusは企業＝非地理のため意図的非採用。
+- **⑧ ワークスペース地図ポップアップ**: `_inWsWin()` の `panel.closest('.ws-win')` が、ws-modeで地図窓へ移設された `#map-container` 内の全ポップアップを誤判定→ドラッグkill。**`panel.parentElement` が `.ws-body`（窓の直接コンテンツ）か**に変更＝本体パネルは保護・地図ポップアップは復活。`_inWsWin2`(resize)も同修正。
+
+---
+
+### #R152 補足（UX/機能バッチ13件＋**地図エンジン抽象層 第1段階**）
+
+#### §7.1 `IntMapGeoEngine` — レンダラー抽象層（第1段階＝#R152 / 第2段階＝#R160 / 第3段階＝#R161）
+`window.__imap=map` の直後（`map.on('load')` 内）に定義する**薄い facade**。目的＝将来 Google-Earth 級 Earth Mode を差し込めるよう MapLibre 依存を隔離すること。**純粋 additive・挙動/性能/モバイル完全同一**。
+
+- **構造**: `IntMapGeoEngine`（facade）→ `_adapter`（現状 `MapLibreAdapter` のみ）。`MapLibreAdapter` は全メソッドが現行 `map` への 1:1 委譲。`use(adapter)` で将来別レンダラーに差替。`capabilities()`／`contracts()`／`can(feat)`。`raw()`＝MapLibre 実体を返すエスケープハッチ（未一般化コード用）。
+- **抽象済み（安全に共通化した処理のみ）**: `camera`（flyTo/easeTo/jumpTo/fitBounds/setPadding/get/setProjection＋**#R160**: getZoom/getCenter/getBearing/getPitch/getBounds/zoomTo/zoomIn/zoomOut/stop）・`coords`（project/unproject/terrainElevation/queryRenderedFeatures）・`layers`（addSource/setSourceData/removeSource/add/remove/setVisible/isVisible/setPaint/setLayout/**setOpacity**＝レイヤ型からopacity paint名を解決＋**#R160**: setFeatureState/removeFeatureState）・**`render`（#R160: resize/triggerRepaint/canvas＋**#R161**: container/size/setCursor）**・`events`（on/off/once＋**#R161**: onLayer/offLayer＝**レイヤ単位のポインタイベント**）＋**#R161**: `ready()`（描画準備完了）・`layers.getPaint()`（paint 読み戻し）。
+- **Cesium**: `CESIUM_CONTRACT`＝capabilities 宣言のみ（`implemented:false`）。**SDK・API キーは未導入**。将来は Cesium 版 Adapter を実装し `use()` するだけ。
+- **#R161 第3段階＝自己完結サブシステムの丸ごと移行（ニュースピン・オーバーレイ）**: 契約を「オーバーレイが必要とするもの一式」（`ready`／`render.container/size/setCursor`／`events.onLayer/offLayer`／`layers.getPaint`）まで広げ、**`setupIntelLayers()` のニュース＋ダッシュのソース/レイヤ生成、`_declutterNewsBands()` の projection＋surface サイズ＋feature-state、帯のテーマ配色、ニュースの hover/click/leave 全6ハンドラ**を engine 経由へ移行。**生 `map` を一切参照しないサブシステムの第1号**＝別レンダラーのアダプタはこの契約を実装するだけでニュースピンを継承できる。
+  - **検証の壁と突破**: hermetic な Playwright ではベースマップの vector source（`tiles.openfreemap.org`）が遮断され `isStyleLoaded()` が永久に false → レイヤが作られず**レイヤ単位の検証が不可能**だった（R143/R130 の既知事象）。`tests/r161.spec.js` はその**1ソースだけを空の TileJSON でスタブ**してスタイルを完了させ、アプリ本来の経路でオーバーレイを作らせて実検証する。
+- **Atlas 配線**: アクション形式は不変。実行部のみ抽象層経由の実証として **Atlas カメラ制御 3ケース（`zoom`/`bearing`/`pitch`）を `const GE=IntMapGeoEngine.camera` で読み取りも駆動もエンジン経由へ**（#R152 で `pitch`/`bearing` の easeTo、#R160 で getter＋`zoom` ケースを追加）。複雑な `flyTo` ケースは誤移行リスクのため据え置き（将来段階）。
+- **未対応（次段階の移行対象）**: `addSource`≈343・`addLayer`≈426・`setPaint/LayoutProperty`≈120・`flyTo`/`fitBounds` の**大量呼出は段階移行**（一括書換えは禁止）。`queryTerrainElevation`／`setSky`／`setTerrain`／`setMaxPitch`／3D地形など **MapLibre 固有機能は当面 `raw()` 経由**（無理に一般化しない）。副次地図（gmap/cmap/minimap）も現状は直接。
+- **次にやること**: ①新規の共通機能は必ず `IntMapGeoEngine` 経由にする（`map` 直呼び禁止の徐々な徹底）、②**次のサブシステム移行**は同じ形の `dash`/`user-pin`/`grid` オーバーレイ（#R161 と同型で低リスク）、③`markers`（`maplibregl.Marker`）名前空間の追加、④`flyTo`/`fitBounds` 系ディスパッチの移行、⑤別レンダラーの capabilities で分岐する UI（Earth Mode トグル）、⑥Cesium Adapter の骨子。
+- **検証**: 契約テスト＝`tests/r152-checks.test.mjs`＋`tests/r160-checks.test.mjs`＋**`tests/r161-checks.test.mjs`#16**（拡幅契約・ニュース6ハンドラの移行・生 `map` へのニュースハンドラ残存ゼロ）＋**`tests/r161.spec.js`（実ブラウザ：facade がレンダラーと数値一致、オーバーレイが実際に engine 経由で生成される）**＋既存スモーク。
+
+#### その他12件（要点）
+①ケッペン**行折返し撲滅で単一行化**（真因は自然高777px・14行折返し／`_fitKoppenLegend`無変更）。②Companies を静的下端オーバーレイ ドックで**Countries完全同一化**。③Atlasタイポ＝フラット文の先頭文をリード太字へ昇格＋見出し拡大。④出典＝ブロックリスト拡張＋`_atlRelevantCards` 関連度ゲート＋未引用を「関連記事」表記。⑤トグル＝全画面＋汎用control。⑥衛星＝**実測(curl)で Esri z19 が keyless 上限**（z20は東京すら灰色2521B）→画質のコード変更なし。⑦SV線細く（glow paint撤去）。⑨Measure/Share 不透過（card-bg）。⑩方位磁針 右クリック数値入力。⑪フライトシム 海面フロア(countryGeo判別)＋水面 fill。⑫等高線 密度スライダー（凡例内）。⑧Companies 月次高精度＋歴史floor 1962。
+
+**重大教訓**: static-checks は**同一スコープ重複 `const` を検出不能**（`_ATL_STOP` 二重宣言でアプリ全体ブート不能＝全Playwright timeout）。**commit前に実 chromium で critical globals を必ず確認**。
+
+---
+
+### #R151 補足（UX/機能バッチ11件：ケッペン全区分停止＋行幅固定／Measure・Share集約／SV coverage自動／モニター削除でハイライト消去／Companies株価バッチ＋全史キャッシュ／Atlas出典SNS除去／Atlasトグル拡充／Terra本番検証）
+
+- **ケッペン凡例（#3・R150を上書き）**: `_fitKoppenLegend` を **`min(自然内容高, ビューポート上限)`** に（内容高は inline `height`/`max-height` を一時中和して `getBoundingClientRect` で実測→復元）。**内容<画面＝最終区分で停止**（空白ゼロ＝「すべて表示されたら止まる」）、**内容>画面＝画面下端で停止＋内側 `.kl-scroll`**。行幅固定＝`.kl-scroll{ scrollbar-gutter:stable }`（スクロールバー出没で~15px 揺れ→行 reflow が真因）。R150 の「ビューポート基準で必ず下端」は空白を生む＝要求転換で上書き。r149/r150 の #3 テストを二挙動（短vp下端／高vp内容停止）へ更新。
+- **通常モード Measure/Share 集約（#4）**: Radius を `#measure-dropdown` 内へ（Distance/area・Draw・Radius）。Screenshot＋リンクを新 `.share-menu-container`（🔗 Share ▾＝Screenshot・共有/リンク・`right:0`）へ。**ID温存**（`btn-tool-radius`/`btn-screenshot`/`btn-share`）で既存ハンドラ・モバイル `data-proxy` 不変。`shareMenuBtn`/`shareLinkBtn`/`coCompareEmpty` を5言語追加。
+- **SV coverage 自動（#8）**: `IntMapStreetView.open()` が coverage OFF 時に `coverage(true)`＋`_covAuto`（手動状態温存）、`close()`（✕も集約）で自動分のみ OFF。パノラマを開くと水色の実カバレッジ線が即表示。
+- **モニター削除でハイライト消去（#6）**: `showOnMap(area,points,monId)` に `_shownMonId` 記録（全呼出元に id）、`remove()` 成功時 `_shownMonId===id`（or 未追跡）で `clearMap()`。UI/Atlas 両経路が同一 `remove` を通る。
+- **Companies 深い歴史＋低遅延（#10）**: `_spark(syms,range,interval)` で Yahoo `v8/finance/spark` を~40銘柄バッチ（旧＝1銘柄1req）→ `loadPrices` 即着色＋未解決のみ従来チャートfallback。`_histAll()` が `spark range=max 1mo` を一度取得し `{tk:{year:年末終値}}` キャッシュ→ `setYear` 年スクラブをネット無し即時（未網羅のみ per-year fallback）・`priceSeries` も同キャッシュ。両response shape対応。
+- **Atlas出典の信頼性（#11）**: `_atlBadSourceHost`（`_SNS_RE`＝X/Twitter/FB/IG/Threads/TikTok/Reddit/YouTube/t.me/bit.ly…）で全出典カード経路（`linkCards`＝analyze/answer/mapReport）から SNS/UGC/短縮/動画を除外。`_analysisSystemPrompt` に「SNS等は出典にしない・各URLは主張を直接支持する具体ページのみ」明記。`IntMapAtlasDebug.badSourceHost/linkCards` 公開。
+- **Atlasトグル拡充（#2）**: 既存(layer/base/grid/3D/国情報/SV/borders/labels/roads/ticker)に **globe（地球儀 on/off）・compare** を `_FEAT_TOG` 追加＋projection/compare dispatch に `_featTogHtml`。
+- **タイポ（#5）**: mdMini で**行全体が `**太字**` の行を実見出し**へ（モデルは `##` より太字を多用＝モデル非依存の階層）＋段落余白 .72→.85em。answer/analysis プロンプトの FORMAT指示は既存。
+- **衛星（#7）**: `predictivePrefetch(aggressive)`＝飛行で RING 3→7・斜め角先読み・傾斜時は横一段浅も warm、飛行ループ 380→300ms＋aggressive。**3D手動 pan/rotate（pitch>25）でも `move` ごとにスロットル先読み**（従来 moveend のみ＝連続移動で先読み皆無）。既存最適化(2/5ホスト分散・native-max DEM z15・fade0・8192キャッシュ・pixelRatio上限)温存。
+- **Companies 空比較ヒント（#1）**: Countries同型は既存＋**空状態ヒント**「Tap company rows to select and compare.」（`coCompareEmpty` 5言語・`renderCoCompareFixed` が `scf-empty`）。
+- **Terra（#9）**: `AI_MODEL` secret＋`OPENAI_DEFAULT_MODEL=gpt-5.6-terra`（コメント整合・再deploy）・Luna は model_not_found のみ。**本番検証＝`current_news.analyzed_by='ai'` が 354 件**（refresh-news cron は fallback無でTerra直呼び＝ai>0 が到達の実証）。
+- テスト: `tests/r151-checks.test.mjs`(node 11) ＋ `tests/r151.spec.js`(Playwright 6)。r149/r150 のケッペン#3を R151 仕様へ、r149/r150-checks の exact-string を .85em/prefetch cadence へ更新。`npm test` 緑（node 79・Playwright 80・pageerror 0）。
+
+### #R150 補足（UX/機能バッチ10件：モニター保存の真因user_id欠落／ケッペン下端伸縮／Atlas曖昧性ゲート統一／調査回答マッピングのコード側検証／Terra採用／衛星飛行プリフェッチ）
+
+- **モニター保存（#6）**: `IntMapMonitors.create()` の挿入行が `user_id` を欠落（`area_monitors.user_id` は `not null`＋insert RLS `user_id=auth.uid()`）→ UIからの作成は毎回失敗し「Could not save the monitor.」。修正＝client が `row.user_id=currentUser.id`（他の user-owned insert と同型）＋ migration `20260721140000` で `alter column user_id set default auth.uid()`（本番適用済み・冪等）。**この機能は service_role 経由でしか検証されておらず、ログインclientの挿入経路は未検証だった**のが盲点。
+- **ケッペン凡例（#3）**: `_fitKoppenLegend` の `maxHeight` を**ビューポート基準**(`innerHeight - top - 12`、content-box分減算)に。従来の**内容高クランプは伸縮を阻害**（背の高い画面/区分少で画面下端まで引けない＝「一番下まで伸ばせない」）。CSS `max-height:calc(100dvh - 84px)` は温存、内側 `.kl-scroll` が全区分を担保。
+- **Atlas地理対象の曖昧性ゲート（#7）**: 共有 `_hlAmbigConfirm` で**単一の確認**を生成し、multi-region/single 両経路が**描画前にゲート**（曖昧が1つでもあれば `R(false,…,{meta:{partial:true}})` で停止＝何も塗らない・planner say 抑止）。従来は塗った成功の隣に `gAmbig`/`ambig` を警告として追記＝「候補確認・部分実行・成功報告・失敗警告」の同時表示が真因。個別地名ハードコード無し＝`resolveHlTarget` の `ambiguous` 判定に駆動。
+- **調査回答マッピングのコード側検証（#10）**: PURE基盤（`IntMapAtlasDebug` 公開でhermeticテスト可）＝`_atlExtractPlaces`(本文抽出=省略時安全網)／`_atlAuditSources`＋`_atlRegDomain`＋`_atlIsOfficial`(出典正規化・単一集中検出・官公庁/一次優先)／`_atlMappingVerdict`(mapped/unplaced/ambiguous)／`_atlGeocodeStrict`(同名≥2でambiguous・place型＋名称一致のみ・座標推測なし)。orchestrator `_pinReplyPlaces` は**既存ピンとMERGE**(clearしない・スキップ廃止・空catch廃止→console.warn＋正直な注記)。
+- **Atlas使用モデル（#9）**: `refresh-news`（同キー・同AI_MODEL・**モデルfallback無**）で `AI_MODEL=gpt-5.6-terra` → ai 61/63(en)・104/116(jp)成功＝**Terra再検証で到達可**。`AI_MODEL` secret=terra・ai-proxy default=terra・`FALLBACK_MODEL=luna`。
+- **タイポ（#4）**: `_atlStanza`(改行無し長塊を~2文stanzaへ)＋mdMiniで文末＋単一改行→ソフト段落余白。構造化済みは不介入。
+- **衛星3D飛行（#8）**: `predictivePrefetch` が `moveend` のみ発火→**飛行中(連続移動)は先読み皆無**が真因。`window._imPredictivePrefetch` 公開＋飛行ループで~2.6回/秒スロットル呼出。`sat-labels` を Esri 2ホストでラウンドロビン。既存最適化(2/5ホスト分散・native-max DEM・fade0・8192キャッシュ)温存。
+- **停止四角(#5)** rect 17.5→15.5。**Companies(#1)** は既に Countries 同型・`.co-logo-box` 32→30px で国旗枠と画素一致。**SVオフ(#2)** にも `_featTogHtml('streetview')`。
+- テスト: `tests/r150-checks.test.mjs`(node 12・ソース保証) ＋ `tests/r150.spec.js`(Playwright 7・業務委託の全ケースを純関数でruntime検証)。r147/r149-checksをR150差分へ更新。PR #23。
+
+### #R143 補足（Atlas地理対象解決の汎用基盤：UN M49国集合＝実国境／多地域＝グループ別色＋凡例／描画前ジオメトリ検証／実状態検証／正直返答）
+
+「東西南北欧をハイライトして」で **西欧未描画・4地域同色・南欧が巨大な三角形・国境でなく雑な近似図形・未完了なのに完了報告・曖昧性の長文説明が地図操作を妨害** が同時発生。**真因＝ヨーロッパのサブ地域（西欧/東欧/南欧/北欧）が「国集合」なのにコードは `REGION_BBOX` の粗い矩形/AIポリゴンでしか解決できず**、多地域の色分け・凡例・描画前検証も無かったこと。Europe専用ハックではなく**Atlas全体の汎用基盤**として、パイプラインを **解釈→地理対象解決→実行計画→描画→実状態検証→返答** に統一。全て `index.html` 加算（単一HTML温存）。`npm test` 緑（静的＋security/monitor logic＋**Playwright 44/44**、内 `IntMapRegionResolverTest` に純検証~30件・新 `tests/r143.spec.js` 10件）。
+
+- **① UN M49 国集合（地理対象解決）**: `REGION_GROUPS` に **UN M49 のサブ地域を実 ISO3 リストで追加**（western/eastern/southern/northern europe＝**互いに素な4分割**、north/south america・caribbean・north/west/east/central/southern africa・western asia・oceania サブ地域…）＋ `europe`/`oceania` は下位の和。`regionGroup` は既存の `GROUP_ALIASES` に加え **5言語 `REGION_ALIASES` も参照**（西欧/Westeuropa/западная европа… が自動で国集合へ。国集合でない自然地域＝Sahara/Alps 等は null で従来のポリゴン経路へ）。→ `resolveHlTarget` の**グループ段（国コード）で確定**し、Nominatim/AI/矩形の不安定経路を回避＝**正式な国境 GeoJSON で描画**。標準定義があるので**不要な確認をしない**（曖昧性の壁は出ない）。
+- **② 複数地域＝グループ別色＋凡例**: highlight dispatch に**多地域分岐**（2つ以上の対象・明示単色なし・河川/流域でない・かつ少なくとも1つが国集合/地域）。各対象を**カテゴリ配色 `_HL_PALETTE` の別色**で `nlq-poly-src` に描画（国集合は `_codesGeo(codes)` で **`window.countryGeo` の実国境から MultiPolygon** 構築・内部境界は `comp:1` で淡く）、返信に**色スウォッチ凡例**（`_hlLegendHtml`：地域名＋か国数＋根拠）。単一対象/単色指定/純国リストは従来の単色 feature-state 経路（無変更）。表示名は **`M49_LABELS`（5言語）で localize**（`_hlPolys` 内部名は正準英語キー＝安定・テスト可）。
+- **③ 描画前ジオメトリ検証（ハリボテ拒否）**: `_validGeo(geo,{trusted})` が **未閉リング・退化した少頂点「巨大三角形」・異常な長辺・自己交差・全世界blob・極小スライバー・非ポリゴン**を描画前に拒否。実国境/OSM/構成境界は `trusted` で粗近似ヒューリスティックを免除、AI/派生/ソフト箱は全検査。多地域・単地域の**両経路**で適用（拒否は正直に「不正な形状のため未描画」）。`_bboxSoftPoly` も**厳密閉リング化**（`sin(2π)≠0` の隙間を解消）。
+- **④ 実状態検証＋正直返答**: 描画後に `_verifyPolyPaint(n)` で **source/layer/feature数** を確認。返信は**実行結果から合成**＝描画できた対象（凡例＋根拠）と **失敗（見つからず／不正形状で拒否／曖昧）を明確に分離**、部分失敗は `meta.partial` で**プランナーの実行前 `say` を抑止**（R140/R142 の say-gate）。
+- **④' (#R158) Terra＝意味/対象/方法の最高意思決定者、IntMap＝忠実な実行装置**: コード側の**自動補正・対象除外・意味推測を廃止**。`_hlReadGptGroups` は Terra の識別子をそのまま実行し、無効/空ISO3は**補正せず**（`resolveCountrySync` 救済を撤去）`unresolved:[{name,iso3,reason,availableIdentifiers}]` として返す（候補は**報告のみ・適用しない**）。dispatch は**構造化実行結果** `{status,action,resolved,unresolved,renderState,capabilities}`（委託書JSONスキーマ）を `R(ok,html,{meta,exec})` で返し（`cg.miss`/`_validGeo` 失敗も unresolved に観測記録）、`runActions` が `a.__exec` に保存、run() の**既存2周repairループ**が `partial_or_failed` を `pending` に投入＋`[EXECUTION RESULT …]` を repair プロンプトに添付＝**Terra自身が**修正/再検索/確認/部分採用を決める。スキーマ/型/セキュリティ/描画検証は**Terraの意味判断を覆さない観測層**として維持。`regionGroup`/legacy `countries` 経路は無改変（R143無回帰）。全アクション共通の契約（highlight が第一実装）。
+- **⑤ 堅牢性（style待機・遅延上書き・再描画）**: 世代トークン `_hlGen`＝**新しいハイライトが古い非同期解決の上書きを阻止**、描画は最大 8×0.7s のバウンド再試行、`styledata` 再描画は既存の `paintPolys` ハンドラが継続。
+- **⑥ 複合展開（頑健化）**: `_expandRegionCompound` が **「東西南北欧」→4 M49 キー**、「南北アメリカ」→2、を決定的に展開。さらに**方向欧の2語以上の共起時は M49 に正準化**（＝「北欧」は単独では北欧5国だが、四方位欧の集合内では M49 Northern Europe＝隙間なし4分割）。
+- **公開/テストAPI**: `IntMapAtlasDebug.{regionGroup,validGeo,codesGeo,expandCompound,paletteColor,legendHtml,polyState}`（純関数＝mapなしでCI検証可）。データソース変更なし（既存 `window.countryGeo` の再利用）。
+
+---
+
+### #R142 補足（UX/正直化バッチ17件：SV実Coverage再修正／Atlas正直化・全幅・Stop／シート同期／Companies順位・時間・比較・拡充／WS読込・レイヤー復帰／東西独国境／Radius整理／News媒体Wikipedia）
+
+ユーザー指摘**17件**を根本原因から修正（`index.html`＋データ `data/cshapes.js`・加算的/微修正・単一HTML温存）。着手前に並列サブエージェント6本で実地調査。`npm test` 緑（静的+security-logic+monitor-logic+**Playwright 26/26**・pageerror 0）。DOM/データ/純関数は localhost プレビューで実測。詳細は DEV-NOTES R142。
+
+- **SV実Coverage再修正（#1）**: `_nearestCoverage` の `null`（タイル遮断＝プライバシー堅牢環境）で無言のクリック点配置＝R140前と同症状→`_loadTile` に **CORSプロキシ・フォールバック**、探索半径 40→115px・z≥14、null は正直トースト（偽マーカー無し）。実測 Times Square 実スナップ。
+- **Atlas正直化（#2/#3/#9/#17）**: プランナー実行前 `say` を **視覚/状態アクション失敗 or `meta.partial/unverified` で抑止**（say-gate 拡張）。`highlight()` は feature 未ロード時 `false` 返却、highlight dispatch は部分ミスで `meta.partial`、layer dispatch は無描画で `meta.unverified`。`OVL_OF.missile` に `'blast'`、layer インライン再トグルを OFF 分岐でも出力。`toggleLayer` が **`cb` 返却**→インライン操作は `r.cb` 再利用（曖昧再解決廃止＝既定状態が実 checkbox 値）。
+- **Atlas UI（#8/#15）**: `.atl-chat` 側 padding 14→8px 等で**サイドバー全幅**。送信ボタンは応答中**赤 Stop スクエア**＝`_setGoBusy`/`_stopRun`（`_runGen++`＋`AbortController`・planner/repair の `askAIJSON` に `signal`）、`run()` を try/finally で全終了経路復帰。
+- **モバイルシート同期（#4）**: `setDetent` の settle `easeTo({padding})` 直前で **残存 `_padRAF` を cancel**（v5 `setPadding`=`jumpTo`→`stop()` が settle を中断していた）。
+- **Companies（#5/#6/#7/#13）**: 順位＝**現在指標のVALUE順位（方向非依存・最大=1）**（両レンダラ・名前ソートは正準指標フォールバック）。**タイムマシン対応**＝`IntMapCompanies.setYear(year)`（keyless v8 chart 月次年末終値→`c.hp`・`mcap()`/`priceOf()` 歴史化・`_coWireTime` 購読・正直バナー・設立前—）。**比較**＝`coCompareSet`＋行シングルクリック選択/ダブルで詳細＋sticky トレイ＋`showCoCompare`（6指標×N社横バー・時間対応）。**拡充**＝US上場27社追加（→147社・123 live）＋**TSMC(TSM) live 化**（25.93B÷5=5.186B ADS）。手法＝安定な**株数×取得価格=snapshot** 自己整合（±5×ガード通過）。新 window.*: `_coToggleCompare/_coClearCompare/_coShowCompare`。新 API: `IntMapCompanies.{setYear,priceOf,histYear}`。
+- **ワークスペース（#10/#11）**: `enable()` に**ローディングオーバーレイ**（`_wsLoadingOn/Off`・2×rAF後に重いビルド・finally 消灯）。`disable()` で**レイヤーパネルを通常復帰**（インライン幾何クリア＋`apply()`＋`_placeActiveSection`）。**副次真因修正**＝R141 Monitors 窓が `defRects()` 未登録→`clampRect(undefined)` throw（毎デスクトップ ws 起動で握り潰し破損）→`monitors:flo(3)` 追加＋`clampRect` に `r=r||[]` ガード。
+- **東西独国境（#12）**: `data/cshapes.js` の内独国境が両側独立簡略化で重なり→**西独=difference(統一 788, 東独 789)**（`polygon-clipping` で offline 再生成・overlap 0・共有頂点60・新 ring1991）。西独era を再ポイント。ビルドツール `polygon-clipping`（非コミット）。
+- **Radius整理（#14）**: プリセット＋色/透明度を `<details>`「Style & presets」開示（既定折畳・全ID温存）、スライダー＋統計は常時表示。
+- **News媒体Wikipedia（#16）**: `.news-pub` を `role="link"` 化→`<lang>.wikipedia.org/.../Special:Search&go=Go`（jp→ja・404回避・`IntMapSafe.url`）。
+
+---
+
+### #R140 補足（既知バグ6件バッチ根本修正：SV透過＋実Coverage／タイムマシン国境の間欠不表示／Atlas嘘ハイライト／モバイル・ボトムシート同期）
+
+ユーザー指摘の既知問題**全6件**を根本原因から修正。全て `index.html` の加算的/微修正（単一HTML・ビルド無し温存）。`npm test` 緑（静的89＋security-logic 10＋Playwright 18/18・pageerror 0）。詳細は DEV-NOTES R140。
+
+- **① SVポップアップを無条件で不透明化**: `#streetview-panel` の base を `var(--popup-bg)`（rgba 0.72/0.74・backdrop-filter無し＝地図が透ける）→完全不透明 `var(--card-bg)` へ。head/nav の半透明はこの不透明ベースに合成される。
+- **② SV Coverage を実データで考慮**（前身の「⑤SVカバレッジ＝ベースマップ道路を水色化」を置換）: `open()` が素のクリック点に置くだけでGoogleの実パノラマ位置を偽っていた真因を修正。Googleの**実SVカバレッジ・タイル** `mts{0-3}.google.com/vt?…lyrs=svv&style=40,18`（ACAO:*・キー/UA/Referer不要・空域=68B）を(a)Coverageモードの**実オーバーレイ**に、(b)新 `IntMapStreetView.nearestCoverage()`＝現在ズームで3×3タイルを画素サンプリング（canvas getImageData・プロキシ不要）し**最寄coverage画素へスナップ**、無ければ正直に「ここにSV無し」（`imToast`5言語）、読取不能は素点フォールバック、(c)マーカーのドラッグ終了も同スナップ。実測: Times Sq 27m・Westminster 15m吸着、Pacific/Sahara=covered:false。出典・プライバシー（JP/EN）にカバレッジ・タイル追記。
+- **③④ タイムマシン国境の間欠不表示/不更新**: `IntMapTimeBorders.apply(fc)` の style未ロード時フォールバックがワンショット `map.once('idle')`（busyマップで永久未発火＝R41で潰した同型バグの残存）→ **`whenStyleReady()`（poll＋~6s hard-resolve）＋seqガード**へ。年変更ショートサーキット2箇所にも ensure()失敗時の一回リトライ。
+- **⑤ Atlas嘘ハイライト**: 返信が**実行前プランナの `say`**（過去形「ハイライトしました」）を無条件先頭表示していた→**全滅時 or 視覚アクション（highlight/outline/draw）失敗時は `say` 抑止**し既存の正直な警告を先頭化（`runActions`）。
+- **⑥ モバイル・ボトムシート同期＝R139修正がno-op**: maplibre 5.24.0 で `setPadding(e,t)=jumpTo({padding:e},t)`＝**瞬時**（第2引数はeventData）→R139の `{duration,easing}` は黙殺され padding が跳んでいた。**`map.easeTo({padding,460ms,同cubic-bezier})`** でロックステップ化、ライブは最新値rAF＋`dragStart`で `map.stop()`。デスクトップ・サイドバーの同型no-opも `easeTo` 化。実ソースで `setPadding=jumpTo`／`easeTo`のpadding対応を確認。
+
+---
+
+### #R139 補足（Companiesタブ新設＝Information廃止／モバイル描画・レイヤーFAB・ボトムシート同期／範囲人口の進行バー正直化／現在地ボタン・時刻タブ精緻化）
+
+ユーザー要望11件。全て `index.html` の追加/微修正（既存機能削除は明示指示の Information タブのみ・単一HTML温存）。`npm test` 緑（静的91＋security-logic＋Playwright 18/18）。詳細は DEV-NOTES R139。R138（IntMapSafe 等）の上に stack。
+
+- **Companies タブ（Information 廃止→置換）**: `window.IntMapCompanies`＝**厳選120社**（`ticker,name,nJp,cc,sector,domain,founded,employees,revB,niB,sharesB,mcapSnapB` の配列）。**時価総額はライブ**＝米国上場銘柄は `shares×live price`（下部ティッカーと同じ keyless Yahoo v8 chart＋CORSプロキシラダー・並行5・5分キャッシュ・進捗で再描画）、非米上場は報告値スナップショット。**サニティガード**＝ライブ mcap がスナップショットの0.2〜5倍を外れたら誤取得（銘柄取り違え/通貨/株数誤り）とみなしスナップショットへフォールバック（ランキングを壊さない）。`renderCompanies` は Countries と同形式（`.stats-toolbar` ソートプルダウン＝時価総額/売上/純利益/P-E/従業員/株価/設立/名称＋数値フィルタ＋`.stat-rank` 順位）を `#info-dashboard` に描画。**国旗のあった位置にロゴ**＝`logo.clearbit.com`→Google favicon→モノグラムの `onerror` カスケード。行クリックで `showCompanyDetail` オーバーレイ（全指標＋サイトリンク）。`renderDashboard()` は先頭で `renderCompanies()` に委譲（全呼出元＝タブ/ws窓/検索/Supabase/キャッシュが Companies を描画・旧ダッシュボードは dead code 化）。タブ `#btn-info`（id温存・mode文字列 `'info'` 温存）を `tabCompanies` へ改称（5言語）。Atlas＝`IntMapOS 'tab.info'` ラベル改称＋NL `companies/company/企業→tab.info`。CO_SECTORS/CO_CC は5言語。出典・プライバシーに Yahoo（企業株価）・Clearbit/Google（ロゴ）を追記。
+- **範囲人口の進行バー正直化（`window._imProgCtl`）**: 真因＝WorldPop 単一リクエストは進捗%が無い（task=created/finished のみ）のに、UIは**指数イーズアウト `0.92*(1-exp(-el/9))`＝100%手前で減速し無意味**だった。修正＝共有 `_imProgCtl(box)`＝`busy()` で**不定形アニメsweep（%非表示）**、実分数が判明した瞬間 `set(f)` で**実線形（単調）**（大面積のタイル分割は tiles-done/total、radius は circles-done/N・各円の内部タイルは帯へマップ）。measure/radius/Draw の3ドライバの偽ランプ＋`_setProg` を撤去。CSS `.tp-prog.indet .tp-prog-fill`（`imProgSweep` キーフレーム）。
+- **モバイル描画（`DrawTool`）**: 真因＝(1) MapLibre がタップから合成する `click` が開始直後のストロークを `finish()` して1点で終了、(2) ヒントが「タップ」なのに実装は press-drag 必須。修正＝`_touchTs` で touch 直後の合成 click を無視、bare tap は `armed` に**再arm**（死んだ1点stateを残さない）、ヒントを coarse pointer 判定で「押したままなぞる／指を離して確定」に（5言語）。
+- **モバイル レイヤーFAB着色（task5）**: `m-fab-map` の `.on` を**衛星ベースマップ→アクティブ層有無**へ。`_refreshActiveLayers` が `window._imActiveLayerCount` を publish し変化時に `window._imSyncMobile()`。`syncControls` は `(window._imActiveLayerCount||0)>0` で着色。
+- **現在地ボタン着色（task7）**: `IntMapLocate` の `.on` を**「追跡中」→「地図中心が現在地に一致」**へ。`_mapCenterAtFix`＝`map.project` の**画面ピクセル距離≤44px**（ズーム非依存）。`move`/`moveend` と各fix・start/stop で `_syncFab`。
+- **ボトムシート↔地図同期（task8）**: スナップ時の `map.setPadding` を **300ms/既定イージング → 460ms＋シートCSSと同一 cubic-bezier(0.32,0.72,0,1)**（新 `_cubicBezier` Newton-Raphson評価器）でロックステップ。ドラッグ中のライブ padding ゲートを **5px→2px**（中心が指を追従）。
+- **タイムマシン時刻タブ精緻化（task9）**: `_applyTimeOfDay` は **Year/Date で選んだ日付**に時刻を載せ、**今日は現在時刻以降を選べない**（`allowFuture:false`＋`_timeMaxMins`＝今日は now分・過去日は1439）。スライダ max と `#ntl-time` の max を `applyMode('time')`/`refreshUI` で追従（実測: 今日=727分キャップ、1990年=1439）。
+- **Countries順位デフォルトON＋iOS風数字（task3）**: `_showRank` を `!=='off'`（既定表示）、設定既定 'on'、`.stat-rank` を `ui-rounded/SF Pro Rounded`・weight600・tabular-nums。**Companies は順位を常時表示**（時価総額ランキングのため）。
+- **ニュース白黒ボタン・地点ピルaccent（task1/2）**: R137で既済を実測再確認（`.btn-read` `#fff`/`#000`、`.loc-chip` accent）。
+- 新 window.*: `IntMapCompanies`, `renderCompanies`, `showCompanyDetail`, `setCoSort`, `toggleCoSortDir`, `_coSf*`, `_imProgCtl`, `_imActiveLayerCount`, `_imLocSyncFab`。
+
+---
+
+### #R137 補足（モバイルUI微調整／Countries順位表示／現在地ライブマーカー／タイムマシン時刻タブ／Atlas逐語重複除去）
+
+ユーザー要望10件。全て `index.html` の追加/微修正のみ（既存機能削除なし・単一HTML温存）。詳細は DEV-NOTES R137。
+
+- **モバイル選択タブ = 白/黒**: `@media(max-width:768px) .mode-btn.active` を accent 塗り→`#fff`/`#000`（デスクトップ R130 と統一）。Atlas タブは高特異度ルールで accent グラデ維持。
+- **ニュースカード**: `.btn-read`（記事を読む）＝白背景/黒文字（`.mnp-read` も）、`.loc-chip`（地点ピル）＝`var(--primary-color)`（旧ハードコード青グラデ→accent 追従）。`.unmapped`/`.publisher` の状態色は据置。
+- **Countries カード**: モバイル `.stat-row` 縦 padding 15→8px。左端に順位番号 `.stat-rank`（19px・tabular-nums・行の最左）＝`renderStats` が `window.imShowRank==='on'` 時に `i+1`（現ソート/フィルタ順）を先頭差込。設定 `#setting-showrank`（Layout & panels・既定 off）→`window.imShowRank`（load/save/open/apply・`intmap_settings` 同期）・5言語 i18n。
+- **現在地 FAB＋ライブマーカー**: `#m-fab-locate`（`.m-fab`＝Map/Tools/Compass と同一UI・compass 直下）→ `window.IntMapLocate`。MapLibre レイヤー `imloc-dot`(accent 点+白縁)/`imloc-dot-halo`/`imloc-acc-fill`+`imloc-acc-line`（`turf.circle` 精度円）を `watchPosition` で毎fix更新＝**点も円もユーザー移動に追従**。accent は `getComputedStyle('--primary-color')` を都度読取、style スワップに `styledata` で再アサート。Atlas `locate` も成功時に `IntMapLocate.start({fly:false})` 併発。新 window.*: `IntMapLocate`。
+- **タイムマシン コンパクト（モバイル）**: `@media(max-width:768px)` 拡張＝`.news-timeline .ntl-body` 幅 314→`min(290px,100vw-20)`・gap 5px、`.ntl-bigval` 26→20px、mode/now/inputs/scale/synced/chip 縮小。
+- **タイムマシン 時刻タブ**: `.ntl-modes` に `#ntl-mode-time`（時刻/Time/Zeit/Время/Hora）＋`#ntl-time`。`.ntl-mode.on` を accent→**白/黒**。`applyMode('time')`＝スライダ `0..1439`(分)・時刻ピッカー。書込 `_applyTimeOfDay`＝現在選択日（ライブなら今日）に時刻を載せ `IntMapTime.set(base,{allowFuture:true})`。**時刻依存の利用可能データ＝昼夜ターミネータ**が同期（Earth-Replay `_terminatorFC` 流用の `imtm-night` レイヤーを Time タブ表示中のみ描画）。iso(日)不変でニュース再取得スパム無し。
+- **Atlas 逐語重複除去**: 全AI自然文整形 `mdMini` 冒頭に純関数 `_dedupText`（段落＋文を正規化キー・長さ閾値15で去重・末尾空白保持で再結合＝略語/小数を壊さない）。node で10ケース実測。
+- **検証**: `npm test` 緑（静的83＋Playwright 11/11）。DOM/計算スタイル/純関数をヘッドレス実測（map は `document.hidden`/WebGL未init）。**新教訓: hidden ペインは CSS トランジション未進行 → 既存要素に class 後付け→`getComputedStyle` は遷移開始値を読む。ルール検証は fresh 要素生成で。媒体クエリは特異度を上げない（`.ntl-body` 後方グローバルに負けるので `.news-timeline` 前置で勝たせた）。**
+
+---
+
+### #R136 補足（昔年代クリックの塗り不一致／Atlasハイライト精度／歴史データ拡充）
+
+- **昔年代クリックの Compare ハイライトが誤国**（「1920sポーランドをクリック→ポーランド判定なのにドイツがハイライト」）: 真因は**検出と塗りが別ロジック**だったこと。検出 `resolveHist` は era feature の `_gw`（Gleditsch-Ward, 1925 Poland=290→POL）で正しく解決するが、Compare の塗り `IntMapTimeBorders.geomForCode(code)` は `_gw` を使わず **MODERN 国外形の内部点を多数決**しており、1925 の modern ポーランド西部（当時 Weimar ドイツ）に票が集まって **Germany のポリゴンを返していた**。修正＝`geomForCode` を**検出と同一解決に統一**（新 `_eraCodeIndex`＝各 era feature を `resolveHist` で解決した `code→features` マップ／`_unionGeom` で合成）。ただし**被覆ガード** `_bbCoverFrac`＝index結果が modern 国 bbox の30%未満なら「吸収された国の断片」（1925 RUS=Karafuto 欠片）として従来の多数決へフォールバック（RUS→ソ連全域を維持）。実測: 1925/1914/1938 で POL→ポーランド・DEU→ドイツ・RUS→ソ連 extent、SUN 等の多継承 former state は hbRe 早期パスで不変。
+- **Atlas「○○をハイライト」の見当違い**（ログアウト時の Nominatim 経路＝Web検証なしの欠陥を `IntMapAtlasDebug.resolveHl` プローブで実測特定）: `_nomExtent` に (a)`accept-language`（UI言語+en＝英語exonym「Tuscany/Persia」が地域のローカル名と突き合う） (b)**完全名一致ボーナスを重要度でゲート**（上位重要度から0.25以内でのみ0.5・下は0.08＝低重要度の同名村が Iran/伊トスカーナを食わない・大阪湾の近接タイブレークは温存） (c)**微小集落ガード**（anchor無しで hamlet/suburb 等かつ重要度<0.35 は正直な miss）。`resolveCountrySync` は**非主権ミクロ地物（`sov===false`）をゆるい部分一致で拾わない**（「Patagonia」→氷原コードSPIを解消）。`resolveHlTarget` に **curated macro-region ガード `_curatedOk`**（curated 名は範囲外の同名／範囲15%未満の微小sub-feature を棄却し gazetteer 箱へ＝Patagonia→南米、Sahel→ベルト全体）。`REGION_BBOX`＋Manchuria/Anatolia(Asia Minor)/the Levant 等＋5言語エイリアス。
+- **歴史データ拡充**: 1943 CShapes 全169 feature を `resolveHist` 監査→植民地/自治領の**modern記事フォールバック**を特定し、**en.wikipedia API で実在検証**した上で `_ERA_WIKI` に植民地期記事12件（GMB/SLE/MUS/MDV/FJI/CPV/GNB/GNQ/TLS/SLB/PNG/KWT・各独立年で終端）を追加。**`_VANISHED` に Dominion of Newfoundland**（`_GW2ISO(21)=CAN` に畳まれていた自治領）を独立identity化＝5言語名＋Union Jack 旗（新 `F_UNIONJACK`）＋`Dominion_of_Newfoundland` wiki（統計なし＝code=null の正直表示、Danzig型）。
+- **検証**: ヘッドレスでデータ層を全項目実測（地図描画は `document.hidden`/WebGL未initで不可＝R129〜R132と同様データ層で担保）。`npm test` 緑（静的83＋Playwright 11/11・AtlasQA 40/40・RegionResolver 13/13）。
+
+---
+
+### #R135 補足（Atlas 時間軸リサーチ・マッピング＝`researchMap`／Request Profile／能力レジストリ／意味的リトライ）
+
+**直接原因**: `mapReport` はプランナー上「調査結果を地図に出す汎用アクション」に見えるが、実装は **GDELT/Google News/読込済みニュースから現在の具体的事件を抽出する“ライブニュース専用”機能**。表示年1900で「当時のオホーツク海はどんな状況？地図で教えて」が `mapReport` に送られ、ライブニュース不在で失敗→repairが**表記だけ変えた再試行**（オホーツク海→Sea of Okhotsk→Okhotsk Sea）→**世界全体の1900年同盟地図へ範囲拡張**→ライブ不足警告の反復、という連鎖を起こした。これを**特定地名のハードコードではなく汎用の仕組み**で防止。
+
+- **Request Profile（`_requestProfile(q)`・純粋関数）**: プランナー呼出前に軽量な構造を生成＝`{temporalMode:historical|current|mixed|unspecified, targetYear, temporalSource:explicit|map-state|conversation|none, geoKind:water|region|city|historical-entity|unknown, evidenceMode:historical|live|mixed|none, outputs:{explanation,map,comparison}}`。**時間軸の優先順位**＝①入力内の明示年 ②「当時／この時代／そのころ」＋タイムマシン有効なら**表示年（`IntMapTime.year()`）** ③会話年（`_wctx.year`） ④表示年（非明示・非現在語） ⑤なし。**「今／最新／current」等は表示年より優先**して current に落とす（1900表示中でも「今のニュース」はライブへ）。`buildPrompt()` に **`[REQUEST PROFILE]` ブロック**（機械可読ヒント＋強制ルール）を `[CURRENT MAP STATE]` に続けて注入。
+- **`mapReport` の責務明確化**: 実装は不変（後方互換）。SYSでの意味を **「current/recent・dated・ライブニュース裏付けの事件のみ」** に限定し、過去年代・歴史背景・当時の勢力/交易/戦略的重要性・現在ニュースを要求しない安定知識には**使わない**ことを明記。
+- **`researchMap`（新アクション・historical/current/mixed）**: `{type:"researchMap",topic,place,temporalMode,year,evidenceMode}`。**文章と地図を独立生成**（§11）＝地図描画に失敗しても説明は返す。証拠は**モードで切替**（§6）＝historical は確立された歴史知識＋Wikipedia（**ライブニュース不使用**）、current はGDELT/Google News/読込済み、mixed は両方を明確に分離。`ai-proxy` の新タスク **`research_map`**（`JSON_TASKS`・`reasoning:medium`・`max_output:2600`・webMode は Profile 由来＝historical は topic の任意Web検証のみで現在ニュース非注入）が `{title,explanation,temporalBasis,items[],limitations[]}` を返す。**AIに座標を書かせない**＝`locationName+country` をクライアントで geocode。地図フォールバック（§8）＝実extent/bbox→中心→関連地点ピン。海域はポリゴン取得を成功条件にしない（`placeExtent`＋既存 `IntMapRegionResolver` を再利用）。
+- **能力レジストリ `ATLAS_ACTION_CAPABILITIES`（§7）**: 各アクションの本来能力（temporalModes/evidenceModes/outputs/geoKinds/topics）を小さく定義。
+- **実行前プラン検証 `_validatePlan(acts,profile,q)`（§7）**: 実行前に不適合アクションを**書換／追加**（repairで事後修復しない）＝①historical質問がライブ専用 `mapReport` へ→`researchMap`(historical, year保持) ②海域/地域/都市の局所質問が世界同盟地図(`historicalMap`, 非alliance)へ→`researchMap` ③説明要求なのにナビのみ→`researchMap` を追加。同盟/大戦/冷戦などの真の勢力図 `historicalMap` は温存。
+- **意味的リトライ制御（§10・§13）**: repair を **JSON完全一致でなく意味キー**で制御。`_researchFamKey`＝family+temporalMode（target非依存）で **翻訳だけの再試行を1回に畳む**。repair アクションも `_validatePlan` を通す（historical→live や 局所→世界 を禁止）。`_isWorldExpansion` で世界/大陸への範囲拡張を拒否。repair は **最大2巡**（旧3）、「近くの著名地／粗い対象」誘導を撤去し**元対象を保持したまま一段だけ拡張**に限定。地図描画失敗を回答失敗として扱わない。
+- **構造化結果 meta（§9）**: `R(ok,html,{meta})` に `{code(NO_LIVE_EVIDENCE/NO_HISTORICAL_EVIDENCE/PLACE_NOT_FOUND/NO_MAPPABLE_ITEMS…), category, retryable, semanticTarget, temporalMode, produced[], userGoalSatisfied}`。`runActions` が各アクションの結果を `_atlasOutcomes` へ収集。
+- **事後 Goal Validation（§12）**: `_goalValidation(profile,outcomes)`＝`{actionSucceeded,mapRendered,explanationProduced,geographicRelevance,temporalMatch,userGoalSatisfied}`。**「世界同盟地図の描画に成功＝オホーツク海の状況説明に成功」とは判定しない**。
+- **複合回答の統合（#R159・`runActions`／`_atlCompose`）**: `runActions` は各アクション結果を無条件連結せず **`ai.__atlResults` に記録**し、`_atlCompose(ai)` が **`_atlGoalKey`（回答系を正規化トピックで grouping・repair答は `__goalKey` 継承）＋`_atlGoalScore`（ok＋userGoalSatisfied＋produced explanation/map・partial減点）で目的単位に最良の1件だけ確定表示**。repairループは**破線dividerの別 `div` を廃止**し `runActions(ai,…)` で同一バブルへ再実行＝**成功した修復が失敗した元回答を置換**（「最初の分析＋修復後の分析の矛盾併存」を解消）。fail サマリから `actLabel`（`mapReport "Taiwan"` 等の内部名/コード/repair回数）露出を撤去。地図描画のみの失敗は分析本文を失敗扱いにしない（`researchMap` は text成功時 `ok:true`＋`produced:['explanation']`＋「地図表示のみ更新不可」を返す）。
+- **Atlas返答タイポ（#R159）**: `mdMini` は本文に**太字を出さない**（インライン `**`＋表セル→プレーン、見出し `#/##/###`＋lead は 750/800→**600 semibold**、`.atl-md-table thead th` 700→600）＋**`##` の上罫線 divider を撤去**（横線ゼロ）。色は `--text-main` のまま（R154）。
+- **デバッグ（§17）**: `window.IntMapAtlasDebug.lastPlan()`＝`{requestProfile,originalPlan,validatedPlan,rejectedActions,actionOutcomes,semanticRetries,scopeChanges,finalGoalValidation}`（通常UI非表示）。
+- **テスト**: `window.IntMapAtlasQA.run()` に R135 の純関数テスト21件を追加（**実測40/40 PASS**・従来19＋新21）＝時間軸判定（当時/1900、今→current、比較→mixed、明示1750、会話年）・地理kind・プラン検証（mapReport historical→researchMap／海域 historicalMap→researchMap／WWI同盟図温存／current mapReport温存／ナビのみ→researchMap追加）・翻訳リトライキー畳込・世界拡張ブロック・レジストリ・profileブロック・goal validation。実サイト（1900表示）で「当時のオホーツク海…」の Profile＝`historical/1900/map-state/water/explanation+map`、検証で `mapReport→researchMap(year=1900)` を実測確認。
+
+---
+
+### #R132 補足（汎用地域解決基盤 `IntMapRegionResolver`・Atlasタブ色・Objects直下ポップアップ・昔年代クリック・FS中ハイライト非表示・歴史Wiki拡充）
+
+- **汎用地域解決基盤 `window.IntMapRegionResolver`**: 未登録の自然/非公式/歴史/経済地域名（East European Plain・関東平野・パンノニア平原・チベット高原・レバント・ドンバス・サヘル・肥沃な三日月地帯…）を、**AIに境界座標を書かせず**実データで解決する汎用基盤。`resolveHlTarget` の**fuzzyテール**（旧 `aiRegionUnits`/`aiRegionPoly` の幻覚経路）をログイン時のみ本基盤へ置換（ログアウトは従来経路へ fail-open）。
+  - **サーバ**: `ai-proxy` に `geo_resolve` タスク（`JSON_TASKS`・`reasoning:"medium"`・`max_output:1800`・`webMode:required`強制）。**構造化メタデータのみ**を返す（`canonicalName/aliases/featureType/ambiguous+candidates/expectedCountries/representativePoint/expectedBbox/geometryStrategy/osmName/adminUnits/mustInclude/mustExclude/boundaryAnchors(時計回り)/confidence/sources`）。最終ポリゴンの頂点列は返さない。
+  - **クライアント配管**: `aiCallServerFull()`＝呼び出し単位の `{text,meta,citations}` エンベロープ＋`opts.signal`（実Abort）。`askAIEnvelope`/`askAIJSONEnvelope`。`aiCallServer` は薄いラッパで全既存呼び出し不変。`geoVerify` は 9秒 Promise.race を廃止し**本物の AbortController**（タイムアウトで fetch 中断・`meta.webUsed` はエンベロープから）。
+  - **解決ラダー（実データ最優先）**: `country`→`admin_union`（`composeRegion`）→`osm_polygon`（`_nomExtent` を representativePoint でアンカー）→`derived_anchors`（Web検証済みアンカーの順序リング→`turf.kinks`自己交差check→凸包、expectedBbox クリップ、`webUsed`必須）。**bboxを境界として塗る処理は撤去**（bboxは検索/選別/fit/検証のみ）。
+  - **検証ゲート `_rrValidate`（fail-closed）**: Polygon/MultiPolygon・座標有効・全世界blob棄却・面積下限・expectedBbox重なり≥0.12・mustInclude内包≥60%・mustExclude侵入≤15%・expectedCountries一致（`codeAtPoint`）。R130の中心距離方式（巨大ポリゴンほど許容も巨大）を置換。通らなければ描画せず正直に失敗。
+  - **曖昧性**: `ambiguous+candidates` を返し、ハイライトdispatchが候補提示（`lastCountry` 一致時のみ自動確定）。
+  - **キャッシュ**: セッション `Map` ＋ IndexedDB `intmap_regionresolver`（`_RR_ALGO`＋TTL 成功90日/否定7日）。
+  - **AI回数**: fuzzyテール=`geo_verify`（安価）＋`geo_resolve`（medium）各1回・以降キャッシュ0。
+  - **Atlas表示**: 「実際のOSM境界データから描画」「N行政区画の実境界を合成」「⬡ Web検証済み境界アンカーから構築した近似範囲」「曖昧なため未描画—候補提示」を返答に明示。
+  - **デバッグ/テスト**: `window.IntMapRegionResolverDebug.last`／`window.IntMapRegionResolverTest.run()`（純粋関数13項目・**実測13/13 PASS**）。
+- **Atlasタブ色（`#R114/#R130`再修正）**: 共有トークン `--atlas-grad = linear-gradient(135deg, var(--primary-color), #5e5ce6 56%, #bf5af2)`（アクセント先頭の3ストップ）で**デフォルトアクセントでも単色化しない**＆任意アクセント追随。アクティブタブ・非アクティブ枠(`::before`)・ユーザー吹き出し `.atl-b.u`・モバイルを統一。
+- **Objectsポップアップ直下化**: `IntMapObjects.open()` に `_placePanel()`＝`#btn-tool-objects` の rect に右揃え＋直下(+8px)。モバイルFAB時はFAB直上。`data-dragged` 尊重・画面内クランプ。
+- **昔年代クリック（再々報告）**: `IntMapTime.setYear()`実ロードで 1919〜1938 全年 Poznań→Poland（Warsaw/Kraków/上シレジア/回廊も POL）を turf-PIP+`resolveHist` で**実測＝正答**。Wrocław/Szczecin→Germany・Danzig→Free City は**史実どおり正しい**（1920年代独領）。残る理論的穴＝era解決失敗時の現代 `countryGeo` フォールバックを封鎖し、**旅行中はフォールバックせず** `{eraLoading}`/`{code:''}`＋「読込中—もう一度」トースト（`resolveAt`・`_pickResolve` 両ピッカー）。
+- **FS中ハイライト非表示**: `_fsStashLayers` の `typeof clearHl==='function'` は別クロージャの関数で恒久 no-op だった。`_fsHideHl`/`_fsShowHl` で overlay 群（`place-hl-*/nlq-fill/nlq-line/nlq-poly-*/nlq-choro/pl-outline-*`）を `visibility:none` 退避→着陸で復元（start/stop の stash/restore へ結線）。
+- **歴史Wiki拡充**: `_ERA_WIKI` に HRV(独立国1941-45)・SGP/BLZ/GUY/SUR/ZMB/MWI/BWA/LSO/SWZ/UGA の植民地期実記事（全て新規キー・ポップアップが存在プローブ）。実測: 1943 Zagreb→`Independent_State_of_Croatia`。
+
+---
+
+### #R131 補足（`analyze` の鮮度検証・日付/証拠の意味づけ・多国カバレッジ・Web検証引用）
+
+「中央アジア直近72時間の監視判断」誤答（対象期間外の7/7事件を直接的証拠に使用・記事公開日を事件発生日と混同・見出しから国家間衝突と断定・燃料報道の過剰解釈・5か国中3か国のみで結論）を、**推論処理を増やさず**（AI呼び出しは従来どおり 1回・reasoning effort は medium 据置）、既存の Hosted Web Search / meta.webUsed / 引用annotation / 並列検索を**正しく接続**して根治。
+
+- **鮮度重要質問の Web検証強制（`_analyzeFreshness`）**: `analyze` は常に `webMode:"auto"`（検索は任意）だった。明示的時間窓（`_FRESH_NUM`＝「72時間/48h/直近N日」等）・最新/現在/直近（`_FRESH_NOW`）・監視/警戒/脅威度（`_FRESH_MON`）・ファクトチェック（`_FRESH_FC`）・直接的証拠/確認済（`_FRESH_DIRECT`）を5言語で検出し、`freshness.critical` なら `webMode:"required"`（検索を強制）。安定知識質問（文化/歴史/科学）は `false`＝従来どおり `auto`（応答時間・回数不変）。実測: 監視/最新/現職/FC/N時間=critical、文化/歴史/GDP比較=非critical。
+- **実クロック＋要求ウィンドウ（`_nowContext`）**: 旧プロンプトは `toISOString()` の**UTC日付のみ**（JST 0-8時は前日）で時刻もウィンドウも無し。`Intl.DateTimeFormat('sv-SE', {timeZone})` で**ローカル現在時刻＋タイムゾーン**を渡し、明示窓があれば `Requested evidence window: <now−窓> through <now>` を `[TIME CONTEXT]` に付す（テスト用に nowMs 注入可）。
+- **日付種別を明示した構造化証拠（`_analyzeEvidence`/`_evidenceBlock`）**: 3つの無日付見出しダンプ（loaded/GDELT/Google News）を、**1つの `[NEWS EVIDENCE]`**（新着順・`[eN]`ID・`article_date`＋`date_type`（publication_date／gdelt_seen_date）＋`event_date: unknown`）へ統合。各フェッチャ（`_gdeltNews`/`_gnewsNews`/`_newsData`）の srcSink push に `dateType`/`origin` を付与。モデルは**記事日付を事件日と誤認できない**。
+- **多国検索が最初の国へ縮まない**: 旧コードは `topicEn` を `codes[0]` の英名で上書き＝「中央アジア(5か国)」が Kazakhstan のみ検索。→**地域**GDELT＋**要求国のOR**GDELT（`("Kazakhstan" OR … OR "Uzbekistan")`）＋ユーザー言語Google News の3系統（GDELT2件はGDELT自IPレート配慮でジョブ内直列）。`[REQUESTED COVERAGE]` で要求国一覧を渡し、証拠が無い国は明示させる（単一国は従来挙動不変）。
+- **分析プロンプト全面改訂（`_analysisSystemPrompt`）**: 公開日/GDELT seen date ≠ 事件日／見出しは lead であり当事者・因果・国内 vs 国家間・分類を推定しない／深刻な見出し=escalationの証拠ではない／「問題を報じる記事」≠「危機が発生」／監視判断は対象窓内に確認済み事件が無ければ**低アラート（維持）を優先**／定例外交会合は短期リスクの**弱い反証**／直接的証拠・未確認兆候・背景・反証を**分離**／多国は情報不足国を明示／**ユーザー指定の出力形式を語数制限（~230語目安）より優先**／誤った "sorted newest-first" 記述を撤去。
+- **webUsed で暫定表示（最優先2）**: `freshness.critical && !meta.webUsed`（検索が走らなかった／タイムアウトでtool-free fallback）なら回答下に**暫定評価バナー**（5言語）＝見出し中心の暫定評価で確認済み直接証拠ではない旨。`webUsed` 実行時のみ「使用データ」に「ライブWeb検証」を加える（未実行を検証済みと偽らない）。
+- **ai-proxy: Web検索引用の保持＋返却（最優先3・デプロイ済）**: `callOpenAI` が Responses API の `output_text.annotations`（`url_citation`）を捨てていた。`{url,title,startIndex,endIndex}` を抽出（重複除去）→ callOpenAI 返却値＋成功レスポンス top-level `citations` に追加。client `aiCallServer` が `window._aiLastCitations` へ格納。`analyze` のソースカードは **①Web検証済み（url_citation）→②モデルが引用した収集記事→③その他の収集記事** に分離表示（収集しただけを回答根拠と同列に並べない）。
+- **プランナー**: `analyze` 説明に「名前付き多国地域／明示国セットは `place` に加え `countries` に**実際の構成国**（英名・地理知識）を入れ、`question` は完全な質問を保持」を追加（中央アジア専用コードは足さない）。
+- **回帰テスト（`window.IntMapAtlasQA`）**: 時計（2026-07-18 05:00 JST）と3見出し fixture（Kyrgyz-Uzbek国境27名拘束=seen 07-16／Kyrgyz-Tajik燃料=07-15／EU-中央アジア定例対話=07-16）を固定し、freshnessCritical・webMode=required・72h窓算出・全項目 event_date:unknown・date_type種別・国境記事がlead扱い・5か国カバレッジ明示・プロンプト各規則・単一AI呼び出しを**19項目全PASS**でヘッドレス検証。
+
+### #R129 補足（範囲人口Progress・戦間期ユーゴ・モバイル分類名・Countriesクリック国選択・歴史拡充）
+
+- **範囲人口 Progress バー（数十%→0%再スタートの根治）**: `IntMapPopArea` のコア（`done/cells.length`）は単調で正しい。UIの2ドライバ（時間ベースの漸近ランプ Driver A ／ 実タイル進捗 onProg Driver B）の**引き継ぎが非単調**だったのが原因＝大面積で最初のタイル完了に5-30秒かかる間にランプが数十%まで登り、onProg発火時に`1/タイル数`(≈3%)へ**逆戻り**していた。**#R129**: 表示フラクションの最大値を保持する `_sp`（`Math.max(shown, …)`）で単調化し、実進捗をランプ引き継ぎ点より**上の帯 `[hand,1]` に再マップ**。measure/area パネル(`#tp-pop-btn`)と自由描画パネル(`_estimateDrawPop`)の両方。実測（ロジック検証）: ランプ51.6%→引き継ぎ後52.5→…→100%、逆戻り0回。
+- **戦間期ユーゴスラビア王国 `IntMapHistStates`（クリック国選択の断片化を根治）**: CShapesは戦間期ユーゴを1ポリゴン「Yugoslavia」(gwcode 345)で描くが registry が SFRY(1945+)のみで**戦間期にエントリ無し**→クリックが現代の Serbia/Croatia/Slovenia… に**断片化**（オーストリア=ハンガリー/チェコスロバキアは単一エンティティに解決されるのに、である）。**#R129**: **Kingdom of Yugoslavia**（`code:'YGK'`, 1918-12-01〜1945-11-28, 5言語名・王国旗`F_YUGK`・`wiki:'Kingdom of Yugoslavia'`）を追加。`madCode:'YUG'` で Maddison の連続YUG系列を再利用（後継国に戦前データが無いため）。SFRYと時間的に不重複＝`activeAt()`が同時に両方を返さないので同一名衝突なし。`agg` に `madCode` サポート、`_eraLocName` は**存続期間一致を優先**（1925ラベルがSFRY名に化けない）。実測: ベオグラード/ザグレブ/リュブリャナ/サラエボ/スコピエ 1925 → すべて **Kingdom of Yugoslavia**（データ 1925=13.4M/$23.5B・1938=16.1M/$32B, Maddison実値）。SFRY(1960)・A-H(1914)・チェコスロバキア(1925)は不変。
+- **Compare クリック国選択の当時ポリゴン優先（`_pickResolve` ／ 新Countries picker）**: **#R129**: era PIP を**最小面積の内包地物**に（簡略化された当時ポリゴンが国境で重なるケースで大きな隣国を誤取得しない＝ポーランド東部Kresy→USSR誤判定を防止）。従来は最初の内包地物を採用していた。
+- **Countries 初期画面のクリック国選択ボタン**: 検索欄の右にクロスヘア（`#csearch-pick`／ws-mode `#csearch-pick-ws`、5言語 `pickCountryMap`、`flex:0 0 auto`で改行なし）。従来は開いた比較ウィンドウ内の◎のみで、初期画面のマップクリックは**現代ポリゴンの `showCountryDetail`**＝タイムトラベル中も現代国を選んでいた。**#R129**: 新picker は `resolveHist` で**era対応**解決（王国・植民地・帝国）→`_toggleCompare` で比較セットへ。`window.__scpPick` を立てて既定の country-fill / handleMapClick を抑止、ESC/再クリック/タブ離脱で解除。`renderUI` が Countries タブ時のみ `.on-tab` 表示。
+- **歴史データ拡充（継続）**: (名/旗/統計) 上記 Kingdom of Yugoslavia（王国旗・5言語名・Maddison実データ）。(Wiki) `_ERA_WIKI` にアルバニア(共和国1925-28/王国1928-39/社会主義人民共和国1946-91)・アイスランド王国・モンテネグロ王国・ネパール王国・スウェーデン=ノルウェー連合・ラオス王国を追加（全て en.wikipedia 実在をAPI確認）。
+- **#R130 素のマップクリックのera対応化（昔年代クリックの真の根治）**: R122〜R129はクロスヘアpicker/`resolveHist`（既に正しかった）を直していたが、ユーザーの実ジェスチャー＝**素のマップクリック**は era非対応の `country-fill` click ハンドラ（`resolveCountryId`→現代countryGeo）が処理していた。→タイムトラベル中は picker と同一の `TB.currentFC()` 最小面積PIP→`resolveHist` を通し**現代ポリゴンに絶対フォールバックしない**（都市ラベル下は場所優先、コードあれば `showCountryDetail(era)`、コードなし実在エンティティは `_imPlacePopup`）。hover も旅行中は現代国の強調/情報を出さない。実測: 1925 ルヴフ/ヴィリニュス/ポズナン→**POL**、ヴロツワフ→DEU(Weimar)、ダンツィヒ→Free City of Danzig。
+- **#R130 消滅国4件を `_VANISHED` に昇格（wrong-carrier根治）**: `_GW2ISO`（step2.4）が East Germany(gw265)/South Vietnam(817)/South Yemen(680)/Danzig(291) を現代キャリアに畳み、クリックで**現代旗＋間違ったera記事**になっていた（東独→西独記事等）。`_VANISHED`（step2b, gwcodeより先発火）に4件＋インラインSVG旗（F_DDR/F_RVN/F_PDRY/F_DANZIG）を追加し identity/旗/Wikipedia を正す。`IntMapHistId` に West Germany(1949-90)・Pahlavi Iran(F_IRPAHL, Persia を to:1925短縮)・Francoist Spain(F_ESPF)。`agg()` が空欄だった capital/currency/languages を `_STINFO`（15カ国）でマージ。`_ERA_WIKI` に Cambodia/Oman/Trucial States、`_ERA_LOC` に南北ベトナム/南北イエメン。
+- **#R130 Atlasハイライトのweb検索検証**: ラダーは Nominatim importance と web盲目AIトレースを無検証で信頼し「塗れば✦成功」だった。ai-proxy に `geo_verify` タスク（webMode:required・JSON・低予算）追加→**デプロイ済**。client `geoVerify(name)` が権威座標を取得（9sタイムアウト・キャッシュ・**fail-open**）→`_nomExtent(place,anchor)` の近接ボーナスで8候補から検証点に最近を選抜（同名語撃退）＋未信頼ラング（Nominatim水域/adminポリ・AIトレース・codeAtPoint）で `_geoAgrees` により明白な位置不一致を棄却（`_gvStrong`=webUsed必須でなければ棄却せず既存挙動維持）。報告に「✓ location web-verified」。
+- **#R130 その他UI**: Objectsボタンを左下FAB→右上ツールバー `#btn-tool-objects`（`objectsBtn` 5言語、`tickFab`が配線・カウント同期・オブジェクト有時のみ表示、FABはモバイル限定）。サイドバーAtlasの`addEdgeResize`辺リサイズを `_inWsWin2` に `atl-tab` skip追加で無効化（width:100%と競合しての「変なことになる」を根治）。Atlas thinking を `stageDots/setStage/_STAGE_OF` で実作業表示（Thinking/Searching/Analyzing/Mapping/Writing・5言語）。通常モード Measure/Radius の使用中(`#…​.tool-on`)を白背景黒文字（Grid/Draw不変）。左タブ News/Info/Countries active=白背景黒文字・Atlas active=`.atl-b.u`と同じアクセントグラデ。地図の国名ラベル3層（ofm-country/imtb-lbl/imtb-lbl2）の `text-transform:uppercase` 撤去で全大文字廃止。位置情報許可ボタン=1回grantで全ウィジェット再描画＋太字解除。
+
+### #R128 補足（再報告4件の根治・上記各モジュールの現状）
+
+- **範囲人口 `IntMapPopArea`（大面積失敗の根治）**: 真の失敗モードは**`fetch()`にタイムアウトが無い**こと＝WorldPop公開APIが負荷時に接続をストールさせると`Promise.all`バッチ全体が数分凍結し「失敗」。**#R128**: `_fetchT`＝AbortController付きfetch（create 30s/poll 18s中断）、固定バッチ→**staggered worker pool**、**CONC 4→2**（多タイルの持続負荷でレート制限されるため）、retry 2→4・長バックオフ、単一ポリゴンもリトライ経由、極小クリップ片(<0.05km²)スキップ。正直partialは維持。実測: 290,851km²→6/6タイル・25,316,807人・64秒（ハング根治）。
+- **昔年代クリックの決定論解決 `IntMapTimeBorders.resolveHist`**: 全CShapes era featureは`properties._gw`（Gleditsch-Wardコード）を持つが両呼出元で捨てられていた。**#R128**: `data/cshapes.js`由来の**`_GW2ISO`表（235件・単一継承コードのみ）**を追加し、step2.4＝`_gw`→現代キャリアを**境界/名前非依存**で直接解決（step1帝国・`_VANISHED`の後、BEC/PIPの前）。改名/**領土変化**国の長い尾（独帝国のポズナン/アルザス→DEU、植民地→現代後継）をPIPフォールバックに頼らず根治。多継承帝国(A-H 300/CSK 315/YUG 345)とTibet(711)は非収載でstep1/`_VANISHED`優先、`_histHidden`ガードで能動的帝国下の後継はstep3bへ委譲。実測: ポズナン→DEU（PIP=POL）。
+- **レイヤー分類名（通常モード）**: 通常/デスクトップ`.lyr-head`・`.layer-group-title`。**#R128**: 12.5px/600/muted（配下の行`.layer-option`13px/500/text-mainより小さく薄く、見出しが下位に見えた）→**15.5px/700/text-main**・上マージン14pxで明快なヘッダに（モバイル18.5px `!important`は不変）。
+- **歴史データ拡充（継続）**: (旗) `_VANISHED`の3消滅国（Tibet/East Turkestan/Manchukuo）にインラインSVG旗を追加し`resolveHist` step2b が`out.flag`を渡すよう配線（従来は旗皆無）。`IntMapHistId`のHUNに戴冠紋章旗`F_HUNK`。(統計) `IntMapHistStates` JEM（大日本帝国）に`popEst:105M/gdpEst:230/estSrc`（pre-1945後継sum崩壊の帝国推計override）。(Wiki) `_ERA_WIKI` +14（残ソ連構成共和国9＋AFG/YEM/ERI/PSE、全て実在確認）。(名) `IntMapHistId`にKOR（大韓帝国）/ETH（エチオピア帝国・帝政三色旗）の年代identity。
+
+### #R127 補足（再報告根治・上記各モジュールの現状）
+
+- **範囲人口 `IntMapPopArea`**: WorldPop 100m グリッド集計。95,000km² 超は `turf.bboxClip` でサブ上限セルにタイル分割→合算。**#R127**: 旧80セル上限を **340**（≈30M km²＝どの単一国も収容）に引き上げ（米本土48州=189/東南アジア海域=195セルは旧コードで throw していた）。各タイルは `_tileWithRetry`（60s×2回）で一過性のレート制限/タイムアウトを再試行し、**失敗タイルを0として黙殺しない**＝全失敗は throw、一部失敗は `partial:true`（件数明示・キャッシュしない）。実測: 欧州451k km²→8/8タイル・87,805,246人。
+- **Atlas 地図オーバーレイのメッセージ別トグル**: 種別ごとに共有 `nlq-*` キャンバスを1メッセージが所有（`_ovlOwn`）。**#R127**: 新描画が共有キャンバスを奪う **`runActions` の描画経路**で、所有権再設定の前に**旧所有者をそのスナップショットから自前のクローン層（`atlm<n>-*`）へ退避**（`_ovlCloneShow`＝R125で手動クリック経路が検証済の同一機構）。→ 新旧が共存し両チップともON（「新規追加で古いものが勝手にオフ」を根治）。
+- **ニュースピンの重複分散 `_spreadDupNewsPins`**: 同一アンカーに積み重なるピンを領域内に散布。**#R127**: `regionFor` が**最大リング（本土）のbbox+ポリゴン**も返し、全体bbox幅>180°（日付変更線アーティファクト＝米/露/フィジー/NZ）なら**本土リングでサンプル**（旧: 全体bbox=幅358.9°で44回中2回しかヒットせず0.12°の点に退化）。各ピンの原座標を `__oc` に保持して散布を**冪等化**し、`countryGeo` ロード完了時に `_respreadNews()` で再散布（コールドロード競合を根治）。実測: 米本土リングで30/30配置・経度41.5°×緯度17.5°。
+- **モバイル通常モードのレイヤー分類名**: `.m-sheet .lyr-head`。**#R127**: 16px（行15.5pxとの差+0.5px）で埋没していたため **18.5px/700**（行比+3px）に、上下マージン27/11pxで明快なセクションヘッダに。
+
+---
 
 *変更履歴の詳細は `DEV-NOTES.md`、守るべき原則は `CONSTITUTION.md` を参照。*

--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -2,6 +2,141 @@
 
 > A living record of *why* things are the way they are, so future sessions (human or AI) have context.
 > Keep this in sync with the code. Inline code comments reference task tags like `(#NN)`.
+>
+> ### この文書の構成 (#R169 で明文化)
+>
+> このファイルは**歴史的な事情で2つの部分がつながっている**。読む前に順序を知らないと混乱するので、
+> ここに書いておく（#R169 まで、どこにも書かれていなかった）。
+>
+> 1. **上半分（このすぐ下 〜 「R86」まで）＝ 新しい順**。1ラウンド1見出し `## R<番号> — 要約`。
+>    **新しいラウンドはファイルの先頭に足す**（標準指示 9「prepend」）。
+> 2. **下半分（`## 1. What IntMap is` 以降）＝ 古い順**。プロジェクト初期の元ノートで、
+>    番号付きの節（`## 1.` 〜）と Round 1〜85 が**古い順**に並ぶ。境界には目印を置いた。
+>
+> 役割分担：**このファイルが「いつ・なぜ・どう直したか」、`Architecture.md` が「今どうなっているか」**。
+> 仕様として残す価値のある長い注記は Architecture.md §19（ラウンド別補足）にある。
+>
+> **既知の欠落**: **R114 / R115 / R116 のラウンド見出しがこのファイルには無い**（R117 の次が R113）。
+> その3ラウンドの内容は `Architecture.md` §5（`gpt-5.6-luna` 移行・フォールバック階段・比較指標）と
+> R116/R117 以降の本文中の参照に残っている。当時の記録そのものは失われているため、
+> **後から書き足して「あったこと」にはしない**。
+
+---
+
+## R169 — **index.html リファクタリング第8弾＝「宣言」と「実行」で切る：11モジュール（−1,947行 / −155KB）＋ Architecture / DEV-NOTES の整理** (tag `#R169`)
+
+指示は2つ：**index.html を徹底的にリファクタリング**、**Architecture.md と DEV-NOTES.md の書き方の乱れ・事実との齟齬を整理**。
+
+### 1. 切り口を変えた（ここが今回の本質）
+
+#R168 で「主題」も出し切り、残ったのは **6,894行・857文のひとつの `DOMContentLoaded` クロージャ**。
+自動クラスタリングにかけると最大の塊が **1430行目〜7420行目にまたがる45KB** になる——つまり
+**もう「まとまって座っている文の集合」は存在しない**。ここで「大きい塊を探す」のをやめた。
+
+新しい軸は **その文は走るのか、宣言するだけなのか**。857文をacornで分類すると：
+
+| 種別 | 量 | 性質 |
+|---|---|---|
+| **純粋な宣言**（関数宣言／リテラル・関数だけで初期化される const・let） | **277KB / 444文** | 呼ばれるまで何も起きない |
+| **実行する文**（DOM配線・`map.on()`・ブート手順・IIFE） | 208KB / 413文 | 位置と順序に意味がある |
+
+**宣言は、いつ評価しても観測できる違いが無い。** だから宣言だけを集めたファクトリは
+**11本まとめて `map` 生成直後に生成してよい**——#R167 で踏んだ TDZ も、#R166 で神経を使った
+呼び出し順も、原理的に起こらない。そして **実行する文は1文も動かしていない**：
+このラウンドは**副作用を1つも並べ替えていない**。これが最大の安全性の根拠。
+
+**出した11本**（合計192KB。すべて `window.IntMapModules.<name>(map, IM_HOST)`）:
+`satellite.js`（衛星コントローラ 19KB）/ `ai-core.js`（Atlas AIトランスポート 24KB）/
+`place-labels.js`（地名・海洋ラベル 28KB）/ `window-manager.js`（ドラッグ/リサイズ/z順 11KB）/
+`search-geocode.js`（検索・ジオコード 15KB）/ `news-context.js`（記事→地点解決 16KB）/
+`news-feed.js`（ニュース取得 18KB）/ `article-reader.js`（サイドバーリーダー 8KB）/
+`community-board.js`（コミュニティ板 21KB）/ `map-readout.js`（座標/標高/レイヤー値/グリッド 27KB）/
+`elevation-profile.js`（標高断面 7KB）。
+
+**index.html: 7,691行/659KB → 5,744行/504KB**（#R162 からの累計 36,955行 → **−84%**）。
+
+### 2. この切り口で新しく必要になったもの
+
+- **巻き上げシムが合計108本**。`function n(){ return IM_X.n.apply(this,arguments); }`。
+  `const` は TDZ、アローは `this` 落ち——#R168 と同じ理由でこの形しか使えない。
+- **`IM_HOST` 201→253メンバー、うち RW が 29→52**。RW が増えたのは
+  「**私有状態でも、宣言だけを出すと変数の宣言文は index.html に残る**」ため。例:
+  `let elevTimer, lastElev, _elevSeq, _crLng, _crLat, lastLayerVal;` は1文で6つ宣言していて、
+  そのうち2つは index.html 側の `map.on('mouseout')` ハンドラも書く。**文は分割しない**方針なので、
+  宣言は残して RW メンバーで書き通す。
+- **罠1: オブジェクトの短縮プロパティ**。抽出スクリプトが自由識別子を `HOST.x` に書き換えるとき、
+  `{id, center, radiusKm, color}` の `radiusKm` は**キーと値が同じノード**なので、素直に置換すると
+  `{…, HOST.radiusKm, …}` という**構文エラー**になった。`{radiusKm: HOST.radiusKm}` に展開する必要がある。
+- **罠2: 既存のシムを新モジュールに吸い込む**。#R168 のシム（`function wireCommList(){ return IM_COMMUNITY…}`）
+  は「私有ヘルパー」に見えるので自動選定が拾ってしまう。シムは**分割済みモジュールへの橋**であって
+  新しい主題の一部ではないので、明示的に除外する。
+- **`++HOST.x` は書き込みである**。`++HOST._elevSeq`（標高リクエストの通し番号）は
+  r165-checks の「所有していないホストメンバーに書くモジュールは無い」検査の正規表現
+  （postfix のみ）を**すり抜けていた**。前置インクリメントも数えるよう修正——今回の発見だが、
+  穴自体は #R165 からあった。
+
+### 3. 検証
+
+- `tests/r169-checks.test.mjs`（9件）: ①11ファイル読込＋ファクトリ1つずつ＋ブートガード名指し
+  ②シム契約（エクスポート名ごとにシムはちょうど1つ・本体は index.html に無い）
+  ③**位置**——11本が `map` 生成後に1ブロック、かつ**それより前に走る文からコールグラフを辿って
+  出した名前に到達しない**（直接呼び出しだけ見ると1段挟んだ経路を見落とす）
+  ④**宣言だけであることをacornで証明**（ファクトリ直下に実行文ゼロ・初期化子が何も呼ばない）
+  ⑤バレ識別子ゼロ ⑥live getter の裏取り ⑦`check-split-scope.mjs` ⑧index.html 縮小＋本体の残留なし
+  ⑨head の不具合修正（下記）。
+- `tests/r169.spec.js`（11件・実ブラウザ）: ニュース取得→フィード30枚、`analyzeContext` が
+  実際に東京を解決、**書き通し2件**（スクロールで2バッチ目=45枚・重複ゼロ＝`renderedCount`/`newsFiltered`、
+  グリッドを2回押して確実に消える＝`isGridOn`）、検索がローカル地名で答える、
+  `window.__sat`/`window.__ai` がモジュールの実体を返す、ラベルレイヤー3種、
+  言語切替に追従、コンソールエラー0。
+- **証明しないものは書かない**: `community-board.js`（Supabase必須）・`elevation-profile.js`（実DEM必須）・
+  `article-reader.js`（到達不能）は spec 冒頭に理由を明記して**ブラウザでの主張をしていない**。
+- `npm test` 全緑（静的チェック / node 242件 / Playwright 162件）。
+
+### 4. index.html の head にあった実害のある3つ
+
+分割の作業中にファイル全体を読み直して見つけた、分割とは独立の不具合：
+
+1. **`</script>` が1つ余分**。ブラウザが黙って許容していただけの、古い編集の残骸。
+2. **MapLibre のスタイルシートが同じURLで2回 `<link>` されていた**（バイト単位で同一）。
+3. **ビルドスタンプが進んでいなかった**。`window.INTMAP_BUILD` は #R133 の
+   `'2026-07-18-R133'`、`window.__imBuild` は #R121 の `'R121-b'` のまま。
+   INTMAP_BUILD は「この端末が見た最新ビルドより古いものが来たら＝キャッシュの先祖返り」を
+   検出する #R16 のガードの**基準値そのもの**なので、進まない限りガードは事実上無効。
+   両方を `R169` 相当に更新（r169-checks #9 でピン留め）。
+
+### 5. 見つけたが**直していない**こと（製品判断が要る）
+
+**サイドバー内の記事リーダーは #R11 以降どこからも呼ばれていない。**
+`openArticleInSidebar` → `fetchReadable` → `renderReader` → `IM_NEWS_UI.renderReaderMode` という
+実装は全部生きているのに、**入口が無い**。`git log -S` で追うと #R11「revert Read->external」で
+ニュースカードの Read ボタンを外部リンクに戻したときに入口が消えている（約150ラウンド前）。
+到達不能コードだが、**消すのはリファクタリングの判断ではなく製品の判断**なので、
+`js/article-reader.js` の冒頭に所見を書いて**そのまま**出した。再配線するか削除するかは要判断。
+
+### 6. Architecture.md / DEV-NOTES.md の整理
+
+**Architecture.md**
+- 冒頭に**「この文書の読み方」**を追加＝「§1–§18 は今の姿だけ、変更ログは DEV-NOTES」という役割分担を明文化。
+  代わりに、冒頭に貼り付いたままだった **R151 の Last reviewed と R41 のラウンド要約**を撤去。
+- **事実と違っていた数字を実測値に**：§1「約15,000行・約1.4MB」（#R165 当時の値）→ 5,744行/0.49MB、
+  §3 の内訳、§14 の動作確認「レイヤー行≈72個」→ **≈130個**（`npm run test:smoke` が同じ値を検査している）。
+- **§5 に埋まっていたラウンド別変更ログ10段落を撤去**。AI の節なのに経路・Compare・レイヤー・UI の話まで入り、
+  しかも R117→R119→R118→R120→R122→R123→R124→R125→R126→R121→R118 という順で並んでいた。
+  内容は DEV-NOTES R117〜R126 に同じものがある。仕様として残す価値のある
+  **`window.IntMapLayers`（レイヤー・データ契約）だけ §7 へ移設**。
+- **§14 と §15 の間に18個バラバラの順序で挟まっていた `#Rxxx 補足` を §19 に集約**し、**新しい順**に並べ直した
+  （R157→R154→R153→R152→R151→R150→R143→R142→R140→R139→R137→R136→R135→R132→R131→R129→R128→R127 だった）。
+  見出しも `##` → `###` に下げて §19 の子にした。
+- §3 / §3.1 に #R169 の11本と手順を追記。
+
+**DEV-NOTES.md**
+- 冒頭に**「この文書の構成」**を追加。このファイルは**上半分が新しい順（R168→R86）、
+  下半分が古い順（番号付きノート＋Round 1〜85）**という2部構成なのに、それがどこにも書かれていなかった。
+  境界にも目印の見出しを置いた。**並べ替えはしない**——4,000行ぶんの相互参照（「上で述べた」等）が全部ずれるため。
+- **R161b を R161 の上へ移動**（`b` の方が新しいのに下にあった＝新しい順の唯一の破れ）。
+- **R114 / R115 / R116 のラウンド見出しがこのファイルに存在しない**（R117 の次が R113）ことを
+  「既知の欠落」として明記。当時の記録は失われているので、**後から書き足して「あったこと」にはしない**。
 
 ---
 
@@ -515,6 +650,22 @@ index.html のクロージャ変数でないことを検証）を新設し、sta
 
 ---
 
+## R161b — **本番のみで再現した誤ピンの修正：`geo_pins` 重複が「曖昧」と誤判定され国の文脈が消えていた** (tag `#R161b`)
+
+**症状（本番検証で発見）**: `Army shells Tripoli in northern Lebanon` が**リビアの**トリポリに刺さる。ローカルでは正しくレバノン。
+
+**真因**: クライアントは `rebuildGeoIndex()` で **Supabase `geo_pins` を `register()`** する（#R161）。`geo_pins` には内蔵辞書と**同じ場所**の行があり、本番では `Lebanon` が**同一座標の2エンティティ**になっていた。`resolveMentions` の pass 1 は `ids.length !== 1` を「曖昧」とみなして**文脈シードから除外**するため、**`ctxISO` に `LB` が入らない**→ `Tripoli` の曖昧性解決から唯一の国の手がかりが消え、rank の高いリビア首都（capital ボーナス付き）が勝つ。**同一座標の重複は「曖昧」ではない**のに曖昧扱いしていたのが誤り。
+
+**修正**: `collapse(ids)` を追加——候補が全て**50km以内**なら重複とみなして1つに畳み、**最も情報量の多い候補**（iso2 を持つ方を優先、次に rank）を代表にする。畳めた場合は pass 1 で文脈シードに使い、pass 2 でもそのまま採用。加えて genuinely 別地点どうしの競合では **iso2 を持つ内蔵エントリに +2**（「運用者データはカバレッジを足すが、検証済みの地点を上書きしない」という #R161 の設計方針をスコアにも反映）。
+
+**影響範囲**: 同じクラスの誤ピンは `Toledo cathedral … in central Spain`（`Spain` も重複）→ **オハイオ州トレド**でも起きていた。両方とも本修正で解消。
+
+**なぜテストが取り逃したか（重要）**: #R161 のテストは全て **register 済みデータが空**の状態で走っていた＝**誰も配っていない辞書**で緑になっていた。`tests/fixtures/geo-pins-prod.json`（**本番の `geo_pins` 294行そのもの**・公開参照データ）を追加し、`tests/r161-checks.test.mjs` **#12b** で**本番と同じ前提**（実データ register 済み）のまま曖昧性解決・階層・トラップ・新規curated地点を検証する。ラベル付きコーパス/ホールドアウトは 100% のまま（回帰なし）。
+
+**なお** `Sudan war: RSF shells El Fasher in Darfur` が `Darfur`（より広い地域）を返すのは geo_pins の有無に関係なく同一＝**本件とは無関係**（誤りではなく粒度が粗いだけ）。切り分けずに「本番バグ」と決めつけないこと。
+
+**教訓**: 実行時に外部データを合流させる仕組みを入れたら、**テストもその外部データが入った状態で回す**こと。空の registry で緑でも本番の前提を検証したことにならない。本番検証を「ページが開くか」で終わらせず、**実際の判定を1件ずつ叩いた**ことで発見できた。
+
 ## R161 — **非AI依存のニュース地点解析システムの全面再設計（決定論エンジン `IntMapNewsGeo`）／MapLibre依存軽減 Phase 3（ニュースピン・オーバーレイを丸ごとエンジン経由へ）** (tag `#R161`)
 
 **背景（委託2件）**: (1) 以前から続けている **MapLibre依存の軽減**の続き、(2) **非AI依存のニュース地点解析システムを10倍正確に**（網羅性と正確性を徹底的に）。
@@ -564,22 +715,6 @@ index.html のクロージャ変数でないことを検証）を新設し、sta
 ### テスト/CI/デプロイ
 新規 `tests/r161-checks.test.mjs`（16件：**振る舞い**＝デートライン/曖昧性/階層/トラップ/大文字ガード/常用語/多言語/媒体名除去/無回答/決定論/速度、**計測**＝コーパス≥95%・ホールドアウト≥90%・旧比5倍以上の誤り減、**配線**＝ミラー同期・クライアント/サーバー配線・Phase 3 契約とニュース6ハンドラ移行）＋ `tests/r161.spec.js`（実Chromium 7件）＋ `tests/newsgeo-corpus.mjs` / `tests/newsgeo-holdout.mjs` / `scripts/newsgeo-eval.mjs` / `scripts/sync-newsgeo.mjs`。`scripts/static-checks.mjs` に**ミラー同期チェック**を追加（ドリフトで落ちることを負テストで確認）。`npm test` 緑（static＋node **178**＋Playwright **107**、CI条件 workers=2/retries=2）。**Edge Function `refresh-news` は変更あり＝本番デプロイ必須**。
 **罠/教訓**: (a) `index.html` は **CRLF** なので改行入りの exact-string assert は必ず落ちる（バックスラッシュ n が実改行にならない）→改行は正規表現の空白クラスで書く。(b) 自変更で **r160 #D2 の exact-string assert が破損**（render 名前空間を拡張したため）→現挙動へ更新（R152/R154/R156/R159/R160 と同じ罠、毎回起きる）。(c) 短い別名は事故のもと——`Газ`(Gaza の語幹)は露語の**「ガス」**に、`LA` は西語の**冠詞 `la`** に、`US` は英語の **`us`** に一致する。**語幹は4文字以上／頭字語は全大文字必須**で構造的に封じた。(d) hermetic Playwright は `isStyleLoaded()` が永久 false ＝ レイヤ検証不能→ベースマップ1ソースだけスタブすれば実検証できる。
-
-## R161b — **本番のみで再現した誤ピンの修正：`geo_pins` 重複が「曖昧」と誤判定され国の文脈が消えていた** (tag `#R161b`)
-
-**症状（本番検証で発見）**: `Army shells Tripoli in northern Lebanon` が**リビアの**トリポリに刺さる。ローカルでは正しくレバノン。
-
-**真因**: クライアントは `rebuildGeoIndex()` で **Supabase `geo_pins` を `register()`** する（#R161）。`geo_pins` には内蔵辞書と**同じ場所**の行があり、本番では `Lebanon` が**同一座標の2エンティティ**になっていた。`resolveMentions` の pass 1 は `ids.length !== 1` を「曖昧」とみなして**文脈シードから除外**するため、**`ctxISO` に `LB` が入らない**→ `Tripoli` の曖昧性解決から唯一の国の手がかりが消え、rank の高いリビア首都（capital ボーナス付き）が勝つ。**同一座標の重複は「曖昧」ではない**のに曖昧扱いしていたのが誤り。
-
-**修正**: `collapse(ids)` を追加——候補が全て**50km以内**なら重複とみなして1つに畳み、**最も情報量の多い候補**（iso2 を持つ方を優先、次に rank）を代表にする。畳めた場合は pass 1 で文脈シードに使い、pass 2 でもそのまま採用。加えて genuinely 別地点どうしの競合では **iso2 を持つ内蔵エントリに +2**（「運用者データはカバレッジを足すが、検証済みの地点を上書きしない」という #R161 の設計方針をスコアにも反映）。
-
-**影響範囲**: 同じクラスの誤ピンは `Toledo cathedral … in central Spain`（`Spain` も重複）→ **オハイオ州トレド**でも起きていた。両方とも本修正で解消。
-
-**なぜテストが取り逃したか（重要）**: #R161 のテストは全て **register 済みデータが空**の状態で走っていた＝**誰も配っていない辞書**で緑になっていた。`tests/fixtures/geo-pins-prod.json`（**本番の `geo_pins` 294行そのもの**・公開参照データ）を追加し、`tests/r161-checks.test.mjs` **#12b** で**本番と同じ前提**（実データ register 済み）のまま曖昧性解決・階層・トラップ・新規curated地点を検証する。ラベル付きコーパス/ホールドアウトは 100% のまま（回帰なし）。
-
-**なお** `Sudan war: RSF shells El Fasher in Darfur` が `Darfur`（より広い地域）を返すのは geo_pins の有無に関係なく同一＝**本件とは無関係**（誤りではなく粒度が粗いだけ）。切り分けずに「本番バグ」と決めつけないこと。
-
-**教訓**: 実行時に外部データを合流させる仕組みを入れたら、**テストもその外部データが入った状態で回す**こと。空の registry で緑でも本番の前提を検証したことにならない。本番検証を「ページが開くか」で終わらせず、**実際の判定を1件ずつ叩いた**ことで発見できた。
 
 ## R160 — サイドバー開閉で地図を動かさない＋幅縮小＋設定バグ／MapLibre依存軽減の続き：**左サイドバーは元の横並び（beside-flex）機構を保ったまま「単一の静止エッジ・ピン」で地図を動かさない（機構は勝手に作り変えない）／右サイドバーは地図を押さないオーバーレイ化（地図領域の位置を動かさない）／R158/R159の毎フレームresize＋エッジアンカー『ループ』は全削除／右サイドバー既定幅（340→300）／設定変更で右サイドバーが勝手に開く不具合の修正／IntMapGeoEngine（レンダラ抽象）Phase 2** (tag `#R160`)
 
@@ -2770,6 +2905,15 @@ Batch from a big feature wishlist; these three shipped solid this round (others 
 - **Multi-point route optimisation / TSP (`#R86c`).** Atlas `optimizeRoute`/`tsp`/`multiStop` — give ≥2 places (or drop pins): `_tspOrder` orders them shortest-first (nearest-neighbour + 2-opt on great-circle distance, first stop fixed as start), then the tour is DRIVEN on the OSM road network (OSRM via `IntMapRouting.route` with waypoints). Reply shows the numbered order + total time/distance. Deterministic NL (EN "optimize route through A, B, C / shortest order to visit …"; JP "A・B・Cを最短で回る / …を効率よく巡る順番"). Verified: colinear A,C,B→A,B,C; scrambled Osaka/Tokyo/Kyoto/Nagoya/Yokohama → Osaka→Kyoto→Nagoya→Yokohama→Tokyo, 548 km/7h33m via OSRM; NL patterns match, negatives excluded.
 - **Route lines coloured BY MODE on the map (`#R86d`).** Bug report: "経路の線、路線や徒歩などの種別での色分けがされていません" — on the map a transit route was drawn in ONE flat colour regardless of leg type (walk vs subway vs rail vs bus), even though the reply note claimed "乗車区間はモード別に色分けして地図表示" and the itinerary detail list already showed a per-leg colour bar. Root cause: R86b coloured each geometry by its ALTERNATIVE (`ALT_PAL`), and `_buildItin` DROPPED the per-leg mode colour — it computed `const col=_modeColor(l.mode)` but pushed only `{coords,walk}` into `lines`, never `col`. Fix (2 lines): `_buildItin` now keeps `col` on each line object; `_drawAlts` paints the **selected** route's legs by their MODE colour (`ln.col` → walk grey-dotted `#7a7f87`, subway `#ff6d00`, tram/light-rail `#00a152`, bus `#7b1fa2`, ferry `#0097a7`, rail `#1558d6`) so it now MATCHES the leg list, while **unselected** alternatives keep their single dimmed `ALT_PAL` colour — so R86b's distinct-per-alternative view is fully preserved (best of both, exactly like Google/Apple Maps: selected route shows line colours, alternatives are dim). `selectAlt(i)` re-paints alt *i* per-mode. Intercity-rail (`_renderRail`) and single-mode drive/walk/cycle already coloured by type — untouched. No data-source/Privacy/ToS change (pure rendering). **Verified** with a faithful V8 harness of the byte-identical `_buildItin`/`_drawAlts`/`_modeColor`: selected 5-leg trip → `grey,orange,grey,purple,grey` (3 distinct hues, was 5× flat blue); unselected alt → all its one palette colour; switching selection re-colours the rail leg to rail-blue. (Live map paint still can't be exercised in the hidden headless tab — `isStyleLoaded` gate — like every map layer.)
 - **Still sequenced (not this round — each is a large feature; cramming would re-introduce facades):** universal object list, unified disaster simulator, slope/aspect analysis, sun/shadow, RF/coverage, Earth Replay.
+
+---
+
+## ここから下は**古い順**（Round 1〜85 と、プロジェクト初期の番号付きノート） — 目印 (#R169)
+
+> 上（ここより前）は **R168 → R86 の新しい順**。ここから下は当時のまま**古い順**で、
+> `## 1. What IntMap is` から始まる番号付きの節と Round 1〜85 が続く。
+> 順序が途中で反転するのはこの1か所だけ。並べ替えると 4,000行ぶんの相互参照
+> （「上で述べた」「前ラウンドの」など）が全部ずれるので、**並べ替えずに目印を置く**方を選んだ。
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ gtag('js', new Date());
    can finish booting in a hidden/background tab (rAF is throttled to zero there, `map.on('load')` never fires
    and nothing map-side can be verified). Never active for normal visitors. */
 if(/[?&]rafshim=1/.test(location.search)){ try{ window.requestAnimationFrame=function(cb){ return setTimeout(function(){ cb(performance.now()); },33); }; window.cancelAnimationFrame=clearTimeout; }catch(_){} }
-window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying that a reload really picked up the edited file (file:// reloads can serve a stale cache) */
+window.__imBuild='R169';   /* (#R121) build marker — bump when verifying that a reload really picked up the edited file (file:// reloads can serve a stale cache) */
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
@@ -50,7 +50,7 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
      the NEWEST build ever loaded on this device. If a load ever serves an OLDER build than one already seen,
      we KNOW it's a stale copy → purge caches + hard-reload ONCE; if it's still old after that, surface a
      banner so it can never silently masquerade as the current app again. */
-  window.INTMAP_BUILD='2026-07-18-R133';
+  window.INTMAP_BUILD='2026-07-25-R169';
   /* (#R29.1) Maintenance/security: capture the last ~25 runtime errors into a ring buffer so the Bug Report
      tool can attach them automatically (and so a silent failure is never invisible). Lightweight, no deps. */
   window.__imErrors=window.__imErrors||[];
@@ -152,7 +152,6 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
     }catch(e){}
   });
   </script>
-  </script>
 
   <title>IntMap — Explore the world. Ask the map.</title>
 
@@ -183,7 +182,6 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
 
   <meta property="og:type" content="website">
 
-  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css" />
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css" />
   <script>document.documentElement.setAttribute('data-theme', window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');</script>
   <!-- (#R162) The stylesheet moved out of this file into css/intmap.css (verbatim, same order and
@@ -748,6 +746,20 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
 <script src="js/tool-panel.js"></script>
 <script src="js/auth-ui.js"></script>
 <script src="js/community.js"></script>
+<!-- (#R169) the eighth split: eleven more SUBJECT modules. Every statement in them is a DECLARATION,
+     so all eleven factories are instantiated together right after `map` exists and each exported
+     name keeps a hoisted shim in index.html (Architecture.md §3.1 #R169). -->
+<script src="js/satellite.js"></script>
+<script src="js/ai-core.js"></script>
+<script src="js/place-labels.js"></script>
+<script src="js/window-manager.js"></script>
+<script src="js/search-geocode.js"></script>
+<script src="js/news-context.js"></script>
+<script src="js/news-feed.js"></script>
+<script src="js/article-reader.js"></script>
+<script src="js/community-board.js"></script>
+<script src="js/map-readout.js"></script>
+<script src="js/elevation-profile.js"></script>
 <script>
   /* (#R162) These files are REQUIRED. Say so loudly and early rather than letting a missing
      one surface later as a confusing "cannot read property of undefined".
@@ -771,7 +783,9 @@ window.__imBuild='R121-b';   /* (#R121) build marker — bump when verifying tha
                  /* (#R167) 15 factories in 7 files (js/tables.js carries data, not factories). */
                  'legal','feedback','onboarding','progressCtl','mobileUI','layoutReflow','newsTimeline','dashExtended','locate','annotations','layerHoverPopup','layerSearch','runwaySearch','terrain','railSeaOverlays',
                  /* (#R168) the six subject modules of the seventh split. */
-                 'countriesUi','newsUi','companiesUi','toolPanel','authUi','community'].filter(function(k){ return typeof M[k]!=='function'; });
+                 'countriesUi','newsUi','companiesUi','toolPanel','authUi','community',
+                 /* (#R169) the eleven subject modules of the eighth split. */
+                 'satellite','aiCore','placeLabels','windowManager','searchGeocode','newsContext','newsFeed','articleReader','communityBoard','mapReadout','elevationProfile'].filter(function(k){ return typeof M[k]!=='function'; });
     if(miss.length) console.error('[IntMap] required module file(s) failed to load: '+miss.join(', ')+' — check the js/ directory is deployed');
     if(missFac.length) console.error('[IntMap] module factories missing: '+missFac.join(', ')+' — the matching js/ file did not load');
     window.__imModuleCheck={ missing:miss, missingFactories:missFac }; })();
@@ -1037,7 +1051,61 @@ window.addEventListener('DOMContentLoaded', () => {
     get satState(){ return satState; }, get scheduleNewsDeclutter(){ return scheduleNewsDeclutter; },
     get setupCommunityLayer(){ return setupCommunityLayer; }, get showCoCompare(){ return showCoCompare; },
     get totalDistance(){ return totalDistance; }, get updateAccountButton(){ return updateAccountButton; },
-    get updateOcclusion(){ return updateOcclusion; }
+    get updateOcclusion(){ return updateOcclusion; },
+    /* ── (#R169) members added for the eighth split — eleven SUBJECT modules (satellite, ai-core,
+     *    place-labels, window-manager, search-geocode, news-context, news-feed, article-reader,
+     *    community-board, map-readout, elevation-profile). Same rule as ever: getter-only unless the
+     *    module is the OWNER of the state, in which case it gets the write half too. ── */
+    /* READ-WRITE — each name below is written by exactly the module that owns the subject: the
+     * satellite controller owns its provider/error state, the search box owns its result marker,
+     * the gazetteer builder replaces geoDB, the news feed replaces the article arrays, the reader
+     * owns its open/current article, the community board owns its post cache and compose draft, and
+     * the readout/graticule owns the cursor + grid + measure state. The variable itself stays
+     * declared in index.html as the single source of truth; `HOST.x=v` runs the setter, so
+     * index.html and the module always read the same live value. Pinned by tests/r165-checks.test.mjs. */
+    get _crLat(){ return _crLat; }, set _crLat(v){ _crLat=v; },
+    get _crLng(){ return _crLng; }, set _crLng(v){ _crLng=v; },
+    get _elevSeq(){ return _elevSeq; }, set _elevSeq(v){ _elevSeq=v; },
+    get composeCat(){ return composeCat; }, set composeCat(v){ composeCat=v; },
+    get composeEditId(){ return composeEditId; }, set composeEditId(v){ composeEditId=v; },
+    get elevTimer(){ return elevTimer; }, set elevTimer(v){ elevTimer=v; },
+    get lastElev(){ return lastElev; }, set lastElev(v){ lastElev=v; },
+    get lastLayerVal(){ return lastLayerVal; }, set lastLayerVal(v){ lastLayerVal=v; },
+    get panelDrag(){ return panelDrag; }, set panelDrag(v){ panelDrag=v; },
+    get pendingImg(){ return pendingImg; }, set pendingImg(v){ pendingImg=v; },
+    get readerCurrent(){ return readerCurrent; }, set readerCurrent(v){ readerCurrent=v; },
+    get readerOpen(){ return readerOpen; }, set readerOpen(v){ readerOpen=v; },
+    get satActive(){ return satActive; }, set satActive(v){ satActive=v; },
+    get satAutoBackoff(){ return satAutoBackoff; }, set satAutoBackoff(v){ satAutoBackoff=v; },
+    get satErrCount(){ return satErrCount; }, set satErrCount(v){ satErrCount=v; },
+    get satLastGood(){ return satLastGood; }, set satLastGood(v){ satLastGood=v; },
+    get searchMarker(){ return searchMarker; }, set searchMarker(v){ searchMarker=v; },
+    /* write halves only — these already have their live getters above with the rest of the mutable state */
+    set commCaps(v){ commCaps=v; },
+    set communityPosts(v){ communityPosts=v; },
+    set geoDB(v){ geoDB=v; },
+    set isGridOn(v){ isGridOn=v; },
+    set measureSnapClose(v){ measureSnapClose=v; },
+    set newsFiltered(v){ newsFiltered=v; },
+    /* read-only for these modules (live getters as ever) */
+    get AI_FREE_DAILY(){ return AI_FREE_DAILY; }, get BUILTIN_GAZETTEER(){ return BUILTIN_GAZETTEER; },
+    get GEO_LABEL_JP(){ return GEO_LABEL_JP; }, get SAT_PROVIDERS(){ return SAT_PROVIDERS; },
+    get SNAP_PX(){ return SNAP_PX; }, get USE_SERVER_NEWS(){ return USE_SERVER_NEWS; },
+    get _DEMONYM_GZ(){ return _DEMONYM_GZ; }, get _DEM_CACHE_MAX(){ return _DEM_CACHE_MAX; },
+    get _ORG_GZ(){ return _ORG_GZ; }, get _pubMatchers(){ return _pubMatchers; },
+    get _spreadDupNewsPins(){ return _spreadDupNewsPins; }, get _stabIdx(){ return _stabIdx; },
+    get _wsNewsHidden(){ return _wsNewsHidden; }, get aiButtonSyncers(){ return aiButtonSyncers; },
+    get aiConfig(){ return aiConfig; }, get aiReport(){ return aiReport; },
+    get aiVisionReady(){ return aiVisionReady; }, get aiWaitMapIdle(){ return aiWaitMapIdle; },
+    get analyzeContext(){ return analyzeContext; }, get appendNewsBatch(){ return appendNewsBatch; },
+    get elevText(){ return elevText; }, get fetchBathymetry(){ return fetchBathymetry; },
+    get fetchViaProxy(){ return fetchViaProxy; }, get fmtElevVal(){ return fmtElevVal; },
+    get forceHoverLayers(){ return forceHoverLayers; }, get geoLabelsOn(){ return geoLabelsOn; },
+    get geoLayersDB(){ return geoLayersDB; }, get imIsPro(){ return imIsPro; },
+    get mapLabelsViaVector(){ return mapLabelsViaVector; }, get newsLangs(){ return newsLangs; },
+    get renderCommunity(){ return renderCommunity; }, get renderReaderMode(){ return renderReaderMode; },
+    get satKeys(){ return satKeys; }, get showComposeImgPreview(){ return showComposeImgPreview; },
+    get wireCommList(){ return wireCommList; }
   };
 
   /* ===== i18n ===== */
@@ -1090,27 +1158,7 @@ window.addEventListener('DOMContentLoaded', () => {
     try{ if(typeof renderNewsLangChecks==='function') renderNewsLangChecks(); }catch(_){}
     renderUI();
   }
-  /* Localize the geopolitical / strategic layer checkboxes in the Layers menu (their text was
-     hard-coded English; pull the right language out of geoLayersDB instead). */
-  /* Fallback names for geo-layer checkboxes whose layer was pulled out of geoLayersDB (e.g. Rimland,
-     now a country-fill) so they still localize EN/JP (#3). */
-  const GEO_LABEL_FALLBACK={ rimland:{name:{en:'Rimland',jp:'リムランド'}}, fsu:{name:{en:'Former Soviet Union',jp:'旧ソ連諸国'}} };
-  function localizeGeoLabels(){
-    document.querySelectorAll('.geo-layer-cb').forEach(cb=>{
-      const key=cb.getAttribute('data-layer'), data=(typeof geoLayersDB!=='undefined'&&geoLayersDB[key])||GEO_LABEL_FALLBACK[key]; if(!data||!data.name) return;
-      const label=cb.closest('.layer-option'); if(!label) return;
-      let span=label.querySelector('.geo-label');
-      if(!span){ /* migrate the bare trailing text node into a span we can re-localize */
-        Array.from(label.childNodes).forEach(n=>{ if(n.nodeType===3 && n.textContent.trim()) n.remove(); });
-        span=document.createElement('span'); span.className='geo-label';
-        /* (#R15e) Insert the label BEFORE the favorite star — appending it to the end put it AFTER the
-           star (which has margin-left:auto), shoving the text to the right with a big gap ("ぐちゃっと"). */
-        const star=label.querySelector('.lyr-star');
-        if(star) label.insertBefore(span,star); else label.appendChild(span);
-      }
-      span.textContent=' '+(data.name[currentLang]||data.name.en||key);
-    });
-  }
+  /* (#R169) moved verbatim to js/place-labels.js — see Architecture.md §3.1. */
 
   /* ===== Theme ===== */
   let bordersOn=true;   /* (#R40) Country borders DEFAULT ON per request. The lazy-create + retry path (R39) now draws them reliably on first load, so the default is honoured (see the startup dispatch after _wireRef). */
@@ -1211,199 +1259,20 @@ window.addEventListener('DOMContentLoaded', () => {
      basemap is always the _nolabels variant, and because the labels are vector layers the
      label-raise self-heal keeps them above EVERY data layer. */
   function mapLabelsViaVector(){ return true; }
-  let _placeLabelsAdded=false;
-  /* (#R27) IDEMPOTENT now. The old `_placeLabelsAdded` early-return made this a one-shot: if the very
-     first call added the layers a hair before the OFM source/style was truly ready, they were never
-     re-added — which is exactly why labels were missing on first load but appeared after toggling
-     names off/on ("デフォルト選択なのに地名ラベルが出ない、再チェックで出る"). The per-source / per-layer
-     `if(!getLayer)` guards already make repeated calls safe, so we just re-attempt every time. */
-  function ensurePlaceLabels(){
-    if(!map||!map.isStyleLoaded()) return;
-    try{
-      /* Use the TileJSON URL (not a hardcoded tile path) — OpenFreeMap serves versioned tiles, so
-         the bare /planet/{z}/{x}/{y}.pbf path 404s at real zooms and labels never appear. */
-      if(!map.getSource('ofm')) map.addSource('ofm',{type:'vector',url:'https://tiles.openfreemap.org/planet',attribution:'© OpenFreeMap © OpenMapTiles © OSM'});
-      const FONT=['Noto Sans Regular'];
-      const before = map.getLayer('grid-lines') ? 'grid-lines' : undefined;
-      if(!map.getLayer('ofm-country')) map.addLayer({id:'ofm-country',type:'symbol',source:'ofm','source-layer':'place',maxzoom:7,filter:['==',['get','class'],'country'],layout:{visibility:'none','text-field':['get','name'],'text-font':FONT,'text-size':['interpolate',['linear'],['zoom'],1,10,4,15],'text-letter-spacing':0.08,'text-max-width':8,'text-padding':6},paint:{'text-color':'#e8eefc','text-halo-color':'rgba(0,0,0,0.75)','text-halo-width':1.4}}, before);
-      if(!map.getLayer('ofm-city')) map.addLayer({id:'ofm-city',type:'symbol',source:'ofm','source-layer':'place',minzoom:3,filter:['all',['in',['get','class'],['literal',['city','town']]]],layout:{visibility:'none','text-field':['get','name'],'text-font':FONT,'text-size':['interpolate',['linear'],['zoom'],4,11,10,15],'text-max-width':7,'text-variable-anchor':['top','bottom','left','right'],'text-radial-offset':0.4,'text-justify':'auto','icon-optional':true},paint:{'text-color':'#ffffff','text-halo-color':'rgba(0,0,0,0.8)','text-halo-width':1.3}});
-      if(!map.getLayer('ofm-other')) map.addLayer({id:'ofm-other',type:'symbol',source:'ofm','source-layer':'place',minzoom:7,filter:['all',['in',['get','class'],['literal',['village','suburb','hamlet','neighborhood']]]],layout:{visibility:'none','text-field':['get','name'],'text-font':FONT,'text-size':['interpolate',['linear'],['zoom'],8,10,13,13],'text-max-width':7},paint:{'text-color':'#d8dde6','text-halo-color':'rgba(0,0,0,0.75)','text-halo-width':1.1}});
-      /* (#R40) "河川や湖、その他地形のラベルが欲しい" — rivers/lakes/seas (water_name) + mountain peaks (mountain_peak),
-         from the same OFM vector source. Italic blue for water (cartographic convention), a ▲ for peaks with
-         elevation. They follow the Place-names toggle + the active label language (handled in applyLabelLang). */
-      const FONTI=['Noto Sans Italic'];
-      /* (#R41) ROOT CAUSE of "水域のラベルが地図からずれている": river names were read from `water_name` (which is
-         POINT label geometry) but drawn with symbol-placement:line — line placement on a point lands the label
-         off the actual river. River/canal names live in the `waterway` LINE layer; placing them there makes them
-         follow the real river line on the basemap (aligned). */
-      if(!map.getLayer('ofm-river')) map.addLayer({id:'ofm-river',type:'symbol',source:'ofm','source-layer':'waterway',minzoom:6,filter:['in',['get','class'],['literal',['river','canal']]],layout:{visibility:'none','symbol-placement':'line','text-field':['get','name'],'text-font':FONTI,'text-size':['interpolate',['linear'],['zoom'],6,10,12,13],'text-max-angle':38,'text-letter-spacing':0.02,'symbol-spacing':350},paint:{'text-color':'#7fc4ff','text-halo-color':'rgba(0,0,0,0.7)','text-halo-width':1.1}});
-      /* (#R62) sea/ocean/bay labels moved OFF the vector tiles: water_name label points are stored PER TILE, so the
-         visible label jumped to a different point at every zoom level ("ズームに応じて位置がどんどんずれてしまう").
-         OFM now only supplies LAKE names (compact bodies → no visible drift); seas/oceans/gulfs come from the fixed
-         gazetteer below (one stable coordinate each, 5 languages, clickable). */
-      /* (#R63) lakes: major lakes now come from the FIXED gazetteer too (their per-tile label points also drifted);
-         OFM keeps only the long tail of small lakes from z5.5 where any drift is sub-glyph. Constant text size —
-         the size interpolation amplified the perceived slide while zooming. */
-      /* (#R64) WATER labels: the vector tiles store a DIFFERENT label geometry for the same lake at every zoom
-         (per-tile LineString label lines), so a tile-driven layer re-anchors on zoom → the visible "slide".
-         Water labels therefore render from a client-side STABLE source ('stab-water-src') that a harvester fills
-         at runtime: every water name keeps the FIRST coordinate it was seen at, worldwide, nothing hardcoded.
-         (#R67) PEAKS ARE THE OPPOSITE CASE and go back to DIRECT tile rendering: summits are exact POINT nodes
-         whose tile-quantization error is always sub-pixel AT THE ZOOM THAT TILE IS VIEWED AT (error and pixel
-         size shrink together), so the raw tile layer is inherently drift-free — while pinning them (R64/R66)
-         BAKED IN one zoom's coarse coordinate and then hopped on refinement, which was itself the reported
-         "山岳名がズームに応じて位置ずれする". Do not re-pin point features. */
-      try{ if(!map.getSource('stab-water-src')) map.addSource('stab-water-src',{type:'geojson',data:{type:'FeatureCollection',features:[]}}); }catch(_){}
-      /* (#R69) both water layers additionally gate each pin on its first-seen tile zoom (`mz`, see _harvestOne)
-         so zoomed-in harvests don't flood lower zooms ("水域ラベルが…過剰な数見えすぎ"). */
-      if(!map.getLayer('ofm-water')) map.addLayer({id:'ofm-water',type:'symbol',source:'stab-water-src',minzoom:5.5,filter:['all',['!',['in',['get','class'],['literal',['ocean','sea','bay','strait','gulf','lagoon']]]],['<=',['coalesce',['get','mz'],0],['+',['zoom'],0.2]]],layout:{visibility:'none','text-field':['get','name'],'text-font':FONTI,'text-size':13,'text-max-width':8},paint:{'text-color':'#8fd0ff','text-halo-color':'rgba(0,0,0,0.7)','text-halo-width':1.1}});
-      /* (#R65) seas/bays/straits/gulfs from the SAME pinned dynamic source (visible from low zoom) — every
-         named water body worldwide gets a stable label, not just the curated majors. */
-      if(!map.getLayer('ofm-water2')) map.addLayer({id:'ofm-water2',type:'symbol',source:'stab-water-src',minzoom:2,filter:['all',['in',['get','class'],['literal',['ocean','sea','bay','strait','gulf','lagoon']]],['<=',['coalesce',['get','mz'],0],['+',['zoom'],0.2]]],layout:{visibility:'none','text-field':['get','name'],'text-font':FONTI,'text-letter-spacing':0.06,'text-max-width':8,'text-size':13.5},paint:{'text-color':'#8fd0ff','text-halo-color':'rgba(0,0,0,0.7)','text-halo-width':1.1,'text-opacity':0.95}});
-      try{ if(!map.getSource('geo-sea-src')){
-        const S=window.SEA_LABELS||[];
-        map.addSource('geo-sea-src',{type:'geojson',data:{type:'FeatureCollection',features:S.map((r,i)=>({type:'Feature',id:i,geometry:{type:'Point',coordinates:[r[0],r[1]]},properties:{z:r[2],big:r[2]<=1?1:0,en:r[3],jp:r[4],de:r[5],ru:r[6],es:r[7]}}))}});
-      }
-      /* (#R73) ROOT CAUSE of "主要な海や湖の名前が表示されない" (and the earlier 東シナ海 report): this layer's
-         text-size was `case(big, interpolate(zoom), interpolate(zoom))` — a zoom interpolation NESTED inside
-         `case`, which the style spec forbids (zoom must be the OUTERMOST expression). MapLibre rejected the
-         whole addLayer SILENTLY (async error event, swallowed try) → the gazetteer sea/lake layer NEVER existed,
-         and because the harvester dedupes any name already in the gazetteer, the majors were labelled NOWHERE.
-         Rewritten with zoom outermost and the big/small distinction inside each stop output (valid form). */
-      if(!map.getLayer('geo-sea')) map.addLayer({id:'geo-sea',type:'symbol',source:'geo-sea-src',minzoom:0,filter:['<=',['get','z'],['+',['zoom'],0.001]],layout:{visibility:'none','symbol-sort-key':['get','z'],'text-field':['get','en'],'text-font':FONTI,'text-letter-spacing':0.08,'text-max-width':8,
-        'text-size':['interpolate',['linear'],['zoom'],1,['case',['==',['get','big'],1],11,10],2,['case',['==',['get','big'],1],12.7,10],4,['case',['==',['get','big'],1],16,12],5,['case',['==',['get','big'],1],16.8,13],8,['case',['==',['get','big'],1],19,15.3],9,['case',['==',['get','big'],1],19.3,16]]},
-        paint:{'text-color':'#8fd0ff','text-halo-color':'rgba(0,0,0,0.7)','text-halo-width':1.1,'text-opacity':0.95}}); }catch(_){}
-      /* (#R63) peaks: CONSTANT text size — size interpolation read as sliding. (#R67) rendered DIRECTLY from the
-         mountain_peak tiles (point nodes are sub-pixel accurate at every zoom's own tiles).
-         (#R68) MEASURED root cause of the still-reported drift: the anchors were glued (≤2.4 m across z10→z13.5,
-         verified via queryRenderedFeatures), but text-anchor:'top' centered the whole "▲ Name" string under the
-         point — the ▲ marker sat half-a-string-width LEFT of the summit, a constant SCREEN offset that spans
-         kilometres of terrain at low zoom and metres at high zoom → the ▲ visibly pointed at different terrain
-         at every zoom. The string is now LEFT-anchored: the ▲ glyph itself sits ON the summit at every zoom. */
-      if(!map.getLayer('ofm-peak')) map.addLayer({id:'ofm-peak',type:'symbol',source:'ofm','source-layer':'mountain_peak',minzoom:7,filter:['has','name'],layout:{visibility:'none','text-field':['concat','▲ ',['get','name']],'text-font':FONT,'text-size':12.5,'text-max-width':30,'text-anchor':'left','text-justify':'left','text-offset':[-0.32,0]},paint:{'text-color':'#e7dcc8','text-halo-color':'rgba(0,0,0,0.8)','text-halo-width':1.2}});
-      _placeLabelsAdded=true;
-      /* register the harvester ONCE — ensurePlaceLabels is intentionally re-run all the time (R27 idempotency),
-         so an unguarded map.on here would pile up listeners. */
-      if(!ensurePlaceLabels._harvestHooked){ ensurePlaceLabels._harvestHooked=true; map.on('idle',()=>{ try{ harvestStableLabels(); }catch(_){}
-        /* (#R72) SELF-HEAL: a basemap/style swap can wipe individual label layers; if the water/sea layers are
-           gone while the toggle is on, re-add + re-apply. This was the reported "東シナ海が全体を写していても
-           出ない" — the fixed sea-label layer had been silently dropped and nothing ever put it back. */
-        try{ if(typeof geoLabelsOn!=='undefined'&&geoLabelsOn&&(!map.getLayer('geo-sea')||!map.getLayer('ofm-water')||!map.getLayer('ofm-water2'))){ ensurePlaceLabels(); if(typeof applyLabelLang==='function') applyLabelLang(); } }catch(_){} }); }
-    }catch(e){ console.warn('ensurePlaceLabels',e); }
-  }
+  /* (#R169) moved verbatim to js/place-labels.js — see Architecture.md §3.1. */
   /* (#R64/#R67) runtime label-anchor pinning — WATER ONLY: lake/sea label geometry genuinely differs per tile
      zoom (LineString label lines), so each water name is pinned to its FIRST-SEEN coordinate in a stable
      geojson source (worldwide, dynamic, nothing hardcoded) and NEVER moves again. Peaks are exact point nodes
      and render straight from the tiles (see #R67 note above) — no pinning, no refinement, nothing to hop. */
   const _stabIdx={water:new Map()};
-  let _stabSeaNames=null, _stabDirty={water:false};
-  function _seaNameSet(){ if(_stabSeaNames) return _stabSeaNames; _stabSeaNames=new Set();
-    try{ (window.SEA_LABELS||[]).forEach(r=>{ for(let i=3;i<=7;i++){ if(r[i]) _stabSeaNames.add(String(r[i]).toLowerCase()); } }); }catch(_){}
-    return _stabSeaNames; }
-  function _harvestOne(kind,sourceLayer,filter,cellDeg){
-    const idx=_stabIdx[kind]; let feats=[];
-    try{ const opts={sourceLayer}; if(filter) opts.filter=filter; feats=map.querySourceFeatures('ofm',opts)||[]; }catch(_){ return; }
-    const seaSet=(kind==='water')?_seaNameSet():null;
-    /* (#R69) DENSITY ("水域ラベルがそれほどズームしていない状態でも過剰な数見えすぎ"): a pin harvested while
-       zoomed in used to stay visible at EVERY lower zoom (the geojson source has no per-feature importance).
-       Each pin now records the lowest tile zoom it was actually SEEN at (`mz`) — exactly the importance grading
-       OpenMapTiles itself applies per zoom — and the label layers filter on it, so zooming out only keeps the
-       water bodies the low-zoom tiles themselves consider worth labelling. mz only ever moves DOWN (a pin never
-       disappears while zooming in) and the pinned POSITION never changes. */
-    let zNow=6; try{ zNow=Math.max(0,Math.floor(map.getZoom())); }catch(_){}
-    for(const f of feats){ try{
-      const p=f.properties||{}; const nm2=p.name||p['name:en']||p.name_en; if(!nm2) continue;
-      if(seaSet){ let dup=false; [p.name,p['name:en'],p.name_en,p['name:ja'],p['name:de'],p['name:ru'],p['name:es']].forEach(v=>{ if(v&&seaSet.has(String(v).toLowerCase())) dup=true; }); if(dup) continue; }   /* the curated multilingual gazetteer already labels it */
-      /* OFM stores lake/water labels as per-tile LineStrings (label placement lines) — exactly why they drifted.
-         Pin the midpoint of the line (or the point) as the one stable anchor. */
-      const g=f.geometry; if(!g) continue; let co=null;
-      if(g.type==='Point') co=g.coordinates;
-      else if(g.type==='LineString'&&g.coordinates.length) co=g.coordinates[Math.floor(g.coordinates.length/2)];
-      else if(g.type==='MultiLineString'&&g.coordinates.length&&g.coordinates[0].length){ const ln=g.coordinates[0]; co=ln[Math.floor(ln.length/2)]; }
-      if(!co) continue;
-      /* (#R65) dedupe radius scales with the feature's physical size class — one "Caspian Sea" pin, not one
-         per tile pyramid level; small bays still allow same-name twins far apart. */
-      const cls=String(p.class||'');
-      const cell=(typeof cellDeg==='number')?cellDeg:(cls==='ocean'?30:cls==='sea'?12:(cls==='bay'||cls==='strait'||cls==='gulf'||cls==='lagoon')?2.5:4);
-      const base=String(nm2).toLowerCase();
-      /* same name may exist in several places (e.g. many "Long Lake") — key by name + coarse cell, and treat a
-         nearby existing pin as THE anchor. FIRST SEEN WINS, FOREVER: a water label floats on the water body, so
-         a few hundred metres of low-zoom quantization is invisible — total positional stability is what matters
-         (#R67: the R66 "refinement" idea is deliberately gone; updating pins was itself visible movement). */
-      /* (#R69) per-class floor keeps rare huge bodies visible early while bays/lagoons wait for closer zooms.
-         (#R72) straits/lagoons raised 5.5→8.5 and bays →7.2: OpenMapTiles ships small 瀬戸/straits in mid-zoom
-         tiles, so they were labelled at region-wide views ("近畿全体を写しているときに〇〇瀬戸が出てくる") —
-         a strait label only makes sense once the strait itself is a meaningful share of the screen. */
-      const clsMin=(cls==='ocean')?0:(cls==='sea')?3:(cls==='gulf')?4.5:(cls==='strait'||cls==='lagoon')?8.5:(cls==='bay')?7.2:6.5;
-      const mzNew=Math.max(clsMin,zNow);
-      let hit=null; for(let dx=-1;dx<=1&&!hit;dx++) for(let dy=-1;dy<=1&&!hit;dy++){ const k=base+'|'+cell+'|'+(Math.round(co[0]/cell)+dx)+'|'+(Math.round(co[1]/cell)+dy); if(idx.has(k)) hit=k; }
-      if(hit){ const ex=idx.get(hit); const exz=(ex&&ex.properties&&typeof ex.properties.mz==='number')?ex.properties.mz:99;
-        if(mzNew<exz-0.01){ ex.properties.mz=mzNew; _stabDirty[kind]=true; }   /* seen in a lower-zoom tile → may appear earlier; position untouched */
-        continue; }
-      const key=base+'|'+cell+'|'+Math.round(co[0]/cell)+'|'+Math.round(co[1]/cell);
-      if(idx.size>9000) return;
-      p.mz=mzNew;
-      idx.set(key,{type:'Feature',id:idx.size,geometry:{type:'Point',coordinates:[co[0],co[1]]},properties:p});
-      _stabDirty[kind]=true;
-    }catch(_){} } }
-  function harvestStableLabels(){
-    let vis=false; try{ vis=map.getLayer('ofm-water')&&map.getLayoutProperty('ofm-water','visibility')==='visible'; }catch(_){}
-    if(!vis) return;
-    /* (#R65) ALL water_name classes — seas, bays, straits, gulfs, lagoons AND lakes — are pinned dynamically.
-       The curated gazetteer is only a multilingual override for the majors; every other water body on the
-       planet gets its label from live tile data (no fixed list, no coverage ceiling). */
-    _harvestOne('water','water_name',null,null);
-    ['water'].forEach(kind=>{ if(!_stabDirty[kind]) return; _stabDirty[kind]=false;
-      try{ const s=map.getSource('stab-'+kind+'-src'); if(s) s.setData({type:'FeatureCollection',features:Array.from(_stabIdx[kind].values())}); }catch(_){} });
-  }
+  /* (#R169) moved verbatim to js/place-labels.js — see Architecture.md §3.1. */
   window._imLabelStats=(dump)=>{ const o={water:_stabIdx.water.size};
     if(dump==='peaks'){ try{ o.z=+map.getZoom().toFixed(2); o.c=[+map.getCenter().lng.toFixed(6),+map.getCenter().lat.toFixed(6)];
       o.rp=map.queryRenderedFeatures({layers:['ofm-peak']}).slice(0,12).map(f=>{ const c=f.geometry&&f.geometry.coordinates; let s=null; try{ s=c?map.project(c):null; }catch(_){}
         return {n:(f.properties||{}).name, c:c?c.map(x=>+x.toFixed(6)):null, px:s?[Math.round(s.x),Math.round(s.y)]:null}; }); }catch(e){ o.rpErr=String(e&&e.message||e); } }
     else if(dump){ o.samples=Array.from(_stabIdx.water.values()).slice(0,10).map(f=>({n:(f.properties||{}).name,mz:(f.properties||{}).mz,cls:(f.properties||{}).class,c:f.geometry.coordinates.map(x=>+x.toFixed(5))})); }
     return o; };   /* diagnostics (read-only) */
-  function applyLabelLang(){
-    if(!map) return;
-    const mode=window.imLabelLang||'ui';
-    let nameExpr;
-    if(mode==='en') nameExpr=['coalesce',['get','name:en'],['get','name:latin'],['get','name_int'],['get','name']];
-    else if(mode==='local') nameExpr=['get','name'];
-    else if(currentLang==='jp') nameExpr=['coalesce',['get','name:ja'],['get','name']];
-    else if(currentLang==='de') nameExpr=['coalesce',['get','name:de'],['get','name:en'],['get','name:latin'],['get','name']];   /* (#R32) German place labels */
-    else if(currentLang==='ru') nameExpr=['coalesce',['get','name:ru'],['get','name:en'],['get','name:latin'],['get','name']];   /* (#R40) Russian place labels — RU previously fell into the English branch (item: 地名ラベルが英語のまま) */
-    else if(currentLang==='es') nameExpr=['coalesce',['get','name:es'],['get','name:en'],['get','name:latin'],['get','name']];   /* (#R40) Spanish place labels */
-    else nameExpr=['coalesce',['get','name:en'],['get','name:latin'],['get','name']];
-    const sat=(currentMapType==='sat');
-    /* Show vector labels in satellite mode (always — replaces ugly Esri) and on the map for jp/local. */
-    const show = namesOn && (sat || mapLabelsViaVector());
-    const isDark = !( (window.imMapColor==='light') || (window.imMapColor!=='dark' && ((userTheme==='light')||(userTheme==='auto'&&window.matchMedia('(prefers-color-scheme: light)').matches))) );
-    /* (#R40) localize + show/hide the water (river/lake/sea) and mountain-peak labels with the same toggle.
-       They keep their own (blue / stone) colors, so they're only given the language expression + visibility. */
-    /* (#R41) water/terrain labels follow their OWN checkbox (geoLabelsOn), independent of place names. */
-    const showGeo = geoLabelsOn && (sat || mapLabelsViaVector());
-    try{ ['ofm-river','ofm-water','ofm-water2'].forEach(id=>{ if(!map.getLayer(id)) return; map.setLayoutProperty(id,'visibility',showGeo?'visible':'none'); map.setLayoutProperty(id,'text-field',nameExpr); });
-      if(map.getLayer('ofm-peak')){ map.setLayoutProperty('ofm-peak','visibility',showGeo?'visible':'none'); map.setLayoutProperty('ofm-peak','text-field',['concat','▲ ',nameExpr]); }
-      /* (#R62) fixed sea labels follow the same toggle; language from the gazetteer's own 5 name fields. */
-      if(map.getLayer('geo-sea')){ const gl=(mode==='en')?'en':(mode==='local')?'en':(({jp:'jp',de:'de',ru:'ru',es:'es'})[currentLang]||'en');
-        map.setLayoutProperty('geo-sea','visibility',showGeo?'visible':'none'); map.setLayoutProperty('geo-sea','text-field',['get',gl]); }
-      /* (#R64) populate the pinned lake/peak anchors immediately when the toggle turns on */
-      if(showGeo) setTimeout(()=>{ try{ harvestStableLabels(); }catch(_){} },250); }catch(_){}
-    /* (#R103) ROOT FIX for "過去に戻っても国名が変わらない (変化なし)": while the time machine is on a past year the
-       MODERN country labels must stay hidden (the era names come from imtb-lbl/lbl2). applyLabelLang runs on many
-       events (styledata, cb-names, language change…) and was unconditionally RE-SHOWING ofm-country based on namesOn,
-       overriding _applyBorders → the present-day country names kept reappearing under/over the era labels. Keep
-       ofm-country hidden here whenever travelling. City/other place labels stay (they aren't country names). */
-    const _travelingLbl=!!(window.IntMapTimeBorders&&window.IntMapTimeBorders.active&&window.IntMapTimeBorders.active());
-    ['ofm-country','ofm-city','ofm-other'].forEach(id=>{ if(!map.getLayer(id)) return;
-      const _showThis=(id==='ofm-country'&&_travelingLbl)?false:show;
-      map.setLayoutProperty(id,'visibility',_showThis?'visible':'none');
-      map.setLayoutProperty(id,'text-field',nameExpr);
-      /* dark map / satellite → light text; light map → dark text */
-      const lightText = sat || isDark;
-      map.setPaintProperty(id,'text-color', lightText?(id==='ofm-country'?'#eaf0ff':'#ffffff'):'#1b1b1f');
-      map.setPaintProperty(id,'text-halo-color', lightText?'rgba(0,0,0,0.8)':'rgba(255,255,255,0.9)');
-    });
-  }
+  /* (#R169) moved verbatim to js/place-labels.js — see Architecture.md §3.1. */
   window.applyLabelLang=applyLabelLang;
   /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
   const {SAT_PROVIDERS}=window.IntMapTables;
@@ -1417,190 +1286,13 @@ window.addEventListener('DOMContentLoaded', () => {
      On mobile the panel lives inside the tools sheet, so it stays available there regardless. */
   let satPanelDismissed=true;   /* desktop floating panel: open only when the user asks for it */
   let satKeys={}; try{ satKeys=JSON.parse(localStorage.getItem('intmap_sat_keys')||'{}')||{}; }catch(_){ satKeys={}; }
-  const saveSatKeys=()=>{ try{ localStorage.setItem('intmap_sat_keys',JSON.stringify(satKeys)); }catch(_){} };
-  const satProviderById=(id)=>SAT_PROVIDERS.find(p=>p.id===id);
+  /* (#R169) moved verbatim to js/satellite.js — see Architecture.md §3.1. */
   /* Pro entitlement: admins always count; otherwise a profiles.is_pro flag (read in refreshCurrentUser). */
   /* (#R10) All features are free now — no Pro paywall. imIsPro() always returns true so every
      previously-gated capability (e.g. satellite BYOK providers) is unlocked. */
   function imIsPro(){ return true; }
   window.imIsPro=imIsPro;
-  /* BYOK/paid satellite providers require Pro AND a saved key; free providers are always usable. */
-  const satHasKey=(p)=>p.tier==='free' || (imIsPro() && !!(satKeys[p.keyName]&&String(satKeys[p.keyName]).trim()));
-  const satMaxDay=()=>new Date().toISOString().slice(0,10);
-  function satMsg(key,p){ return String(t(key)||'').replace('{provider}',(p&&(p.name[currentLang]||p.name.en||p.short))||''); }
-  function satCaptureLabel(p){ if(!p) return ''; if(!p.dated) return t('satLatest'); if(p.dateMode==='year') return satState.year+' '+t('satMosaicSuffix'); return satState.day; }
-  function satChipHTML(){ const p=satProviderById(satState.providerId); if(!p) return ''; return `<span class="cr-sat">📡 ${p.short} · ${satCaptureLabel(p)}</span>`; }
-  function satRefreshReadout(){ try{ renderCoordReadout(); }catch(_){} }
-  function satToast(msg){
-    let el=document.getElementById('sat-toast');
-    if(!el){ el=document.createElement('div'); el.id='sat-toast'; el.className='sat-toast'; document.body.appendChild(el); }
-    el.textContent=msg; el.classList.add('show');
-    clearTimeout(satToast._t); satToast._t=setTimeout(()=>el.classList.remove('show'),4400);
-  }
-  /* Self-rescheduling style-ready guard (same pattern that fixed the layer race). */
-  function satReady(cb,n){ n=n||0; if(map&&map.isStyleLoaded()){ try{cb();}catch(_){ } return; } if(n>80) return; setTimeout(()=>satReady(cb,n+1),160); }
-  function satBuildTiles(p){
-    const da=p.dateMode==='year'?satState.year:satState.day;
-    if(p.tier==='pro'){ const k=satKeys[p.keyName]; if(!k||!String(k).trim()) return null; return p.tiles(da,String(k).trim()); }
-    return p.tiles(da);
-  }
-  /* Core: load the selected provider into the idle buffer, then cross-fade (double-buffering). */
-  function satApply(animate){
-    if(!map) return;
-    const p=satProviderById(satState.providerId); if(!p) return;
-    satErrCount=0;
-    /* Esri = the always-present base layer (layer-sat): no buffer needed → it is our fallback. */
-    if(p.id==='esri'){ satShowBase(animate); return; }
-    const tiles=satBuildTiles(p);
-    if(!tiles){ satToast(t('satLocked')); satRevertToFallback(); return; }
-    if(map.getLayer('layer-sat')) map.setPaintProperty('layer-sat','raster-opacity',1); /* solid fallback under the buffer */
-    const target=(satActive===0)?1:0, srcId='sat-src-'+target, lyrId='sat-fx-'+target;
-    try{ if(map.getLayer(lyrId)) map.removeLayer(lyrId); if(map.getSource(srcId)) map.removeSource(srcId); }catch(_){}
-    try{
-      map.addSource(srcId,{type:'raster',tiles:tiles,tileSize:256,maxzoom:p.maxzoom||19,attribution:p.attribution||''});
-      const before=map.getLayer('layer-sat-labels')?'layer-sat-labels':undefined;
-      map.addLayer({id:lyrId,type:'raster',source:srcId,layout:{visibility:'visible'},
-        paint:{'raster-opacity':animate?0:satState.opacity,'raster-opacity-transition':{duration:animate?450:0}}},before);
-    }catch(e){ console.warn('satApply add failed',e); return; }
-    const prev=satActive;
-    const finish=()=>{
-      if(map.getLayer(lyrId)) map.setPaintProperty(lyrId,'raster-opacity',satState.opacity);
-      if(prev!==-1 && prev!==target){
-        const pl='sat-fx-'+prev, ps='sat-src-'+prev;
-        if(map.getLayer(pl)){ map.setPaintProperty(pl,'raster-opacity-transition',{duration:450}); map.setPaintProperty(pl,'raster-opacity',0); }
-        setTimeout(()=>{ if(satActive!==prev){ try{ if(map.getLayer(pl)) map.removeLayer(pl); if(map.getSource(ps)) map.removeSource(ps); }catch(_){} } },520);
-      }
-      satActive=target; satLastGood=satState.providerId; satErrCount=0;
-    };
-    if(!animate){ finish(); return; }
-    let done=false;
-    const onData=(e)=>{ if(e&&e.sourceId===srcId&&e.isSourceLoaded){ if(done)return; done=true; map.off('sourcedata',onData); finish(); } };
-    map.on('sourcedata',onData);
-    setTimeout(()=>{ if(!done){ done=true; map.off('sourcedata',onData); finish(); } },1900);
-  }
-  function satShowBase(animate){
-    if(satActive!==-1){
-      const a=satActive, pl='sat-fx-'+a, ps='sat-src-'+a;
-      if(map.getLayer(pl)){ map.setPaintProperty(pl,'raster-opacity-transition',{duration:animate?450:0}); map.setPaintProperty(pl,'raster-opacity',0); }
-      setTimeout(()=>{ if(satState.providerId==='esri'){ try{ if(map.getLayer(pl)) map.removeLayer(pl); if(map.getSource(ps)) map.removeSource(ps); }catch(_){} } },animate?520:0);
-      satActive=-1;
-    }
-    if(map.getLayer('layer-sat')) map.setPaintProperty('layer-sat','raster-opacity',satState.opacity);
-    satLastGood='esri';
-  }
-  function satSetOpacity(v){
-    satState.opacity=v;
-    const p=satProviderById(satState.providerId);
-    if(p&&p.id==='esri'){ if(map.getLayer('layer-sat')) map.setPaintProperty('layer-sat','raster-opacity',v); }
-    else if(satActive!==-1&&map.getLayer('sat-fx-'+satActive)){ map.setPaintProperty('sat-fx-'+satActive,'raster-opacity',v); }
-  }
-  function satSelectProvider(id){
-    const p=satProviderById(id); if(!p) return;
-    if(!satHasKey(p)){ satToast(t('satLocked')); satRenderController(); return; }
-    satState.providerId=id; satErrCount=0; satAutoBackoff=0;
-    satRenderController(); satApply(true); satRefreshReadout();
-  }
-  function satStepDay(delta,auto){
-    if(!auto) satAutoBackoff=0;
-    const d=new Date(satState.day+'T00:00:00Z'); if(isNaN(d.getTime())) return;
-    d.setUTCDate(d.getUTCDate()+delta);
-    let s=d.toISOString().slice(0,10); const today=satMaxDay(); if(s>today) s=today;
-    satState.day=s;
-    const inp=document.getElementById('satc-day'); if(inp) inp.value=s;
-    satApply(true); satRefreshReadout();
-  }
-  function satRevertToFallback(){
-    const fb=(satLastGood&&satLastGood!==satState.providerId)?satLastGood:'esri';
-    satState.providerId=fb; satErrCount=0;
-    satRenderController(); satApply(true); satRefreshReadout();
-  }
-  /* Render-state tracking: tile/auth failures on a sat buffer → notify + fall back. */
-  function satOnError(e){
-    if(!e||!e.sourceId||String(e.sourceId).indexOf('sat-src-')!==0) return;
-    const p=satProviderById(satState.providerId); if(!p) return;
-    const st=e.error&&e.error.status;
-    if(st===401||st===403){ satToast(satMsg('satErrAuth',p)); satErrCount=0; satRevertToFallback(); return; }
-    satErrCount++;
-    /* Dated GIBS day-layers: the latest day may not be processed yet → walk back to the freshest
-       AVAILABLE day before giving up, so "latest" really means latest-that-exists. */
-    if(p.dated && p.dateMode==='day' && satAutoBackoff<5 && satErrCount>=2){
-      satAutoBackoff++; satErrCount=0; satStepDay(-1,true); return;
-    }
-    if(satErrCount>=4){ satErrCount=0; satToast(satMsg('satErrTiles',p)); satRevertToFallback(); }
-  }
-  /* Sat-Controller panel (provider + capture-date + opacity). Rebuilt on change / language. */
-  function satRenderController(){
-    const panel=document.getElementById('sat-controller'); if(!panel) return;
-    const p=satProviderById(satState.providerId)||SAT_PROVIDERS[0];
-    let opts='';
-    SAT_PROVIDERS.forEach(pr=>{
-      const sel=pr.id===satState.providerId?' selected':'', nm=pr.name[currentLang]||pr.name.en;
-      if(pr.tier==='free') opts+=`<option value="${pr.id}"${sel}>${nm}</option>`;
-      else { const has=satHasKey(pr); opts+=`<option value="${pr.id}"${sel}${has?'':' disabled'}>${has?'':'🔒 '}${nm}${has?'':' — '+t('satLocked')}</option>`; }
-    });
-    let dateCtrl;
-    if(p.dated&&p.dateMode==='day'){
-      dateCtrl=`<div class="satc-row"><label>${t('satDate')}</label><div class="satc-date"><button class="satc-step" id="satc-prev" title="${t('satPrevDay')}">◀</button><input type="date" id="satc-day" value="${satState.day}" max="${satMaxDay()}"><button class="satc-step" id="satc-next" title="${t('satNextDay')}">▶</button></div></div>`;
-    } else if(p.dated&&p.dateMode==='year'){
-      const yo=p.years.map(y=>`<option value="${y}"${y===satState.year?' selected':''}>${y}</option>`).join('');
-      dateCtrl=`<div class="satc-row"><label>${t('satDate')}</label><select id="satc-year">${yo}</select></div>`;
-    } else {
-      dateCtrl=`<div class="satc-row"><label>${t('satDate')}</label><span class="satc-latest">${t('satLatest')}</span></div>`;
-    }
-    panel.innerHTML=`<div class="satc-head">📡 <span>${t('satCtrlTitle')}</span><button id="satc-close" title="${currentLang==='jp'?'閉じる':currentLang==='de'?'Schließen':currentLang==='ru'?'Закрыть':currentLang==='es'?'Cerrar':'Close'}" aria-label="Close" style="margin-left:auto;background:transparent;border:none;color:var(--text-muted);width:26px;height:26px;font-size:22px;font-weight:300;line-height:1;cursor:pointer;">×</button></div>`+
-      `<div class="satc-row"><label>${t('satProvider')}</label><select id="satc-provider">${opts}</select></div>`+
-      dateCtrl+
-      `<div class="satc-row"><label>${t('opacity')}</label><input type="range" id="satc-op" min="0.2" max="1" step="0.05" value="${satState.opacity}"></div>`+
-      aiSatChangeBlockHTML(p)+
-      `<div class="satc-attr">${p.attribution||''}</div>`;
-    const sp=panel.querySelector('#satc-provider'); if(sp) sp.onchange=ev=>satSelectProvider(ev.target.value);
-    const dd=panel.querySelector('#satc-day'); if(dd) dd.onchange=ev=>{ satState.day=ev.target.value||satState.day; satApply(true); satRefreshReadout(); };
-    const yy=panel.querySelector('#satc-year'); if(yy) yy.onchange=ev=>{ satState.year=parseInt(ev.target.value,10)||satState.year; satApply(true); satRefreshReadout(); };
-    const pv=panel.querySelector('#satc-prev'); if(pv) pv.onclick=()=>satStepDay(-1);
-    const nx=panel.querySelector('#satc-next'); if(nx) nx.onclick=()=>satStepDay(1);
-    const op=panel.querySelector('#satc-op'); if(op) op.oninput=ev=>satSetOpacity(parseFloat(ev.target.value));
-    const cb=panel.querySelector('#ai-satchange-btn'); if(cb){ cb.classList.toggle('ai-needs-key',!aiVisionReady()); cb.title=aiVisionReady()?'':(aiReady()?t('aiNoVision'):t('aiNoKey')); cb.onclick=aiSatChangeDetect; }
-    const cl=panel.querySelector('#satc-close'); if(cl) cl.onclick=()=>{ satPanelDismissed=true; panel.style.display='none'; };
-  }
-  /* Settings-modal API-key management (Pro / BYOK providers). */
-  function satRenderKeyInputs(){
-    const wrap=document.getElementById('sat-keys-list'); if(!wrap) return;
-    /* Only Pro users may register their own (paid) satellite imagery providers. */
-    if(!imIsPro()){
-      wrap.innerHTML=`<div style="font-size:12.5px;color:var(--text-muted);line-height:1.55;padding:4px 0;">${currentLang==='jp'?'🔒 独自の衛星画像サービス（API連携）を追加できるのは <b>Pro</b> ユーザーのみです。':currentLang==='de'?'🔒 Nur <b>Pro</b>-Nutzer können eigene Satellitenbild-Dienste (API-Integrationen) hinzufügen.':currentLang==='ru'?'🔒 Только пользователи <b>Pro</b> могут добавлять собственные сервисы спутниковых снимков (API).':currentLang==='es'?'🔒 Solo los usuarios <b>Pro</b> pueden añadir sus propios servicios de imágenes satelitales (API).':'🔒 Only <b>Pro</b> users can add their own satellite imagery services (API integrations).'}<br><button type="button" id="sat-keys-upgrade" style="margin-top:8px;background:linear-gradient(135deg,#ffe08a,#e9b949);color:#7a5a00;border:none;padding:8px 14px;border-radius:8px;font-weight:700;font-size:12px;cursor:pointer;">${currentLang==='jp'?'IntMap Pro を見る':currentLang==='de'?'IntMap Pro ansehen':currentLang==='ru'?'Смотреть IntMap Pro':currentLang==='es'?'Ver IntMap Pro':'See IntMap Pro'}</button></div>`;
-      const up=wrap.querySelector('#sat-keys-upgrade'); if(up) up.onclick=()=>{ try{ if(typeof window.openProModal==='function') window.openProModal(); }catch(_){} };
-      return;
-    }
-    wrap.innerHTML=SAT_PROVIDERS.filter(p=>p.tier==='pro').map(p=>{
-      const v=satKeys[p.keyName]||'', on=!!String(v).trim();
-      const nm=(p.keyLabel&&(p.keyLabel[currentLang]||p.keyLabel.en))||(p.name[currentLang]||p.name.en);
-      return `<div class="sat-key-row"><div class="sat-key-top"><span class="sat-key-name">${nm}</span>`+
-        `<span class="sat-key-status ${on?'on':''}">${on?'● '+t('satKeyConnected'):'○ '+t('satKeyNone')}</span></div>`+
-        `<input type="text" class="sat-key-input" data-keyname="${p.keyName}" value="${String(v).replace(/"/g,'&quot;')}" placeholder="${String(p.keyPh||'').replace(/"/g,'&quot;')}" autocomplete="off" autocapitalize="off" spellcheck="false"></div>`;
-    }).join('');
-  }
-  function satSaveKeyInputs(){
-    const wrap=document.getElementById('sat-keys-list'); if(!wrap) return;
-    wrap.querySelectorAll('.sat-key-input').forEach(inp=>{ const k=inp.getAttribute('data-keyname'), val=inp.value.trim(); if(val) satKeys[k]=val; else delete satKeys[k]; });
-    saveSatKeys();
-    const cur=satProviderById(satState.providerId);
-    if(cur&&cur.tier==='pro'&&!satHasKey(cur)&&currentMapType==='sat') satRevertToFallback();
-    else if(currentMapType==='sat') satRenderController();
-  }
-  function satSetup(){
-    if(!map) return;
-    if(!satSetup._wired){ satSetup._wired=true; try{ map.on('error',satOnError); }catch(_){}
-      /* (#R24) auto-dismiss the FLOATING satellite controller when the user starts operating elsewhere
-         ("それ以外の場所を操作し始めたら自動で消える"); it re-opens via the Satellite button (which resets
-         satPanelDismissed). On mobile it lives inside the sheet (not floating), so leave that one alone. */
-      const _satDismiss=()=>{ try{ const p=document.getElementById('sat-controller');
-        if(p && p.style.display==='block' && !(window.matchMedia&&window.matchMedia('(max-width:768px)').matches)){ satPanelDismissed=true; p.style.display='none'; } }catch(_){} };
-      try{ map.on('dragstart',_satDismiss); map.on('zoomstart',(e)=>{ if(e&&e.originalEvent) _satDismiss(); }); }catch(_){}
-      document.addEventListener('pointerdown',(e)=>{ try{ const p=document.getElementById('sat-controller');
-        if(p && p.style.display==='block' && e.target && !e.target.closest('#sat-controller') && !e.target.closest('#btn-view-sat')) _satDismiss(); }catch(_){} }, true);
-    }
-    if(currentMapType==='sat') satReady(()=>{ satRenderController(); satApply(false); });
-  }
+  /* (#R169) moved verbatim to js/satellite.js — see Architecture.md §3.1. */
   /* Debug aid (same spirit as window.__imap / window.refreshDatedLayer): inspect the sat engine. */
   try{ window.__sat={ providers:SAT_PROVIDERS, state:satState, keys:()=>satKeys, build:satBuildTiles, hasKey:satHasKey,
     render:satRenderController, apply:satApply, select:satSelectProvider, setOpacity:satSetOpacity, step:satStepDay,
@@ -1621,14 +1313,7 @@ window.addEventListener('DOMContentLoaded', () => {
     aiConfig.models=Object.assign({},s.models||{});
     if(typeof s.model==='string' && s.model && !aiConfig.models[aiConfig.provider]) aiConfig.models[aiConfig.provider]=s.model; /* migrate legacy single-model field */
   } }catch(_){}
-  const saveAIConfig=()=>{ try{ localStorage.setItem('intmap_ai_config',JSON.stringify(aiConfig)); }catch(_){} };
-  /* (#R27) Account-based AI: the first-party server proxy is ALWAYS configured (see INTMAP_AI_PROXY
-     below), so the engine is always "ready" to RECEIVE a click. The real gate — login required + the
-     per-day free quota — is enforced in aiGate() at click time and authoritatively re-checked on the
-     server. Buttons therefore never appear greyed-out as "needs key" (BYOK is retired). */
-  function aiReady(){ return (typeof aiProxyOn==='function') ? aiProxyOn() : true; }
-  function aiVisionReady(){ return aiReady(); }
-  function aiErrSnippet(txt){ try{ const j=JSON.parse(txt); return (j.error&&(j.error.message||j.error.code))||JSON.stringify(j).slice(0,180); }catch(_){ return String(txt||'').slice(0,180); } }
+  /* (#R169) moved verbatim to js/ai-core.js — see Architecture.md §3.1. */
 
 
   /* ---- (#R27) FIRST-PARTY, ACCOUNT-BASED AI -----------------------------------------------------
@@ -1643,297 +1328,39 @@ window.addEventListener('DOMContentLoaded', () => {
   if(!window.INTMAP_AI_PROXY.url){
     try{ window.INTMAP_AI_PROXY.url = (window.SUPABASE_URL||'').replace(/\/$/,'') + '/functions/v1/ai-proxy'; }catch(_){ window.INTMAP_AI_PROXY.url=''; }
   }
-  function aiProxyOn(){ try{ return !!(window.INTMAP_AI_PROXY && window.INTMAP_AI_PROXY.url); }catch(_){ return false; } }
-  const aiJP=()=>(typeof currentLang!=='undefined'&&currentLang==='jp');
-  function aiToday(){ try{ return new Date().toISOString().slice(0,10); }catch(_){ return ''; } }   /* UTC date — matches the server */
+  /* (#R169) moved verbatim to js/ai-core.js — see Architecture.md §3.1. */
+   /* UTC date — matches the server */
   /* Quota state, kept in sync from each server response + an on-login fetch. limit is plan-driven
      (the server is the source of truth); aiDailyLimit() centralizes the number for easy plan tiers. */
   let aiUsage = { date:'', used:0, limit:AI_FREE_DAILY };
-  /* (#R31) Developer = unlimited AI. Enabled by localStorage intmap_dev='1' or the owner's account email.
-     This lifts the CLIENT-side gate; for a truly unlimited server quota, the ai-proxy function also grants
-     the dev user id/email an unlimited plan (DEV_USER_IDS / DEV_EMAILS secret) — see DEV-NOTES. */
-  function aiDev(){ try{ if(localStorage.getItem('intmap_dev')==='1') return true;
-    /* (#R36) ROOT CAUSE of "開発者なのに無制限が設定欄のグラフに反映されない（まだ変わっていない）": the dev flag was
-       only set by logging in with the owner email, but the developer runs this build LOCALLY (file:// or
-       localhost) without logging in → aiDev() stayed false → the graph showed the 5/day quota. Treat the local
-       dev environment itself as the developer context. The PUBLIC site is served from its real domain, so
-       end-users on the deployed site are unaffected (their quota is unchanged). */
-    const proto=location.protocol, h=location.hostname;
-    if(proto==='file:'||h==='localhost'||h==='127.0.0.1'||h==='[::1]'||h===''){ try{ localStorage.setItem('intmap_dev','1'); }catch(_){} return true; }
-    const e=(typeof currentUser!=='undefined'&&currentUser&&currentUser.email)||''; return /2ppzc4kk6r@privaterelay\.appleid\.com/i.test(e); }catch(_){ return false; } }
+  /* (#R169) moved verbatim to js/ai-core.js — see Architecture.md §3.1. */
   window.aiDev=aiDev;
-  function aiDailyLimit(){ return (aiUsage && aiUsage.limit) || AI_FREE_DAILY; }
-  function aiUsesLeft(){ if(aiDev()) return Infinity; if(aiUsage.date!==aiToday()) return aiDailyLimit(); return Math.max(0, aiDailyLimit() - (aiUsage.used||0)); }
-  function aiSetUsage(used, limit){
-    aiUsage.date=aiToday();
-    if(typeof used==='number') aiUsage.used=used;
-    if(typeof limit==='number' && limit>0) aiUsage.limit=limit;
-    try{ aiRenderSettings(); }catch(_){}
-  }
-  function aiLoginMsg(){ return aiJP()?'AI機能を使うにはログインが必要です。':'Please log in to use AI features.'; }
-  function aiLimitMsg(){ return aiJP()?'本日の無料AI使用回数に達しました。':'You have reached today’s free AI limit.'; }
-  /* Fetch today's usage for the logged-in user (RLS lets a user read only their own row). Lets the
-     gate block + the Settings panel show "残り N/5" BEFORE any AI request is spent. */
-  async function aiFetchUsage(){
-    try{
-      if(!currentUser || !window.sb){ return; }
-      const { data } = await window.sb.from('ai_usage').select('count').eq('user_id',currentUser.id).eq('usage_date',aiToday()).maybeSingle();
-      aiSetUsage(data && typeof data.count==='number' ? data.count : 0, aiDailyLimit());
-    }catch(_){}
-  }
+  /* (#R169) moved verbatim to js/ai-core.js — see Architecture.md §3.1. */
   window.aiFetchUsage=aiFetchUsage;
-  /* The single click-time gate every AI feature runs FIRST. Extensible: future paid plans only need to
-     raise the limit the server returns (aiUsage.limit) — no per-feature change. */
-  function aiGate(){
-    if(typeof currentUser==='undefined' || !currentUser){ try{ openAuthModal(aiLoginMsg()); }catch(_){ try{ aiToast(aiLoginMsg()); }catch(__){} } return false; }
-    if(aiUsage.date===aiToday() && aiUsesLeft()<=0){ try{ aiToast(aiLimitMsg()); }catch(_){} return false; }
-    return true;
-  }
+  /* (#R169) moved verbatim to js/ai-core.js — see Architecture.md §3.1. */
   window.aiGate=aiGate;
-  /* (#R113) Map a typed PROVIDER error (ai-proxy 502/503) to a clear, localized message. These are DISTINCT from
-     the IntMap daily free-use limit (HTTP 429) — a Google-side 429 must never be shown as "out of free uses". */
-  function aiProviderErrMsg(code, message){
-    const _pl=(en,jp,de,ru,es)=>currentLang==='jp'?jp:currentLang==='de'?de:currentLang==='ru'?ru:currentLang==='es'?(es||en):en;
-    const M={
-      provider_rate_limit:_pl('The AI service is busy right now — please try again in a moment (this is not your IntMap usage limit).','AIサービスが混雑しています。少し待って再試行してください（IntMapの利用回数上限ではありません）。','Der KI-Dienst ist gerade ausgelastet — bitte gleich erneut versuchen (nicht Ihr IntMap-Limit).','Сервис ИИ сейчас перегружен — повторите через мгновение (это не ваш лимит IntMap).','El servicio de IA está ocupado — inténtalo de nuevo en un momento (no es tu límite de IntMap).'),
-      provider_quota:_pl('The AI provider quota was reached — this is separate from your IntMap free uses. Please try again later.','AIプロバイダ側の利用上限に達しました（あなたのIntMap無料利用枠とは別です）。後ほど再試行してください。','Das Kontingent des KI-Anbieters ist erschöpft — getrennt von Ihren IntMap-Freinutzungen. Später erneut versuchen.','Достигнут лимит провайдера ИИ — это отдельно от бесплатных использований IntMap. Повторите позже.','Se alcanzó la cuota del proveedor de IA — es independiente de tus usos gratuitos de IntMap. Inténtalo más tarde.'),
-      provider_empty:_pl('The AI returned an empty response — please try again.','AIが空の応答を返しました。もう一度お試しください。','Die KI lieferte eine leere Antwort — bitte erneut versuchen.','ИИ вернул пустой ответ — повторите попытку.','La IA devolvió una respuesta vacía — inténtalo de nuevo.'),
-      provider_malformed:_pl('The AI response was malformed — please try again.','AIの応答が不正な形式でした。もう一度お試しください。','Die KI-Antwort war fehlerhaft — bitte erneut versuchen.','Ответ ИИ был некорректным — повторите попытку.','La respuesta de la IA fue incorrecta — inténtalo de nuevo.'),
-      provider_blocked:_pl('The AI safety filter blocked that. Try rephrasing it as a public-information, broad-area analysis (e.g. an approximate zone or reach rings for defence/preparedness) rather than precise targeting.','AIの安全フィルタによりブロックされました。正確な標的指定ではなく、公開情報に基づく広域の分析（例：おおよそのゾーンや到達圏の表示など、防災・脅威評価目的）として言い換えてお試しください。','Der KI-Sicherheitsfilter hat das blockiert. Formulieren Sie es als öffentlich-informationsbasierte, großräumige Analyse (z. B. eine ungefähre Zone oder Reichweitenringe für Verteidigung/Vorsorge) statt als präzise Zielerfassung.','Фильтр безопасности ИИ заблокировал это. Переформулируйте как анализ по открытым данным для широкой области (например, приблизительная зона или кольца досягаемости для обороны/готовности), а не точное целеуказание.','El filtro de seguridad de la IA lo bloqueó. Reformúlalo como un análisis de información pública y de área amplia (p. ej., una zona aproximada o anillos de alcance para defensa/preparación) en lugar de una localización precisa de objetivos.'),
-      provider_unavailable:_pl('The AI service is temporarily unavailable — please try again shortly.','AIサービスが一時的に利用できません。少し後に再試行してください。','Der KI-Dienst ist vorübergehend nicht verfügbar — bitte gleich erneut versuchen.','Сервис ИИ временно недоступен — повторите вскоре.','El servicio de IA no está disponible temporalmente — inténtalo pronto.'),
-      invalid_structured_output:_pl('The AI structured output was invalid — please try again.','AIの構造化出力が不正でした。もう一度お試しください。','Die strukturierte KI-Ausgabe war ungültig — bitte erneut versuchen.','Структурированный вывод ИИ был неверным — повторите попытку.','La salida estructurada de la IA no era válida — inténtalo de nuevo.')
-    };
-    return M[code] || ('AI: '+(message||code||'error'));
-  }
-  /* (#R132) FULL-envelope server call: returns {text, meta, citations} for a SINGLE call (no reliance on the global
-     window._aiLastMeta, which a concurrent call can overwrite) and accepts opts.signal for real AbortController
-     cancellation (a timed-out / cancelled region-resolution call now aborts the underlying fetch instead of leaving
-     it running in the background). aiCallServer stays a thin text-only wrapper so every existing caller is unchanged. */
-  async function aiCallServerFull(prompt, system, imgs, opts){
-    const cfg=window.INTMAP_AI_PROXY||{};
-    const headers={'Content-Type':'application/json'};
-    if(cfg.headerName && cfg.headerValue) headers[cfg.headerName]=cfg.headerValue;
-    /* Attach the Supabase session JWT + anon apikey so the function can identify the user + enforce quota. */
-    let token='';
-    try{ const r=await window.sb.auth.getSession(); token=(r&&r.data&&r.data.session&&r.data.session.access_token)||''; }catch(_){}
-    if(window.SUPABASE_ANON_KEY){ headers['apikey']=window.SUPABASE_ANON_KEY; if(!token) headers['Authorization']='Bearer '+window.SUPABASE_ANON_KEY; }
-    if(token) headers['Authorization']='Bearer '+token;
-    const body={ prompt, system:system||'', images:(imgs||[]), lang:(typeof currentLang!=='undefined'?currentLang:'en') };
-    /* (#R113) task-aware contract: tell the proxy WHICH feature this is (output budget / JSON+structured-output
-       mode / web policy are chosen per-task server-side) instead of one MAX_TOKENS + one boolean for everything. */
-    if(opts){
-      if(opts.task) body.task=String(opts.task);
-      /* webMode: 'off' | 'auto' | 'required'. Back-compat: a bare {web:true} maps to 'auto'. */
-      body.webMode = opts.webMode ? String(opts.webMode) : (opts.web ? 'auto' : 'off');
-      if(body.webMode!=='off') body.web=true;   /* keep the legacy boolean in sync for the Anthropic native-search path */
-      if(opts.requestedCount!=null && isFinite(+opts.requestedCount)) body.requestedCount=+opts.requestedCount;
-      if(opts.schema && typeof opts.schema==='object') body.schema=opts.schema;
-      if(opts.effortHint) body.effortHint=String(opts.effortHint);   /* (#R117) complexity hint → planner/analysis may think at "high" server-side */
-      if(opts.imageDetail) body.imageDetail=String(opts.imageDetail);   /* (#R156) "high" → OpenAI input_image detail:high (small-text/math OCR); server clamps by task */
-    }
-    const fetchOpts={method:'POST',headers,body:JSON.stringify(body)};
-    if(opts&&opts.signal) fetchOpts.signal=opts.signal;   /* (#R132) real Abort */
-    const r=await fetch(cfg.url,fetchOpts);
-    if(r.status===401){ try{ openAuthModal(aiLoginMsg()); }catch(_){} throw new Error(aiLoginMsg()); }
-    if(r.status===429){ let j=null; try{ j=await r.json(); }catch(_){} if(j&&typeof j.used==='number') aiSetUsage(j.used, j.limit); else { aiUsage.date=aiToday(); aiUsage.used=aiDailyLimit(); } throw new Error(aiLimitMsg()); }
-    if(!r.ok){
-      /* (#R113) a typed PROVIDER error (502/503) is NOT the IntMap daily limit — surface a clear, distinct message
-         (and never mislabel a Google-side 429 as "out of free uses"). */
-      let ej=null; try{ ej=await r.json(); }catch(_){}
-      if(ej&&ej.error) throw new Error(aiProviderErrMsg(ej.error, ej.message));
-      throw new Error('AI '+r.status+': '+aiErrSnippet(await r.text().catch(()=>'')));
-    }
-    const j=await r.json().catch(()=>null);
-    if(j==null) return {text:'',meta:null,citations:[]};
-    if(typeof j.used==='number') aiSetUsage(j.used, j.limit);
-    const meta=(j&&typeof j==='object'&&j.meta&&typeof j.meta==='object')?j.meta:null;
-    const citations=(j&&typeof j==='object'&&Array.isArray(j.citations))?j.citations:[];
-    /* (#R114/#R131) still mirror to the globals for the many existing readers, but the ENVELOPE is authoritative per call. */
-    try{ window._aiLastMeta=meta; }catch(_){}
-    try{ window._aiLastCitations=citations; }catch(_){}
-    let text='';
-    if(typeof j==='string') text=j;
-    else if(typeof j.text==='string') text=j.text;
-    else if(j.content&&Array.isArray(j.content)) text=j.content.map(b=>b.text||'').join('');
-    else if(j.choices&&j.choices[0]) text=(j.choices[0].message&&j.choices[0].message.content)||j.choices[0].text||'';
-    return {text, meta, citations};
-  }
-  async function aiCallServer(prompt, system, imgs, opts){ return (await aiCallServerFull(prompt, system, imgs, opts)).text; }
-  /* ---- Unified entry point used by every AI feature ---- */
-  async function askAI(prompt, systemPrompt, imageDatas, opts){
-    const imgs=(imageDatas||[]).filter(Boolean);
-    /* Account-based path (always on). Gate first so we never spend a network round-trip when the user
-       is logged out / over quota, and so the auth modal opens immediately. */
-    if(!currentUser){ try{ openAuthModal(aiLoginMsg()); }catch(_){} throw new Error(aiLoginMsg()); }
-    if(aiUsage.date===aiToday() && aiUsesLeft()<=0){ throw new Error(aiLimitMsg()); }
-    if(aiProxyOn()) return aiCallServer(prompt, systemPrompt, imgs, opts);
-    throw new Error(aiLimitMsg());
-  }
-  async function askAIJSON(prompt, systemPrompt, imageDatas, opts){ opts=opts||{}; if(!opts.task) opts.task='json_extract';   /* (#R113) JSON call → server JSON/structured-output mode by default */
-    return aiParseJSON(await askAI(prompt, systemPrompt, imageDatas, opts)); }
-  /* (#R132) ENVELOPE variants — same gating as askAI/askAIJSON but return {text|data, meta, citations} for a SINGLE
-     call (no reliance on the global window._aiLastMeta a concurrent call could clobber) and forward opts.signal for
-     real AbortController cancellation. Used by the region resolver so one resolve reads exactly its own meta/citations. */
-  async function askAIEnvelope(prompt, systemPrompt, imageDatas, opts){
-    const imgs=(imageDatas||[]).filter(Boolean);
-    if(!currentUser){ try{ openAuthModal(aiLoginMsg()); }catch(_){} throw new Error(aiLoginMsg()); }
-    if(aiUsage.date===aiToday() && aiUsesLeft()<=0){ throw new Error(aiLimitMsg()); }
-    if(aiProxyOn()) return aiCallServerFull(prompt, systemPrompt, imgs, opts);
-    throw new Error(aiLimitMsg()); }
-  async function askAIJSONEnvelope(prompt, systemPrompt, imageDatas, opts){ opts=opts||{}; if(!opts.task) opts.task='json_extract';
-    const env=await askAIEnvelope(prompt, systemPrompt, imageDatas, opts);
-    return { data:aiParseJSON(env.text), text:env.text, meta:env.meta, citations:env.citations }; }
+  /* (#R169) moved verbatim to js/ai-core.js — see Architecture.md §3.1. */
   /* (#R39) Force the AI OUTPUT language to follow the app language. The inline brief/summary prompts only had
      EN/JP branches, so German/Russian users got English answers ("AI Briefがドイツ語・ロシア語では英語になる").
      Appended to the SYSTEM prompt of the free-TEXT generators ONLY — never the JSON geocoders (place names
      must stay canonical) nor the connectivity test. Harmless/​reinforcing for EN/JP. */
   function _aiLangName(){ return ({en:'English',jp:'Japanese',de:'German',ru:'Russian',es:'Spanish'})[currentLang]||'English'; }
   window._aiLangLine=function(){ const L=_aiLangName(); return ' IMPORTANT: Write your ENTIRE response in '+L+' only — every sentence, heading and bullet must be in '+L+', regardless of the language of the input or these instructions. Do not reply in English unless '+L+' is English.'+(L==='Japanese'?' When writing in Japanese, use polite form (です・ます／敬語) by default unless the user is clearly casual or explicitly asks for plain/casual speech.':''); };   /* (#R147) Japanese default = keigo */
-  function aiParseJSON(raw){
-    if(raw==null) return null;
-    let s=String(raw).trim();
-    const fence=s.match(/```(?:json)?\s*([\s\S]*?)```/i); if(fence) s=fence[1].trim();
-    const seg=s.match(/[\[{][\s\S]*[\]}]/); if(seg) s=seg[0];
-    try{ return JSON.parse(s); }catch(_){ try{ return JSON.parse(s.replace(/,\s*([\]}])/g,'$1')); }catch(__){ return null; } }
-  }
-
-  /* ---- Shared UI: toast + report popup (used by all four features) ---- */
-  function aiToast(msg){
-    let el=document.getElementById('ai-toast');
-    if(!el){ el=document.createElement('div'); el.id='ai-toast'; el.className='sat-toast'; document.body.appendChild(el); }
-    el.textContent=msg; el.classList.add('show');
-    clearTimeout(aiToast._t); aiToast._t=setTimeout(()=>el.classList.remove('show'),4600);
-  }
-  function aiEsc(s){ return String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
-  /* Generic report popup. opts:{title, sub, images:[{src,caption}]}. Returns an api
-     with setLoading()/setBody(text)/setError(msg,onRetry)/close(). */
-  function aiReport(opts){
-    opts=opts||{};
-    let ov=document.getElementById('ai-report-modal');
-    if(!ov){ ov=document.createElement('div'); ov.id='ai-report-modal'; ov.className='modal-overlay'; document.body.appendChild(ov);
-      ov.addEventListener('click',e=>{ if(e.target===ov) ov.style.display='none'; }); }
-    const imgsHtml=(opts.images&&opts.images.length)?`<div class="ai-report-imgs">${opts.images.map(im=>`<figure><img src="${aiEsc(im.src)}">${im.caption?`<figcaption>${aiEsc(im.caption)}</figcaption>`:''}</figure>`).join('')}</div>`:'';
-    ov.innerHTML=`<div class="modal-content">
-      <div class="ai-report-head">✨ <span>${aiEsc(opts.title||'AI')}</span></div>
-      ${opts.sub?`<div class="ai-report-sub">${aiEsc(opts.sub)}</div>`:''}
-      ${imgsHtml}
-      <div class="ai-report-body loading" id="ai-report-body"><span class="ai-spin"></span><span>${aiEsc(t('aiThinking'))}</span></div>
-      <div class="ai-report-actions" id="ai-report-actions"></div>
-    </div>`;
-    ov.style.display='flex';
-    const bodyEl=ov.querySelector('#ai-report-body'), actEl=ov.querySelector('#ai-report-actions');
-    const api={
-      el:ov,
-      close(){ ov.style.display='none'; },
-      setLoading(msg){ bodyEl.className='ai-report-body loading'; bodyEl.innerHTML=`<span class="ai-spin"></span><span>${aiEsc(msg||t('aiThinking'))}</span>`; actEl.innerHTML=''; },
-      setBody(text){ bodyEl.className='ai-report-body'; bodyEl.textContent=String(text||'');
-        actEl.innerHTML=`<button id="ai-rep-copy">${aiEsc(t('aiCopy'))}</button><button class="primary" id="ai-rep-close">${aiEsc(t('aiClose'))}</button>`;
-        actEl.querySelector('#ai-rep-close').onclick=api.close;
-        actEl.querySelector('#ai-rep-copy').onclick=ev=>{ try{ navigator.clipboard.writeText(String(text||'')); ev.target.textContent=t('aiCopied'); }catch(_){} };
-      },
-      setError(msg,onRetry){ bodyEl.className='ai-report-body'; bodyEl.innerHTML=`<span style="color:#ff453a">⚠ ${aiEsc(t('aiError'))}</span><br><span style="font-size:12px;color:var(--text-muted)">${aiEsc(msg||'')}</span>`;
-        actEl.innerHTML=(onRetry?`<button id="ai-rep-retry">${aiEsc(t('aiRetry'))}</button>`:'')+`<button class="primary" id="ai-rep-close">${aiEsc(t('aiClose'))}</button>`;
-        actEl.querySelector('#ai-rep-close').onclick=api.close;
-        const rb=actEl.querySelector('#ai-rep-retry'); if(rb) rb.onclick=()=>{ api.setLoading(); onRetry(); };
-      }
-    };
-    return api;
-  }
-
-  /* ---- (#R27) Settings modal: AI section — account-based, NO key/provider/model picker ----
-     Built-in AI: nothing to configure. We only show login state + today's free-use counter. */
-  function aiRenderSettings(){
-    const wrap=document.getElementById('ai-settings-body'); if(!wrap) return;
-    const jp=aiJP();
-    /* (#R34) DEV = UNLIMITED — check this FIRST. It used to sit BELOW the "not logged in" early-return, so a
-       developer (intmap_dev flag, or logged in but currentUser not yet populated) saw the login prompt instead
-       of the unlimited state ("開発者なので無制限に / 設定欄のグラフに反映されていない"). */
-    if(aiDev()){
-      wrap.innerHTML=
-        /* (#R101) the "✨ Built-in AI is ready…" line duplicated the section hint above — removed (de-dup + no ✨). */
-        `<div class="ai-row" style="font-size:13px;color:var(--text-main);font-weight:600;">`+
-          aiEsc(jp?'開発者アカウント — AI利用は無制限です。':'Developer account — unlimited AI usage.')+
-          `<div style="height:7px;border-radius:5px;background:var(--input-bg);overflow:hidden;margin-top:8px;"><div style="height:100%;width:100%;background:linear-gradient(90deg,#34c759,#0a84ff);"></div></div>`+
-        `</div>`;
-      return;
-    }
-    if(typeof currentUser==='undefined' || !currentUser){
-      wrap.innerHTML=
-        /* (#R33) The in-Settings "Log in / Sign up" button was removed as redundant (use the account button
-           top-right). Only the explanatory line remains. */
-        `<div class="ai-row" style="font-size:12px;color:var(--text-muted);line-height:1.5;">`+
-          aiEsc(jp?'AI機能（要約・翻訳・位置解析・画像比較など）は、右上のアカウントからログインすると無料でご利用いただけます（1日'+AI_FREE_DAILY+'回まで）。APIキーは不要です。'
-                  :'AI features (summaries, translation, locating, image compare…) are free once you log in from the account button (top-right) — up to '+AI_FREE_DAILY+' uses per day. No API key needed.')+
-        `</div>`;
-      return;
-    }
-    const left=aiUsesLeft(), lim=aiDailyLimit(), used=Math.max(0, lim-left);
-    const pct=lim>0?Math.round((used/lim)*100):0;
-    const bar=`<div style="height:7px;border-radius:5px;background:var(--input-bg);overflow:hidden;margin-top:8px;"><div style="height:100%;width:${pct}%;background:${left>0?'var(--primary-color)':'#ff453a'};transition:width .25s;"></div></div>`;
-    wrap.innerHTML=
-      /* (#R101) the "✨ Built-in AI is ready…" line duplicated the section hint above — removed (de-dup + no ✨). */
-      `<div class="ai-row" style="font-size:13px;color:var(--text-main);font-weight:600;">`+
-        aiEsc(jp?('本日の無料利用： 残り '+left+' / '+lim+' 回')
-                :('Today’s free uses: '+left+' / '+lim+' left'))+
-        bar+
-        (left<=0?`<div style="font-size:11.5px;color:#ff453a;margin-top:7px;font-weight:500;">`+aiEsc(aiLimitMsg())+`</div>`:'')+
-      `</div>`;
-  }
+  /* (#R169) moved verbatim to js/ai-core.js — see Architecture.md §3.1. */
   window.aiRenderSettings=aiRenderSettings;
-  function aiSaveSettings(){ saveAIConfig(); try{ aiSyncFeatureButtons(); }catch(_){} }   /* (#R115) BYOK inputs are gone — nothing to read back */
+  /* (#R169) moved verbatim to js/ai-core.js — see Architecture.md §3.1. */
+   /* (#R115) BYOK inputs are gone — nothing to read back */
   /* Each AI feature registers a syncer here; called after the AI config changes so
      feature buttons can refresh their enabled/disabled state. */
   const aiButtonSyncers=[];
-  function aiSyncFeatureButtons(){ aiButtonSyncers.forEach(fn=>{ try{ fn(); }catch(_){} }); }
-  /* Toggle a busy spinner + disabled state on an .ai-action-btn (shared by all features). */
-  function aiSetBtnBusy(btn,busy,label){
-    if(!btn) return;
-    if(busy){ if(!btn.dataset.olabel) btn.dataset.olabel=btn.textContent; btn.disabled=true; btn.innerHTML='<span class="ai-spin"></span><span>'+aiEsc(label||btn.dataset.olabel)+'</span>'; }
-    else { btn.disabled=false; if(btn.dataset.olabel!=null){ btn.textContent=btn.dataset.olabel; delete btn.dataset.olabel; } }
-  }
+  /* (#R169) moved verbatim to js/ai-core.js — see Architecture.md §3.1. */
   /* Debug hook (same spirit as window.__sat / window.__imap). */
   try{ window.__ai={ config:()=>aiConfig, ready:aiReady, visionReady:aiVisionReady,
     ask:askAI, askJSON:askAIJSON, parse:aiParseJSON, report:aiReport, toast:aiToast, render:aiRenderSettings }; }catch(_){}
 
-  /* ===== AI FEATURE 4: satellite change detection (vision) =====
-     Capture the map canvas at two dates and ask a vision model to compare them. Requires
-     preserveDrawingBuffer:true on the map (set in the map config) + a vision-capable model. */
-  function aiSatChangeBlockHTML(p){
-    if(!p||!p.dated) return '';
-    const today=satMaxDay(); let inputs;
-    if(p.dateMode==='year'){
-      const yo=v=>(p.years||[]).map(y=>`<option value="${y}"${y===v?' selected':''}>${y}</option>`).join('');
-      inputs=`<select id="aic-date-a">${yo((p.years||[])[0])}</select><span>→</span><select id="aic-date-b">${yo((p.years||[])[(p.years||[]).length-1])}</select>`;
-    } else {
-      const dA=new Date(Date.now()-33*864e5).toISOString().slice(0,10);
-      inputs=`<input type="date" id="aic-date-a" value="${dA}" max="${today}"><span>→</span><input type="date" id="aic-date-b" value="${satState.day}" max="${today}">`;
-    }
-    return `<div class="aic-sec"><div class="aic-head">🛰 ${t('aiVisHead')}</div><div class="aic-dates">${inputs}</div><button class="ai-action-btn" id="ai-satchange-btn">✨ ${t('aiVisBtn')}</button></div>`;
-  }
-  function aiDownscaleDataURL(canvas,maxDim){
-    try{ const w=canvas.width,h=canvas.height,s=Math.min(1,(maxDim||1024)/Math.max(w,h));
-      const c=document.createElement('canvas'); c.width=Math.max(1,Math.round(w*s)); c.height=Math.max(1,Math.round(h*s));
-      c.getContext('2d').drawImage(canvas,0,0,c.width,c.height); return c.toDataURL('image/jpeg',0.85);
-    }catch(e){ return null; }
-  }
-  function aiWaitMapIdle(timeout){ return new Promise(res=>{ if(!map){ res(); return; } let done=false; const fin=()=>{ if(done)return; done=true; try{ map.off('idle',fin); }catch(_){} res(); }; try{ map.on('idle',fin); }catch(_){ } setTimeout(fin,timeout||4500); }); }
-  async function aiCaptureSatAt(p,val){
-    if(p.dateMode==='year') satState.year=parseInt(val,10)||satState.year; else satState.day=val;
-    try{ satApply(false); }catch(_){}
-    await aiWaitMapIdle(5000);
-    await new Promise(r=>setTimeout(r,500)); /* let the cross-fade buffer cleanup settle */
-    return await aiCaptureCanvas(1024);
-  }
-  /* Read the WebGL canvas INSIDE a render tick so capture works without preserveDrawingBuffer
-     (a WebGL drawing buffer is only guaranteed valid in the same frame it was drawn). */
-  function aiCaptureCanvas(maxDim){
-    return new Promise(res=>{
-      if(!map){ res(null); return; }
-      let done=false; const grab=()=>{ if(done)return; done=true; try{ res(aiDownscaleDataURL(map.getCanvas(),maxDim)); }catch(_){ res(null); } };
-      try{ map.once('render',grab); map.triggerRepaint(); }catch(_){ grab(); }
-      setTimeout(grab,900); /* safety net if no render event fires */
-    });
-  }
+  /* (#R169) moved verbatim to js/satellite.js — see Architecture.md §3.1. */
+  /* (#R169) moved verbatim to js/ai-core.js — see Architecture.md §3.1. */
+  /* (#R169) moved verbatim to js/satellite.js — see Architecture.md §3.1. */
   /* (#R119) SPLIT into reusable stages so the Atlas `satelliteCompare` action shares the exact same pipeline
      (capture two dated frames → vision analysis) — the button UI below is unchanged. */
   window._imSatCapture=async function(va,vb){
@@ -1960,24 +1387,7 @@ window.addEventListener('DOMContentLoaded', () => {
       : "You are a satellite-imagery analyst comparing two images of the same area (first = earlier, second = later). Report: military construction/expansion, movement of ships/aircraft/vehicles, land clearing, natural disasters (floods, fires, landslides), and urban/infrastructure change. Use bullet points, each with a confidence level (high/medium/low). If nothing changed, say so, and beware false positives from clouds, image quality, or seasonal differences.")+window._aiLangLine();
     const prompt=currentLang==='jp'?`1枚目の日付: ${va}\n2枚目の日付: ${vb}\nこの2枚を比較し、変化を報告してください。`:`First image date: ${va}\nSecond image date: ${vb}\nCompare the two images and report the changes.`;
     return askAI(prompt,sys,[imgA,imgB]); };
-  async function aiSatChangeDetect(){
-    if(!aiGate()) return;
-    const aEl=document.getElementById('aic-date-a'), bEl=document.getElementById('aic-date-b');
-    const va=aEl&&aEl.value, vb=bEl&&bEl.value;
-    const btn=document.getElementById('ai-satchange-btn'); aiSetBtnBusy(btn,true,t('aiVisCapturing'));
-    const cap=await window._imSatCapture(va,vb);
-    aiSetBtnBusy(btn,false);
-    if(cap.err){ aiToast(cap.err); return; }
-    const imgA=cap.imgA, imgB=cap.imgB;
-    const rep=aiReport({ title:t('aiVisTitle'), sub:t('aiVisSub').replace('{a}',va).replace('{b}',vb),
-      images:[{src:imgA,caption:t('aiVisBefore')+' · '+va},{src:imgB,caption:t('aiVisAfter')+' · '+vb}] });
-    const run=async()=>{
-      rep.setLoading(t('aiThinking'));
-      try{ const out=await window._imSatAnalyze(va,vb,imgA,imgB); rep.setBody(out||''); }
-      catch(e){ rep.setError((e&&e.message)||t('aiError'),run); }
-    };
-    run();
-  }
+  /* (#R169) moved verbatim to js/satellite.js — see Architecture.md §3.1. */
   aiButtonSyncers.push(function(){ const b=document.getElementById('ai-satchange-btn'); if(!b) return; b.classList.toggle('ai-needs-key',!aiVisionReady()); b.title=aiVisionReady()?'':(aiReady()?t('aiNoVision'):t('aiNoKey')); });
 
   window.matchMedia('(prefers-color-scheme: light)').addEventListener('change',()=>{ if(userTheme==='auto') applyTheme(); });
@@ -2249,6 +1659,106 @@ window.addEventListener('DOMContentLoaded', () => {
   const IM_COMMUNITY=window.IntMapModules.community(map,IM_HOST);
   function renderCommunity(){ return IM_COMMUNITY.renderCommunity.apply(this,arguments); }
   function wireCommList(){ return IM_COMMUNITY.wireCommList.apply(this,arguments); }
+  /* ── (#R169) EIGHTH SPLIT — eleven more SUBJECT modules (Architecture.md §3.1 #R169).
+   *  Same shape as the #R168 block above: each factory only DECLARES (verified statement-by-statement
+   *  with a parser — see tests/r169-checks.test.mjs), so instantiating them all here, once `map`
+   *  exists, cannot run app code early. Every name index.html still calls keeps a hoisted `function`
+   *  shim, so call sites textually above this line behave exactly as before. */
+  const IM_SAT=window.IntMapModules.satellite(map,IM_HOST);
+  function aiCaptureSatAt(){ return IM_SAT.aiCaptureSatAt.apply(this,arguments); }
+  function satApply(){ return IM_SAT.satApply.apply(this,arguments); }
+  function satBuildTiles(){ return IM_SAT.satBuildTiles.apply(this,arguments); }
+  function satCaptureLabel(){ return IM_SAT.satCaptureLabel.apply(this,arguments); }
+  function satChipHTML(){ return IM_SAT.satChipHTML.apply(this,arguments); }
+  function satHasKey(){ return IM_SAT.satHasKey.apply(this,arguments); }
+  function satProviderById(){ return IM_SAT.satProviderById.apply(this,arguments); }
+  function satReady(){ return IM_SAT.satReady.apply(this,arguments); }
+  function satRefreshReadout(){ return IM_SAT.satRefreshReadout.apply(this,arguments); }
+  function satRenderController(){ return IM_SAT.satRenderController.apply(this,arguments); }
+  function satRenderKeyInputs(){ return IM_SAT.satRenderKeyInputs.apply(this,arguments); }
+  function satRevertToFallback(){ return IM_SAT.satRevertToFallback.apply(this,arguments); }
+  function satSaveKeyInputs(){ return IM_SAT.satSaveKeyInputs.apply(this,arguments); }
+  function satSelectProvider(){ return IM_SAT.satSelectProvider.apply(this,arguments); }
+  function satSetOpacity(){ return IM_SAT.satSetOpacity.apply(this,arguments); }
+  function satSetup(){ return IM_SAT.satSetup.apply(this,arguments); }
+  function satStepDay(){ return IM_SAT.satStepDay.apply(this,arguments); }
+  function satToast(){ return IM_SAT.satToast.apply(this,arguments); }
+  const IM_AI=window.IntMapModules.aiCore(map,IM_HOST);
+  function aiDev(){ return IM_AI.aiDev.apply(this,arguments); }
+  function aiEsc(){ return IM_AI.aiEsc.apply(this,arguments); }
+  function aiFetchUsage(){ return IM_AI.aiFetchUsage.apply(this,arguments); }
+  function aiGate(){ return IM_AI.aiGate.apply(this,arguments); }
+  function aiLimitMsg(){ return IM_AI.aiLimitMsg.apply(this,arguments); }
+  function aiLoginMsg(){ return IM_AI.aiLoginMsg.apply(this,arguments); }
+  function aiParseJSON(){ return IM_AI.aiParseJSON.apply(this,arguments); }
+  function aiReady(){ return IM_AI.aiReady.apply(this,arguments); }
+  function aiRenderSettings(){ return IM_AI.aiRenderSettings.apply(this,arguments); }
+  function aiReport(){ return IM_AI.aiReport.apply(this,arguments); }
+  function aiSaveSettings(){ return IM_AI.aiSaveSettings.apply(this,arguments); }
+  function aiSetBtnBusy(){ return IM_AI.aiSetBtnBusy.apply(this,arguments); }
+  function aiSyncFeatureButtons(){ return IM_AI.aiSyncFeatureButtons.apply(this,arguments); }
+  function aiToast(){ return IM_AI.aiToast.apply(this,arguments); }
+  function aiToday(){ return IM_AI.aiToday.apply(this,arguments); }
+  function aiUsesLeft(){ return IM_AI.aiUsesLeft.apply(this,arguments); }
+  function aiVisionReady(){ return IM_AI.aiVisionReady.apply(this,arguments); }
+  function aiWaitMapIdle(){ return IM_AI.aiWaitMapIdle.apply(this,arguments); }
+  function askAI(){ return IM_AI.askAI.apply(this,arguments); }
+  function askAIJSON(){ return IM_AI.askAIJSON.apply(this,arguments); }
+  function askAIJSONEnvelope(){ return IM_AI.askAIJSONEnvelope.apply(this,arguments); }
+  const IM_LABELS=window.IntMapModules.placeLabels(map,IM_HOST);
+  function applyLabelLang(){ return IM_LABELS.applyLabelLang.apply(this,arguments); }
+  function buildGeoFC(){ return IM_LABELS.buildGeoFC.apply(this,arguments); }
+  function ensureGeoLayers(){ return IM_LABELS.ensureGeoLayers.apply(this,arguments); }
+  function ensurePlaceLabels(){ return IM_LABELS.ensurePlaceLabels.apply(this,arguments); }
+  function localizeGeoLabels(){ return IM_LABELS.localizeGeoLabels.apply(this,arguments); }
+  function updateGeoLayers(){ return IM_LABELS.updateGeoLayers.apply(this,arguments); }
+  const IM_WINMGR=window.IntMapModules.windowManager(map,IM_HOST);
+  function addEdgeResize(){ return IM_WINMGR.addEdgeResize.apply(this,arguments); }
+  function bringToFront(){ return IM_WINMGR.bringToFront.apply(this,arguments); }
+  function makeDraggable(){ return IM_WINMGR.makeDraggable.apply(this,arguments); }
+  function registerWindow(){ return IM_WINMGR.registerWindow.apply(this,arguments); }
+  const IM_SEARCH=window.IntMapModules.searchGeocode(map,IM_HOST);
+  function doGeocode(){ return IM_SEARCH.doGeocode.apply(this,arguments); }
+  function localFuzzyPlaces(){ return IM_SEARCH.localFuzzyPlaces.apply(this,arguments); }
+  const IM_NEWSCTX=window.IntMapModules.newsContext(map,IM_HOST);
+  function analyzeContext(){ return IM_NEWSCTX.analyzeContext.apply(this,arguments); }
+  function rebuildGeoIndex(){ return IM_NEWSCTX.rebuildGeoIndex.apply(this,arguments); }
+  const IM_NEWSFEED=window.IntMapModules.newsFeed(map,IM_HOST);
+  function aiTranslateTitles(){ return IM_NEWSFEED.aiTranslateTitles.apply(this,arguments); }
+  function fetchData(){ return IM_NEWSFEED.fetchData.apply(this,arguments); }
+  function loadNewsFromSupabase(){ return IM_NEWSFEED.loadNewsFromSupabase.apply(this,arguments); }
+  function startNews(){ return IM_NEWSFEED.startNews.apply(this,arguments); }
+  const IM_READER=window.IntMapModules.articleReader(map,IM_HOST);
+  function openArticleInSidebar(){ return IM_READER.openArticleInSidebar.apply(this,arguments); }
+  const IM_COMMBOARD=window.IntMapModules.communityBoard(map,IM_HOST);
+  function cmAddPost(){ return IM_COMMBOARD.cmAddPost.apply(this,arguments); }
+  function cmEditPost(){ return IM_COMMBOARD.cmEditPost.apply(this,arguments); }
+  function commCatLabel(){ return IM_COMMBOARD.commCatLabel.apply(this,arguments); }
+  function imViewProfile(){ return IM_COMMBOARD.imViewProfile.apply(this,arguments); }
+  function loadCommunity(){ return IM_COMMBOARD.loadCommunity.apply(this,arguments); }
+  function openComposeModal(){ return IM_COMMBOARD.openComposeModal.apply(this,arguments); }
+  function renderCommList(){ return IM_COMMBOARD.renderCommList.apply(this,arguments); }
+  function setupCommunityLayer(){ return IM_COMMBOARD.setupCommunityLayer.apply(this,arguments); }
+  function visibleCommunityPosts(){ return IM_COMMBOARD.visibleCommunityPosts.apply(this,arguments); }
+  const IM_READOUT=window.IntMapModules.mapReadout(map,IM_HOST);
+  function _demZoomForSpan(){ return IM_READOUT._demZoomForSpan.apply(this,arguments); }
+  function demElevAt(){ return IM_READOUT.demElevAt.apply(this,arguments); }
+  function demElevBilinear(){ return IM_READOUT.demElevBilinear.apply(this,arguments); }
+  function demZoomForMap(){ return IM_READOUT.demZoomForMap.apply(this,arguments); }
+  function fetchBathymetry(){ return IM_READOUT.fetchBathymetry.apply(this,arguments); }
+  function fmtElevVal(){ return IM_READOUT.fmtElevVal.apply(this,arguments); }
+  function fmtLL(){ return IM_READOUT.fmtLL.apply(this,arguments); }
+  function handleMapClick(){ return IM_READOUT.handleMapClick.apply(this,arguments); }
+  function refreshGrid(){ return IM_READOUT.refreshGrid.apply(this,arguments); }
+  function renderCoordReadout(){ return IM_READOUT.renderCoordReadout.apply(this,arguments); }
+  function setGrid(){ return IM_READOUT.setGrid.apply(this,arguments); }
+  function showMeasureTip(){ return IM_READOUT.showMeasureTip.apply(this,arguments); }
+  function updateCompass(){ return IM_READOUT.updateCompass.apply(this,arguments); }
+  function updateCoord(){ return IM_READOUT.updateCoord.apply(this,arguments); }
+  function updateLayerReadout(){ return IM_READOUT.updateLayerReadout.apply(this,arguments); }
+  function warmDEMTiles(){ return IM_READOUT.warmDEMTiles.apply(this,arguments); }
+  const IM_ELEVPROF=window.IntMapModules.elevationProfile(map,IM_HOST);
+  function _openProfilePanel(){ return IM_ELEVPROF._openProfilePanel.apply(this,arguments); }
 
   /* Coalesce resizes to one per frame (#32) — the sidebar open/close transition fires the
      ResizeObserver dozens of times; calling map.resize() on each caused a visible flicker. */
@@ -2522,94 +2032,11 @@ window.addEventListener('DOMContentLoaded', () => {
     return Object.entries(sourceDict).map(([k,v])=>{ const isC=cjk.test(k);
       return { loc:v.loc, label:k, cjk:isC, re:isC?null:new RegExp('\\b'+k.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')+'\\b','i') }; })
       .sort((a,b)=>b.label.length-a.label.length); })();
-  function matchPublisher(publisher){ if(!publisher) return null;
-    for(const m of _pubMatchers){ if(m.cjk?publisher.includes(m.label):m.re.test(publisher)) return m; }
-    /* (#R32) Non-AI publisher-location BOOST ("AIを用いない発信地解析を強化 / 位置不明のピンが多い"): a huge
-       share of Google-News sources are LOCAL outlets whose name embeds their city/region/country
-       ("Manila Bulletin", "Kashmir Observer", "Texas Tribune", "Nairobi News"…). When the curated dict
-       misses, scan the publisher string against the place gazetteer and use the most specific match, so far
-       fewer publisher pins land "unknown". Skip demonyms/orgs and very short terms to avoid false hits. */
-    try{ if(typeof geoDB!=='undefined' && geoDB){ let best=null,bestLen=0,bestLocal=-1;
-      for(const g of geoDB){ if(g.demonym||g.org||!g._terms) continue;
-        for(const t of g._terms){ const term=t.term; if(!term||term.length<4) continue;
-          const hit = t.jp ? publisher.includes(term) : (t.matchRe&&t.matchRe.test(publisher));
-          if(hit){ const loc=(typeof TYPE_LOCAL!=='undefined'?(TYPE_LOCAL[g.type]||0):0);
-            if(term.length>bestLen || (term.length===bestLen && loc>bestLocal)){ best=g; bestLen=term.length; bestLocal=loc; } } } }
-      if(best) return { loc:best.loc, label:(best.name&&(best.name[currentLang]||best.name.en))||'', cjk:false }; } }catch(_){}
-    return null; }
-
-  /* Precompile per-term matchers once (runs ≈290 entries × N news items on every refresh):
-       jp      — CJK terms match by substring; Latin terms match on word boundaries
-       matchRe — word-boundary matcher for Latin terms
-       ctxRe   — "is this place governed by a locational preposition / particle?"
-                 EN: in/at/to/from/near/into <place>   ·   JP: <place>で/へ/に/を/から */
-  function isCJKTerm(term){ return /[　-鿿]/.test(term); }
-  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
-  const {_DERU_GZ,_DERU_DEM,_ES_GZ,_ES_DEM}=window.IntMapTables;
-  /* Rebuild the flat geoDB + per-term matchers from geoRaw. Called after the
-     Supabase geo_pins load (and on realtime updates). */
-  function rebuildGeoIndex(){
-    /* Merge the always-present built-in gazetteer (#11) with the Supabase geo_pins so news placement
-       is strong even before/without server data. */
-    const merged={};
-    [BUILTIN_GAZETTEER, geoRaw].forEach(src=>{ for(const type in src){ (merged[type]=merged[type]||[]).push(...src[type]); } });
-    /* (#R25/#28) MASSIVE coverage boost for the non-AI locator: auto-add EVERY country (+ its capital name)
-       from the already-bundled countryStats — ~200 countries with real EN/JP names and a representative
-       point. Curated cities/flashpoints still outrank these (higher TYPE_SCORE + lead-position bonus), so
-       precision is unchanged; this just means almost any country/capital mention now places. */
-    try{ if(typeof countryStats==='object'&&countryStats){ for(const code in countryStats){ const s=countryStats[code];
-      if(!s||!s.latlng||s.latlng[0]==null||s.latlng[1]==null) continue;
-      const terms=[]; if(s.nameEn) terms.push(s.nameEn); if(s.nameJp&&s.nameJp!==s.nameEn) terms.push(s.nameJp);
-      if(s.capital&&String(s.capital).length>=4) terms.push(s.capital);
-      if(!terms.length) continue;
-      (merged.country=merged.country||[]).push({terms, loc:[s.latlng[1],s.latlng[0]], name:{en:s.nameEn||code, jp:s.nameJp||s.nameEn||code}}); } } }catch(_){}
-    /* (#R27) demonyms join as low-confidence country entries (flagged so scoreGeo ranks them below a real
-       place name) — coverage for "Ukrainian/Israeli/Iranian…" headlines that name no explicit place. */
-    try{ for(const [dem,lng,lat,en,jp] of _DEMONYM_GZ){ (merged.country=merged.country||[]).push({terms:[dem], loc:[lng,lat], name:{en,jp}, demonym:true}); } }catch(_){}
-    /* (#R28) organizations / institutions / armed groups join as flagged org:true entries — docked below an
-       explicit place (see scoreGeo) so they only place a story that names no explicit city/country. */
-    try{ for(const [terms,lng,lat,en,jp] of _ORG_GZ){ (merged.country=merged.country||[]).push({terms:terms.slice(), loc:[lng,lat], name:{en,jp}, org:true}); } }catch(_){}
-    /* (#R39) German + Russian places (full DE exonyms / RU stems) and Russian demonyms. */
-    try{ for(const [type,terms,lng,lat,en,jp] of _DERU_GZ){ (merged[type]=merged[type]||[]).push({terms:terms.slice(), loc:[lng,lat], name:{en,jp}}); } }catch(_){}
-    try{ for(const [dem,lng,lat,en,jp] of _DERU_DEM){ (merged.country=merged.country||[]).push({terms:[dem], loc:[lng,lat], name:{en,jp}, demonym:true}); } }catch(_){}
-    /* (#R40) Spanish exonyms + demonyms (same shape) — gives the non-AI locator full Spanish coverage. */
-    try{ for(const [type,terms,lng,lat,en,jp] of _ES_GZ){ (merged[type]=merged[type]||[]).push({terms:terms.slice(), loc:[lng,lat], name:{en,jp}}); } }catch(_){}
-    try{ for(const [dem,lng,lat,en,jp] of _ES_DEM){ (merged.country=merged.country||[]).push({terms:[dem], loc:[lng,lat], name:{en,jp}, demonym:true}); } }catch(_){}
-    geoDB=Object.entries(merged).flatMap(([type,arr])=>arr.map(g=>({...g,type})));
-    /* (#R161) hand the ADMIN-CURATED Supabase geo_pins to the NewsGeo engine too, so a place an
-       operator added in admin.html is matchable by the primary locator and not only by the legacy
-       fallback. Registered at a lower rank than the built-in gazetteer (curated rows add coverage,
-       they never override a verified place) and de-duplicated inside register(), which matters
-       because this function re-runs on every geo_pins realtime update. */
-    try{ if(window.IntMapNewsGeo&&window.IntMapNewsGeo.register){
-      const extra=[]; for(const type in geoRaw){ for(const g of (geoRaw[type]||[])){
-        if(!g||!g.loc||!Array.isArray(g.terms)||!g.terms.length) continue;
-        extra.push({ terms:g.terms, lng:g.loc[0], lat:g.loc[1], type, name_en:(g.name&&g.name.en)||g.terms[0], name_jp:(g.name&&g.name.jp)||'' }); } }
-      if(extra.length) window.IntMapNewsGeo.register(extra);
-    } }catch(_){}
-    /* longer keywords first → "Tel Aviv" wins over "Israel" (stable tiebreaker on equal scores) */
-    geoDB.sort((a,b)=>Math.max(...b.terms.map(t=>t.length)) - Math.max(...a.terms.map(t=>t.length)));
-    geoDB.forEach(g=>{
-      g._terms=g.terms.map(term=>{
-        const jp=isCJKTerm(term), cyr=/[Ѐ-ӿ]/.test(term), esc=term.replace(/[.*+?^${}()|[\]\\]/g,'\\$&');
-        /* (#R39) Cyrillic/Russian path: JS `\b` word-boundaries don't fire around Cyrillic (it isn't `\w`),
-           AND Russian inflects heavily — so match the supplied STEM plus up to 4 trailing Cyrillic letters,
-           bounded by a non-Cyrillic-letter on the left (a consuming prefix, not lookbehind, for old-Safari
-           safety). e.g. stem «Москв» → Москва/Москве/Москвы/Москву; «Росси» → России/Россию. */
-        if(cyr){ return { term, jp:false, cyr:true,
-          matchRe: new RegExp('(?:^|[^А-Яа-яЁёІіЇїЄє])'+esc+'[а-яёіїєa-z]{0,4}','i'),
-          ctxRe:   new RegExp('(?:в|во|на|из|под|у|около)\\s+'+esc,'i') }; }
-        return { term, jp,
-          matchRe: jp?null:new RegExp(`\\b${esc}\\b`,'i'),
-          ctxRe:   jp?new RegExp(`${esc}(?:で|へ|に|を|から|では)`)
-                     :new RegExp(`\\b(?:in|at|to|from|near|into)\\s+${esc}\\b`,'i') };
-      });
-    });
-  }
+  /* (#R169) moved verbatim to js/news-context.js — see Architecture.md §3.1. */
 
   /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
   const {geoLayersDB,GEO_LABEL_JP}=window.IntMapTables;
-  function geoLabel(s){ return (currentLang==='jp' && GEO_LABEL_JP[s]) ? GEO_LABEL_JP[s] : s; }
+  /* (#R169) moved verbatim to js/place-labels.js — see Architecture.md §3.1. */
   /* (#R8b) Catmull-Rom densifier → polylines render as natural CURVES through their control points
      instead of straight chords (the user: "線が直線的すぎる"). Returns the input unchanged for paths that
      cross the antimeridian (|Δlng|>170), so seam-spanning routes are never smeared across the globe. */
@@ -2623,67 +2050,11 @@ window.addEventListener('DOMContentLoaded', () => {
                    0.5*((2*p1[1])+(-p0[1]+p2[1])*s+(2*p0[1]-5*p1[1]+4*p2[1]-p3[1])*s2+(-p0[1]+3*p1[1]-3*p2[1]+p3[1])*s3) ]); } }
     out.push(pts[pts.length-1]); return out;
   };
-  function buildGeoFC(data){
-    const feats=[];
-    (data.areas||[]).forEach(a=>{
-      const ring=a.ring.slice(); const f=ring[0], l=ring[ring.length-1];
-      if(f[0]!==l[0]||f[1]!==l[1]) ring.push(f);
-      feats.push({type:'Feature',geometry:{type:'Polygon',coordinates:[ring]},properties:{}});
-      if(a.label){ let sx=0,sy=0; a.ring.forEach(p=>{sx+=p[0];sy+=p[1];}); feats.push({type:'Feature',geometry:{type:'Point',coordinates:[sx/a.ring.length,sy/a.ring.length]},properties:{label:geoLabel(a.label)}}); }
-    });
-    (data.lines||[]).forEach(ln=>{
-      const path=(data.smooth&&window.smoothGeoPath)?window.smoothGeoPath(ln.path,16):ln.path;
-      feats.push({type:'Feature',geometry:{type:'LineString',coordinates:path},properties:{kind:ln.kind||''}});
-      if(ln.label){ const m=ln.path[Math.floor(ln.path.length/2)]; feats.push({type:'Feature',geometry:{type:'Point',coordinates:m},properties:{label:geoLabel(ln.label),kind:ln.kind||''}}); }
-    });
-    (data.points||[]).forEach(pt=>{
-      feats.push({type:'Feature',geometry:{type:'Point',coordinates:pt.at},properties:{label:geoLabel(pt.label),marker:1}});
-    });
-    return {type:'FeatureCollection',features:feats};
-  }
+  /* (#R169) moved verbatim to js/place-labels.js — see Architecture.md §3.1. */
   /* Re-emit every geo source's data so on-map labels follow the active language (#1). */
   function refreshGeoLabels(){ if(!map) return; for(const key of Object.keys(geoLayersDB)){ const src=map.getSource(key); if(src){ try{ src.setData(buildGeoFC(geoLayersDB[key])); }catch(_){} } } }
   window.refreshGeoLabels=refreshGeoLabels;
-  function ensureGeoLayers(){
-    if(!map) return;
-    /* Style may not be ready yet (e.g. right after setProjection on load). Retry until it is. */
-    if(!map.isStyleLoaded()){ clearTimeout(ensureGeoLayers._t); ensureGeoLayers._t=setTimeout(ensureGeoLayers,160); return; }
-    for(const[key,data] of Object.entries(geoLayersDB)){
-      if(map.getSource(key)) continue;
-      try{ map.addSource(key,{type:'geojson',data:buildGeoFC(data)}); }catch(e){ continue; }
-      try{
-        if(data.areas&&data.areas.length){
-          map.addLayer({id:key+'-fill',type:'fill',source:key,filter:['==','$type','Polygon'],layout:{visibility:'none'},paint:{'fill-color':data.color,'fill-opacity':0.22}});
-          /* soft, fuzzy zone edge — no hard outline (zones are conceptual, not borders) */
-          map.addLayer({id:key+'-edge',type:'line',source:key,filter:['==','$type','Polygon'],layout:{visibility:'none','line-cap':'round','line-join':'round'},paint:{'line-color':data.color,'line-width':16,'line-opacity':0.18,'line-blur':8}});
-        }
-        /* (#R8) High-quality pipeline network: two-tone OIL/GAS color, a crisp dark casing and
-           zoom-scaled width = an "infrastructure map" look. Other geo lines (theory corridors) carry
-           kind:'' so the match falls through to their single conceptual color — unchanged. */
-        const _pipe=key==='pipelines';
-        const _lineColor=_pipe?['match',['get','kind'],'oil','#d6451f','gas','#f4a72c',data.color]:data.color;
-        map.addLayer({id:key+'-glow',type:'line',source:key,filter:['==','$type','LineString'],layout:{visibility:'none','line-cap':'round','line-join':'round'},paint:{'line-color':_lineColor,'line-width':_pipe?['interpolate',['linear'],['zoom'],1,7,5,14]:10,'line-opacity':_pipe?0.22:0.18,'line-blur':4}});
-        if(_pipe) map.addLayer({id:key+'-casing',type:'line',source:key,filter:['==','$type','LineString'],layout:{visibility:'none','line-cap':'round','line-join':'round'},paint:{'line-color':'#1f0d05','line-width':['interpolate',['linear'],['zoom'],1,3,4,5.5,8,10],'line-opacity':0.6}});
-        map.addLayer({id:key+'-line',type:'line',source:key,filter:['==','$type','LineString'],layout:{visibility:'none','line-cap':'round','line-join':'round'},paint:{'line-color':_lineColor,'line-width':_pipe?['interpolate',['linear'],['zoom'],1,1.6,4,3.2,8,5.5]:3.5,'line-opacity':0.97}});
-        map.addLayer({id:key+'-pt',type:'circle',source:key,filter:['==','marker',1],layout:{visibility:'none'},paint:{'circle-radius':5,'circle-color':data.color,'circle-stroke-color':'#fff','circle-stroke-width':2,'circle-opacity':0.95}});
-        map.addLayer({id:key+'-label',type:'symbol',source:key,filter:['has','label'],layout:{visibility:'none','text-field':['get','label'],'text-size':12,'text-font':['literal',['Noto Sans Regular']],'text-offset':[0,1.1],'text-anchor':'top','text-allow-overlap':false,'symbol-placement':'point'},paint:{'text-color':data.color,'text-halo-color':'rgba(255,255,255,0.95)','text-halo-width':1.8}});
-      }catch(e){ console.warn('geoLayer add fail',key,e); }
-    }
-    updateGeoLayers();
-  }
-  function updateGeoLayers(){
-    if(!map)return;
-    /* (#R13c) If the style is mid-load, a toggle-OFF would silently no-op and the layer would STAY on
-       ("消したはずのレイヤーが残る"). Re-run once the style settles so the on/off state always lands. */
-    if(!map.isStyleLoaded()){ try{ map.once('idle',()=>{ try{ updateGeoLayers(); }catch(_){} }); }catch(_){} return; }
-    const isDark=document.documentElement.getAttribute('data-theme')==='dark';
-    for(const key of Object.keys(geoLayersDB)){
-      const cb=document.querySelector(`input[data-layer="${key}"]`);
-      const vis=((cb&&cb.checked)||forceHoverLayers.has(key))?'visible':'none';
-      ['-fill','-edge','-glow','-casing','-line','-pt','-label'].forEach(s=>{ if(map.getLayer(key+s)) map.setLayoutProperty(key+s,'visibility',vis); });
-      if(map.getLayer(key+'-label')) map.setPaintProperty(key+'-label','text-halo-color',isDark?'rgba(0,0,0,0.85)':'rgba(255,255,255,0.95)');
-    }
-  }
+  /* (#R169) moved verbatim to js/place-labels.js — see Architecture.md §3.1. */
   window.triggerLayerHover=function(k,h){ if(!k)return; if(h)forceHoverLayers.add(k); else forceHoverLayers.delete(k); updateGeoLayers(); };
 
   let countryGeo=null, countryStats={}, countryDataLoaded=false, countryDataPromise=null;
@@ -2742,126 +2113,9 @@ window.addEventListener('DOMContentLoaded', () => {
     if(closeBtn) closeBtn.onclick=()=>{ popup.style.display='none'; };
   }
 
-  /* ===== Grid (zoom-adaptive, red equator) ===== */
-  function gridStepForZoom(z){
-    if(z<1.5) return {major:30,minor:10};
-    if(z<3)   return {major:15,minor:5};
-    if(z<5)   return {major:10,minor:2};
-    if(z<7)   return {major:5, minor:1};
-    if(z<9)   return {major:2, minor:0.5};
-    if(z<11)  return {major:1, minor:0.25};
-    if(z<13)  return {major:0.5,minor:0.1};
-    return    {major:0.1,minor:0.025};
-  }
-  function buildGridFeatures(){
-    if(!hasTurf()) return [];
-    const z=map?map.getZoom():2;
-    const {major,minor}=gridStepForZoom(z);
-    const b=map?map.getBounds():null;
-    let minLng=-180,maxLng=180,minLat=-80,maxLat=80;
-    if(b){
-      const pad=Math.max(major*2,2);
-      minLng=Math.max(-180,Math.floor(b.getWest()/major)*major-pad);
-      maxLng=Math.min(180, Math.ceil(b.getEast()/major)*major+pad);
-      minLat=Math.max(-85, Math.floor(b.getSouth()/major)*major-pad);
-      maxLat=Math.min(85,  Math.ceil(b.getNorth()/major)*major+pad);
-    }
-    const f=[];
-    /* Cap vertices PER LINE (scales with the visible span instead of a fixed dense step) — far
-       fewer points to build + upload, so the grid appears much faster (#15). On globe a line still
-       gets enough points to look curved; on flat it's nearly straight anyway. */
-    const latSpan=maxLat-minLat, lngSpan=maxLng-minLng;
-    const latStep=Math.max(minor, latSpan/30), lngStep=Math.max(minor, lngSpan/36);
-    const majLatStep=Math.max(major/2, latSpan/40), majLngStep=Math.max(major/2, lngSpan/48);
-    /* Minor lines */
-    for(let lng=Math.ceil(minLng/minor)*minor; lng<=maxLng; lng+=minor){
-      if(Math.abs(lng%major)<1e-6) continue;
-      const pts=[]; for(let la=minLat; la<=maxLat; la+=latStep) pts.push([lng,la]); pts.push([lng,maxLat]);
-      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'minor'}});
-    }
-    for(let lat=Math.ceil(minLat/minor)*minor; lat<=maxLat; lat+=minor){
-      if(Math.abs(lat%major)<1e-6 || Math.abs(lat)<1e-6) continue;
-      const pts=[]; for(let lo=minLng; lo<=maxLng; lo+=lngStep) pts.push([lo,lat]); pts.push([maxLng,lat]);
-      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'minor'}});
-    }
-    /* Major lines */
-    for(let lng=Math.ceil(minLng/major)*major; lng<=maxLng; lng+=major){
-      const pts=[]; for(let la=minLat; la<=maxLat; la+=majLatStep) pts.push([lng,la]); pts.push([lng,maxLat]);
-      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'major'}});
-    }
-    for(let lat=Math.ceil(minLat/major)*major; lat<=maxLat; lat+=major){
-      if(Math.abs(lat)<1e-6) continue; /* equator drawn separately in red */
-      const pts=[]; for(let lo=minLng; lo<=maxLng; lo+=majLngStep) pts.push([lo,lat]); pts.push([maxLng,lat]);
-      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'major'}});
-    }
-    /* Red equator */
-    if(minLat<=0 && maxLat>=0){
-      const pts=[]; const step=Math.max(major/4,1);
-      for(let lo=minLng; lo<=maxLng; lo+=step) pts.push([lo,0]);
-      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'equator'}});
-    }
-    /* Prime meridian */
-    if(minLng<=0 && maxLng>=0){
-      const pts=[]; const step=Math.max(major/4,1);
-      for(let la=minLat; la<=maxLat; la+=step) pts.push([0,la]);
-      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'prime'}});
-    }
-    /* Edge labels (along axes) */
-    const labelStep=major;
-    const c=map?map.getCenter():{lng:0,lat:0};
-    const baseLng=Math.max(minLng+major*0.5,Math.min(maxLng-major*0.5,c.lng));
-    const baseLat=Math.max(minLat+major*0.5,Math.min(maxLat-major*0.5,c.lat));
-    for(let lat=Math.ceil(minLat/labelStep)*labelStep; lat<=maxLat; lat+=labelStep){
-      if(Math.abs(lat)>85) continue;
-      f.push({type:'Feature',geometry:{type:'Point',coordinates:[baseLng,lat]},properties:{label:degLabel(+lat.toFixed(3),'lat')}});
-    }
-    for(let lng=Math.ceil(minLng/labelStep)*labelStep; lng<=maxLng; lng+=labelStep){
-      f.push({type:'Feature',geometry:{type:'Point',coordinates:[lng,baseLat]},properties:{label:degLabel(+lng.toFixed(3),'lng')}});
-    }
-    /* Intersection labels at major grid crossings — sparse so they don't clutter */
-    const crossStep=major*2;
-    for(let lat=Math.ceil(minLat/crossStep)*crossStep; lat<=maxLat; lat+=crossStep){
-      if(Math.abs(lat)>80) continue;
-      for(let lng=Math.ceil(minLng/crossStep)*crossStep; lng<=maxLng; lng+=crossStep){
-        if(Math.abs(lat)<1e-6 && Math.abs(lng)<1e-6) continue;
-        f.push({type:'Feature',geometry:{type:'Point',coordinates:[lng,lat]},properties:{kind:'cross',label:`${degLabel(+lat.toFixed(3),'lat')} ${degLabel(+lng.toFixed(3),'lng')}`}});
-      }
-    }
-    return f;
-  }
-  let gridRebuildTimer=null, _gridKey='';
-  function refreshGrid(){
-    if(!isGridOn||!map||!map.getSource('grid-source')) return;
-    clearTimeout(gridRebuildTimer);
-    gridRebuildTimer=setTimeout(()=>{
-      try{
-        /* Skip the rebuild if the zoom-step + rounded viewport haven't really changed (#15) — avoids
-           re-tessellating the whole grid on every tiny pan/rotate of the globe. */
-        const z=map.getZoom(), {major,minor}=gridStepForZoom(z), b=map.getBounds();
-        const key=major+'/'+minor+'/'+(b?[b.getWest(),b.getEast(),b.getSouth(),b.getNorth()].map(v=>Math.round(v/Math.max(major,1))).join(','):'');
-        if(key===_gridKey) return; _gridKey=key;
-        map.getSource('grid-source').setData({type:'FeatureCollection',features:buildGridFeatures()});
-      }catch(e){}
-    },90);
-  }
-  /* (#R38) ROOT FIX for "Grid & labels が何度消しても自動的にチェックされる": toggleGrid() used to blindly FLIP
-     isGridOn on every checkbox change. The R36 async-race guard re-dispatches a `change` on a box that went OFF
-     (idempotent for normal layers, which READ e.target.checked) — but the flip made that re-dispatch turn Grid
-     back ON ~500ms later. Split into an IDEMPOTENT setGrid(on) (drives state FROM the box) + a toggleGrid() for
-     the toolbar button. The checkbox change now calls setGrid(checked), so a stray/duplicate change can never
-     re-enable Grid. */
-  function setGrid(on){
-    on=!!on; isGridOn=on;
-    const gb=document.getElementById('btn-tool-grid'); if(gb) gb.classList.toggle('tool-on',isGridOn);
-    const gcb=document.getElementById('cb-grid'); if(gcb && gcb.checked!==isGridOn) gcb.checked=isGridOn;   /* (#R10) Grid now lives in the Layers menu */
-    document.querySelectorAll('[data-proxy="cb-grid"]').forEach(x=>x.classList.toggle('active',isGridOn));
-    _gridKey='';
-    if(!map||!map.getSource('grid-source'))return;
-    if(isGridOn) map.getSource('grid-source').setData({type:'FeatureCollection',features:buildGridFeatures()});
-    else map.getSource('grid-source').setData({type:'FeatureCollection',features:[]});
-  }
+  /* (#R169) moved verbatim to js/map-readout.js — see Architecture.md §3.1. */
   function toggleGrid(){ setGrid(!isGridOn); }
-  function degLabel(v,k){ if(v===0)return'0°'; const d=k==='lat'?(v>0?'N':'S'):(v>0?'E':'W'); return Math.abs(v)+'°'+d; }
+  /* (#R169) moved verbatim to js/map-readout.js — see Architecture.md §3.1. */
 
   /* ===== Units & measurement =====
    * Auto-scale: metric flips km→m below 1 km; imperial flips mi→ft (yd for mid range) below 0.19 mi.
@@ -3044,15 +2298,7 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   function refreshTool(){ if(map&&map.getSource('tool-source')) map.getSource('tool-source').setData({type:'FeatureCollection',features:sanitizeFeatures(buildToolFeatures())}); }
 
-  function showMeasureTip(pt,txt){ const el=document.getElementById('measure-tooltip'); if(!el) return; el.innerText=txt; el.style.display='block';
-    /* (#R14/#7) keep the measure tooltip inside the map — it's drawn translate(12px,-50%), so flip it to
-       the LEFT of the point near the right edge and clamp Y, instead of overflowing off-screen. */
-    try{ const mc=document.getElementById('map-container').getBoundingClientRect(); const w=el.offsetWidth||120, h=el.offsetHeight||24;
-      el.style.transform=(pt.x+12+w > mc.width-6)?('translate(-'+(w+12)+'px,-50%)'):'translate(12px,-50%)';
-      el.style.left=Math.max(6,Math.min(mc.width-6,pt.x))+'px';
-      el.style.top=Math.max(h/2+6,Math.min(mc.height-h/2-6,pt.y))+'px';
-    }catch(_){ el.style.left=pt.x+'px'; el.style.top=pt.y+'px'; }
-  }
+  /* (#R169) moved verbatim to js/map-readout.js — see Architecture.md §3.1. */
   function hideMeasureTip(){ document.getElementById('measure-tooltip').style.display='none'; }
   function totalDistance(p){ let s=0; for(let i=1;i<p.length;i++)s+=turf.distance(turf.point(p[i-1]),turf.point(p[i]),{units:'kilometers'}); return s; }
   function ringArea(p){
@@ -3093,85 +2339,7 @@ window.addEventListener('DOMContentLoaded', () => {
     document.getElementById('map-container').classList.add('tool-active'); if(map)map.doubleClickZoom.disable();
     const p=document.getElementById('tool-panel'); p.style.left=''; p.style.top=''; p.style.right=''; updateToolPanel();
   }
-  /* (#R14) Draggable panels now support TOUCH too (mobile users reported the tool panel "couldn't be
-     moved" — only onmousedown was wired) and CLAMP to the offset-parent so a panel can never be dragged
-     off-screen and become unreachable (the other half of the mobile measure complaint, #7). */
-  function makeDraggable(panel,handle){
-    /* (#R27) ROOT CAUSE of "ポップアップや凡例の×を押しても反応しない" on mobile: the drag handle is the
-       panel HEADER, which CONTAINS the close ×. The touchstart below calls preventDefault() — and on
-       touch devices preventDefault on touchstart CANCELS the synthesized click, so the ×'s onclick never
-       fired. (On desktop, mousedown-preventDefault does NOT cancel click, which is why it worked there.)
-       Fix: if the gesture STARTS on a button / control, don't start a drag and don't preventDefault —
-       let the tap become a normal click. Dragging from the empty header area still works. */
-    const NODRAG='button, input, select, textarea, a, label, [role="button"], .layer-popup-x, .legend-min, .tp-close, .kip-x, .country-popup-close, .pin-popup-close, .src-card-close, .satc-close, .wgt-x, .wgt-cfg';
-    const onCtl=(e)=>{ try{ return !!(e.target&&e.target.closest&&e.target.closest(NODRAG)); }catch(_){ return false; } };
-    const clampTo=(l,t)=>{ const op=panel.offsetParent||document.documentElement; const ow=op.clientWidth||window.innerWidth, oh=op.clientHeight||window.innerHeight; const pw=panel.offsetWidth||0, ph=panel.offsetHeight||0; return [Math.max(6,Math.min(ow-Math.min(pw,ow)-6,l)), Math.max(6,Math.min(oh-Math.min(ph,oh)-6,t))]; };
-    /* (#R16) Write position with INLINE !important. On mobile the .tool-panel rule pins
-       `left:12px!important; top:auto!important`, which silently beat the drag's plain inline styles —
-       so panels "couldn't be moved" / "only moved left-right". Inline-!important beats stylesheet-
-       !important, so the drag now fully controls BOTH axes on phones. data-dragged lets any
-       :not([data-dragged]) auto-placement leave it alone. */
-    const move=(cx,cy)=>{ if(!panelDrag)return; const c=clampTo(panelDrag.l+cx-panelDrag.x, panelDrag.t+cy-panelDrag.y);
-      panel.style.setProperty('left',c[0]+'px','important'); panel.style.setProperty('top',c[1]+'px','important');
-      panel.style.setProperty('right','auto','important'); panel.style.setProperty('bottom','auto','important');
-      panel.setAttribute('data-dragged','1'); };
-    /* (#R79b) when this panel is wrapped inside a workspace window, the WINDOW owns drag/resize — the panel's
-       own handlers would fight it (the Atlas input field "moved freely" while resizing). Bail out cleanly. */
-    /* (#R79b/#R153) Disable a panel's OWN drag ONLY when it IS a workspace window's content — i.e. a DIRECT child of
-       .ws-body (the moved source elements: Atlas panel, News/Countries feed, #map-container). In workspace mode the whole
-       #map-container is relocated INTO the map window, so every in-map popup (tool-panel, legends, etc.) became a DEEP
-       descendant of a .ws-win and the old `closest('.ws-win')` test wrongly killed their drag ("ワークスペースモード内の
-       地図内のポップアップは自由に動かせない"). A direct-child-of-.ws-body test protects the window content while letting
-       genuinely-floating in-map popups drag again (their offset-parent-relative math already clamps them inside the map). */
-    const _inWsWin=()=>{ try{ return !!(panel.parentElement&&panel.parentElement.classList&&panel.parentElement.classList.contains('ws-body')); }catch(_){ return false; } };
-    handle.onmousedown=(e)=>{ if(onCtl(e)||panel.dataset.resizing||_inWsWin()) return; panelDrag={x:e.clientX,y:e.clientY,l:panel.offsetLeft,t:panel.offsetTop}; e.preventDefault(); document.onmousemove=(ev)=>move(ev.clientX,ev.clientY); document.onmouseup=()=>{ panelDrag=null; document.onmousemove=null; document.onmouseup=null; }; };
-    handle.addEventListener('touchstart',(e)=>{ if(onCtl(e)||panel.dataset.resizing||_inWsWin()) return; const tc=e.touches[0]; if(!tc)return; panelDrag={x:tc.clientX,y:tc.clientY,l:panel.offsetLeft,t:panel.offsetTop}; e.preventDefault();
-      const mv=(ev)=>{ const t2=ev.touches[0]; if(t2) move(t2.clientX,t2.clientY); };
-      const up=()=>{ panelDrag=null; document.removeEventListener('touchmove',mv); document.removeEventListener('touchend',up); };
-      document.addEventListener('touchmove',mv,{passive:false}); document.addEventListener('touchend',up); },{passive:false});
-    registerWindow(panel);   /* (#R47) any draggable panel also gets click-to-front + all-edge resize */
-  }
-  /* ================= (#R47) Window manager — the user: "前後位置が切り替わらない／触れたものを全面に／右下だけの
-     リサイズは不便／移動・リサイズのマークは要らない". One small system applied to every floating window+popup:
-       • bringToFront(el): clicking ANY managed window raises it above the others (capped below modals).
-       • addEdgeResize(el): resize from ANY edge or corner with NO visible handle (hit-tested border zone),
-         replacing the native bottom-right-only `resize:both` grab-mark.
-     makeDraggable auto-registers its panel; bigger windows (Atlas, Compare) also add edge-resize. ================= */
-  const __winReg=new Set(); let __winZ=4300;
-  function bringToFront(el){ if(!el) return; try{ let mx=4300; __winReg.forEach(w=>{ if(w===el||!w.isConnected) return; const z=parseInt(w.style.zIndex,10)||0; if(z>mx&&z<6000) mx=z; }); __winZ=Math.min(5999,Math.max(__winZ,mx)+1); el.style.zIndex=String(__winZ); }catch(_){} }
-  function registerWindow(el){ if(!el||__winReg.has(el)) return; __winReg.add(el); try{ el.addEventListener('pointerdown',()=>bringToFront(el),true); }catch(_){ try{ el.addEventListener('mousedown',()=>bringToFront(el),true); }catch(__){} } }
-  function addEdgeResize(panel,opts){ opts=opts||{}; if(!panel||panel.dataset.edgeResize) return; panel.dataset.edgeResize='1';
-    const M=9, minW=(opts.min&&opts.min[0])||220, minH=(opts.min&&opts.min[1])||130;
-    const CUR={n:'ns-resize',s:'ns-resize',e:'ew-resize',w:'ew-resize',ne:'nesw-resize',sw:'nesw-resize',nw:'nwse-resize',se:'nwse-resize'};
-    const edgeAt=(cx,cy)=>{ const r=panel.getBoundingClientRect(); const x=cx-r.left,y=cy-r.top; if(x<0||y<0||x>r.width||y>r.height) return ''; let h='',v=''; if(x<=M)h='w'; else if(x>=r.width-M)h='e'; if(y<=M)v='n'; else if(y>=r.height-M)v='s'; return v+h; };
-    /* (#R79b) inside a workspace window the WINDOW handles resize — skip the panel's own edge-resize */
-    /* (#R79b) inside a workspace window the WINDOW handles resize — skip the panel's own edge-resize.
-       (#R130) ALSO skip when the panel is the Atlas SIDEBAR TAB (class `atl-tab`): in tab mode the Atlas panel is
-       pinned to width:100%!important inside #atlas-feed, so the invisible edge-resize border-zone let the user drag
-       (incl. left/right) and fought the forced width — the reported "サイドバー内Atlasに左右方向のリサイズ機構があり、
-       変なことになる". `atl-tab` is present only in tab mode (removed in ws-mode), so the floating Atlas window and the
-       Compare window keep edge-resize. */
-    const _inWsWin2=()=>{ try{ if(panel.classList&&panel.classList.contains('atl-tab')) return true; return !!(panel.parentElement&&panel.parentElement.classList&&panel.parentElement.classList.contains('ws-body')); }catch(_){ return false; } };   /* (#R153) same fix as _inWsWin: only the window's own content (direct .ws-body child) is exempt from edge-resize — in-map popups nested in the relocated #map-container resize normally */
-    panel.addEventListener('pointermove',(e)=>{ if(panel.dataset.resizing||_inWsWin2()) return; const d=edgeAt(e.clientX,e.clientY); panel.style.cursor=d?CUR[d]:''; });
-    panel.addEventListener('pointerleave',()=>{ if(!panel.dataset.resizing) panel.style.cursor=''; });
-    panel.addEventListener('pointerdown',(e)=>{ if(_inWsWin2()) return; if(e.target.closest&&e.target.closest('button,input,select,textarea,a,[role="button"],.atl-go,.atl-in')) return; const d=edgeAt(e.clientX,e.clientY); if(!d) return; e.preventDefault(); e.stopPropagation(); panel.dataset.resizing=d; bringToFront(panel);
-      const r=panel.getBoundingClientRect(), op=panel.offsetParent||document.documentElement, opr=op.getBoundingClientRect();
-      /* (#R48) ROOT CAUSE of the buggy resize: the Atlas panel is centred with transform:translateX(-50%) (from
-         left:50%). The old code pinned left to the VISUAL rect but LEFT THE TRANSFORM ON, so on grab the panel
-         jumped half its width and drifted while resizing. Neutralise the transform + bottom/right anchors first,
-         pin to the exact on-screen box, then read the transform-free offset. */
-      panel.style.setProperty('transform','none','important'); panel.style.setProperty('right','auto','important'); panel.style.setProperty('bottom','auto','important');
-      panel.style.setProperty('left',(r.left-opr.left)+'px','important'); panel.style.setProperty('top',(r.top-opr.top)+'px','important');
-      const sx=e.clientX, sy=e.clientY, sw=r.width, sh=r.height, sl=panel.offsetLeft, st=panel.offsetTop;
-      try{ panel.setPointerCapture&&panel.setPointerCapture(e.pointerId); }catch(_){}
-      const mv=(ev)=>{ let w=sw,h=sh,l=sl,t=st; const dx=ev.clientX-sx, dy=ev.clientY-sy;
-        if(d.indexOf('e')>=0) w=Math.max(minW,sw+dx); if(d.indexOf('s')>=0) h=Math.max(minH,sh+dy);
-        if(d.indexOf('w')>=0){ w=Math.max(minW,sw-dx); l=sl+(sw-w); } if(d.indexOf('n')>=0){ h=Math.max(minH,sh-dy); t=st+(sh-h); }
-        panel.style.setProperty('width',w+'px','important'); panel.style.setProperty('height',h+'px','important');
-        panel.style.setProperty('left',l+'px','important'); panel.style.setProperty('top',t+'px','important'); panel.setAttribute('data-dragged','1'); };
-      const up=(ev)=>{ delete panel.dataset.resizing; try{ panel.releasePointerCapture&&panel.releasePointerCapture(ev.pointerId); }catch(_){} document.removeEventListener('pointermove',mv); document.removeEventListener('pointerup',up); panel.style.cursor=''; };
-      document.addEventListener('pointermove',mv); document.addEventListener('pointerup',up); });
-    registerWindow(panel); }
+  /* (#R169) moved verbatim to js/window-manager.js — see Architecture.md §3.1. */
   try{ window.bringToFront=bringToFront; window.addEdgeResize=addEdgeResize; window.registerWindow=registerWindow; }catch(_){}
 
   window.removeRadiusItem=function(id){ radiusItems=radiusItems.filter(c=>c.id!==id); if(window._activeRadiusId===id) window._activeRadiusId=null; refreshTool(); updateToolPanel(); };
@@ -3238,218 +2406,22 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   { const vb=document.getElementById('ai-view-summary-btn'); if(vb) vb.onclick=aiSummarizeView; }
   aiButtonSyncers.push(function(){ const b=document.getElementById('ai-summarize-btn'); if(!b) return; b.classList.toggle('ai-needs-key',!aiReady()); b.title=aiReady()?'':t('aiNoKey'); });
-  function handleMapClick(lng,lat,point,viaBtn){
-    if(window.__scpPick) return;   /* (#R86) Compare "pick a country on the map" mode owns the click */
-    /* (#R7-draw) The freehand Draw tool owns the map gesture while it is active. */
-    if(window.DrawTool && window.DrawTool.active()) return;
-    /* Köppen click-to-highlight (#25): when the climate layer is on, clicking the map highlights
-       (toggles) the climate zone at that point. Works whether or not a measurement tool is active. */
-    try{
-      const climCb=document.getElementById('dl-climate');
-      if(climCb && climCb.checked && window.sampleKoppenAt){
-        /* (#R122) do NOT also toggle/highlight the climate zone when the tap is opening a place-label popup —
-           the click landed on a place name, not on empty climate raster ("地名ラベルをクリックする際、その
-           クリック地点の気候区分までクリックされ…ないように"). */
-        let onLabel=false;
-        try{ const pt=point||(map&&map.project([lng,lat]));
-          if(pt&&map){ const ls=['ofm-country','ofm-city','ofm-other','geo-sea','ofm-water','ofm-water2','ofm-river','ofm-peak'].filter(id=>map.getLayer(id));
-            if(ls.length){ const pad=(typeof isMobile==='function'&&isMobile())?15:6; const near=map.queryRenderedFeatures([[pt.x-pad,pt.y-pad],[pt.x+pad,pt.y+pad]],{layers:ls}); if(near&&near.length) onLabel=true; } } }catch(_){}
-        if(!onLabel){ const code=window.sampleKoppenAt(lng,lat);
-          if(code && window.kSelected){
-            window.kSelected.has(code)?window.kSelected.delete(code):window.kSelected.add(code);
-            if(window._buildKoppenLegend) window._buildKoppenLegend();
-            if(window._refreshKoppenImage) window._refreshKoppenImage();
-          }
-        }
-      }
-    }catch(_){}
-    /* On phones, tapping the map outside a legend collapses any expanded legend so it stops
-       covering the map (#29). */
-    try{ if(isMobile() && window._minimizeOpenLegends) window._minimizeOpenLegends(); }catch(_){}
-    if(!toolMode||!hasTurf())return;
-    /* (#R11) On mobile, measuring is center-fixed: a tap does NOT add a point — only the "Add point"
-       button (which calls this with viaBtn=true) adds the map-center coordinate. */
-    if(isMobile() && !viaBtn) return;
-    /* Polar safety (#10): the poles AND their surroundings are singular for great-circle / area
-       math and make turf emit NaN or globe-wrapping geometry. Clamp out of the polar caps. */
-    lat=Math.max(-88,Math.min(88,lat));
-    /* Don't add a measure point if the click landed on an existing pin or intel marker */
-    if(point && map){
-      try{
-        const hit=map.queryRenderedFeatures(point,{layers:['user-pin-dot','news-dots','dash-dots'].filter(l=>map.getLayer(l))});
-        if(hit&&hit.length) return;
-      }catch(e){}
-    }
-    if(toolMode==='radius'){
-      const rid='r_'+Date.now()+'_'+Math.random().toString(36).slice(2,6);
-      radiusItems.push({id:rid,center:[lng,lat],radiusKm,color:radiusColor,opacity:radiusOpacity}); window._activeRadiusId=rid;
-      refreshTool(); updateToolPanel(); return;
-    }
-    /* === Auto-close for the Measure tool: if 3+ points and the new click lands within
-       SNAP_PX of the start point (the highlighted vertex), close into AREA mode. The same
-       threshold drives the on-map highlight so "add vs. close" is unambiguous (#47). */
-    if(toolMode==='measure' && measurePoints.length>=3 && point){
-      try{
-        const pStart=map.project(measurePoints[0]);
-        const dx=pStart.x-point.x, dy=pStart.y-point.y;
-        if(Math.hypot(dx,dy)<SNAP_PX){
-          toolMode='area'; measureSnapClose=false;
-          document.getElementById('measure-tooltip').classList.remove('closing');
-          _syncToolBtns();
-          refreshTool(); updateToolPanel();
-          return;
-        }
-      }catch(_){}
-    }
-    measurePoints.push([lng,lat]); refreshTool(); updateToolPanel();
-  }
+  /* (#R169) moved verbatim to js/map-readout.js — see Architecture.md §3.1. */
 
   /* ===== Coord readout (coords + elevation/depth) ===== */
   let elevTimer=null, lastElev='', _elevSeq=0, _crLng=null, _crLat=null, lastLayerVal='';
-  const _elevCache=new Map();
-  function fmtLL(lng,lat){ return `${Math.abs(lat).toFixed(3)}°${lat>=0?'N':'S'}  ${Math.abs(lng).toFixed(3)}°${lng>=0?'E':'W'}`; }
-  function renderCoordReadout(lng,lat){
-    const el=document.getElementById('coord-readout'); if(!el) return;
-    if(lng!=null){ _crLng=lng; _crLat=lat; }
-    if(_crLng==null){ el.style.display='none'; return; }
-    const parts=[];
-    parts.push(`<span>${fmtLL(_crLng,_crLat)}</span>`); parts.push(`<span class="cr-elev">${lastElev||'·····'}</span>`);
-    if(lastLayerVal) parts.push(`<span class="cr-sat">${lastLayerVal}</span>`);
-    /* (#R8c) Live wind speed/direction under the cursor while the Wind layer is on. */
-    /* (#R19) No emoji in the always-on readout ("🌬みたいな絵文字は…いらない") — value + direction only. */
-    try{ if(window.Wind&&window.Wind.on&&window.Wind.on()){ const w=window.Wind.sampleAt(_crLng,_crLat); if(w){ const card=['N','NE','E','SE','S','SW','W','NW'][Math.round(w.dir/45)%8]; const sp=window.fmtWindSpeed?window.fmtWindSpeed(w.speed):(w.speed.toFixed(1)+' m/s'); parts.push(`<span class="cr-wind">${sp} ${card}</span>`); } } }catch(_){}
-    /* Satellite-imagery chip removed from the readout per request — coords + elevation only. */
-    if(!parts.length){ el.style.display='none'; return; }
-    el.style.display='flex';
-    el.innerHTML=parts.join('');
-  }
-  /* === Instant elevation/depth from cached terrarium DEM tiles (includes ocean bathymetry) === */
-  const _demCache=new Map();
+  /* (#R169) moved verbatim to js/map-readout.js — see Architecture.md §3.1. */
   /* (#R19) Hard cap on retained DEM tiles (LRU): a 400 km Line-of-Sight at z13 touches hundreds of
      tiles; each cached 256² canvas+pixels is ~½ MB, and they previously accumulated FOREVER — a real
      mobile OOM vector ("重い動作をすると頻繁にブラウザが落ちます"). Map preserves insertion order, so
      evicting the first non-loading entries is a cheap LRU. */
   const _DEM_CACHE_MAX=(typeof isMobile==='function'&&isMobile())?140:560;   /* (#R21) follows the raised desktop LOS tile budget */
-  function _demCacheTrim(){ if(_demCache.size<=_DEM_CACHE_MAX) return;
-    for(const k of _demCache.keys()){ if(_demCache.size<=_DEM_CACHE_MAX) break; const v=_demCache.get(k); if(v==='loading') continue; _demCache.delete(k); } }
-  /* (#R19) Per-tile decoded pixel buffer, extracted ONCE. demElevBilinear used to call a full 256×256
-     getImageData (a ~256 KB copy) for EVERY sample — ~72,000 samples per LOS run ≈ 18 GB of memory
-     traffic, which is exactly the "Line of sightを使うとパソコンでもブラウザがフリーズ" freeze. */
-  function _demPix(cv){ if(!cv||cv==='loading') return null;
-    if(!cv.__pix){ try{ cv.__pix=cv.getContext('2d',{willReadFrequently:true}).getImageData(0,0,256,256).data; }catch(e){ return null; } }
-    return cv.__pix; }
-  function _ll2tile(lng,lat,z){ const n=Math.pow(2,z); const x=(lng+180)/360*n; const lr=lat*Math.PI/180; const y=(1-Math.log(Math.tan(lr)+1/Math.cos(lr))/Math.PI)/2*n; return {x,y,n}; }
-  /* Pick a DEM tile-zoom matched to the map zoom. Zoomed out → low z (a handful of tiles cover the
-     whole view, so the readout is instant everywhere). Zoomed in → high z (sharper elevation). */
-  function demZoomForMap(){ let mz=4; try{ if(map) mz=map.getZoom(); }catch(_){} return Math.max(3,Math.min(12,Math.round(mz)+1)); }
-  function demElevAt(lng,lat,onReady,zArg){
-    const z=(zArg!=null?zArg:demZoomForMap()); const tl=_ll2tile(lng,lat,z); const xi=Math.floor(tl.x), yi=Math.floor(tl.y);
-    if(xi<0||yi<0||xi>=tl.n||yi>=tl.n||lat>85||lat<-85) return null;
-    const key=z+'/'+xi+'/'+yi; let c=_demCache.get(key);
-    if(c===undefined){
-      _demCacheTrim();
-      _demCache.set(key,'loading');
-      const img=new Image(); img.crossOrigin='anonymous';
-      img.onload=()=>{ try{ const cv=document.createElement('canvas'); cv.width=256; cv.height=256; cv.getContext('2d',{willReadFrequently:true}).drawImage(img,0,0); _demCache.set(key,cv); if(onReady) onReady(); }catch(e){ _demCache.set(key,null); } };
-      img.onerror=()=>_demCache.set(key,null);
-      img.src=`https://s3.amazonaws.com/elevation-tiles-prod/terrarium/${z}/${xi}/${yi}.png`;
-      return null;
-    }
-    if(c==='loading'||c===null) return null;
-    /* (#R19) read from the per-tile decoded buffer — no per-sample getImageData */
-    const d=_demPix(c); if(!d) return null;
-    const px=Math.min(255,Math.max(0,Math.floor((tl.x-xi)*256))), py=Math.min(255,Math.max(0,Math.floor((tl.y-yi)*256)));
-    const i=(py*256+px)*4; return (d[i]*256+d[i+1]+d[i+2]/256)-32768;
-  }
-  /* === Shared async DEM sampler (#R12) — used by the elevation profile and line-of-sight viewshed.
-     Warms every terrarium tile covering a set of points, then samples them LOCALLY. The terrarium
-     DEM carries ocean bathymetry (negative = below sea level), so profiles dip under water and the
-     viewshed reads real terrain — replacing the old per-point Open-Meteo fetch that fired hundreds
-     of requests at once and silently failed (the root cause of "Line of Sight doesn't work"). */
-  function _demZoomForSpan(km){ return Math.max(5, Math.min(13, Math.round(Math.log2(481000/Math.max(1,km))))); }
-  /* (#R18) onProgress(frac 0..1) lets callers (Line of Sight / elevation profile) show a real % + bar
-     while the covering DEM tiles load — the slow part of a viewshed ("計算の進捗をパーセントで表示"). */
-  function warmDEMTiles(points, z, timeoutMs, onProgress){
-    const keys=new Set();
-    points.forEach(p=>{ if(!p) return; const tl=_ll2tile(p[0],p[1],z); const xi=Math.floor(tl.x), yi=Math.floor(tl.y); if(xi>=0&&yi>=0&&xi<tl.n&&yi<tl.n){ keys.add(z+'/'+xi+'/'+yi); demElevAt(p[0],p[1],null,z); } });
-    const total=keys.size||1;
-    return new Promise(res=>{ const t0=Date.now(); (function poll(){ let pending=0; keys.forEach(k=>{ const c=_demCache.get(k); if(c===undefined||c==='loading') pending++; }); if(onProgress){ try{ onProgress((total-pending)/total); }catch(_){} } if(pending===0||Date.now()-t0>(timeoutMs||9000)) res(); else setTimeout(poll,90); })(); });
-  }
-  async function demSampleAll(points, z, timeoutMs, onProgress){ await warmDEMTiles(points, z, timeoutMs, onProgress); return points.map(p=>{ if(!p) return null; const v=demElevAt(p[0],p[1],null,z); return (v==null)?null:v; }); }
-  /* (#R18) Bilinear DEM sample for the viewshed — smooths the stair-stepping of nearest-pixel sampling so
-     ridge lines (which decide what's blocked) are physically truer. Reads the 4 surrounding texels and
-     interpolates; falls back to nearest at tile edges. Tiles must already be warm (LOS warms them first). */
-  function demElevBilinear(lng,lat,z){
-    const tl=_ll2tile(lng,lat,z); const xi=Math.floor(tl.x), yi=Math.floor(tl.y);
-    if(xi<0||yi<0||xi>=tl.n||yi>=tl.n||lat>85||lat<-85) return null;
-    const cv=_demCache.get(z+'/'+xi+'/'+yi); if(!cv||cv==='loading') return null;
-    const d=_demPix(cv); if(!d) return null;   /* (#R19) decoded once per tile, not per sample */
-    const fx=(tl.x-xi)*256-0.5, fy=(tl.y-yi)*256-0.5;
-    const x0=Math.max(0,Math.min(255,Math.floor(fx))), y0=Math.max(0,Math.min(255,Math.floor(fy)));
-    const x1=Math.min(255,x0+1), y1=Math.min(255,y0+1); const tx=Math.max(0,Math.min(1,fx-x0)), ty=Math.max(0,Math.min(1,fy-y0));
-    const el=(px,py)=>{ const i=(py*256+px)*4; return (d[i]*256+d[i+1]+d[i+2]/256)-32768; };
-    const a=el(x0,y0), b=el(x1,y0), c=el(x0,y1), e=el(x1,y1);
-    return (a*(1-tx)+b*tx)*(1-ty)+(c*(1-tx)+e*tx)*ty;
-  }
-  /* Elevation/depth respects the measurement-units setting (#R13c): imperial → feet, both → "m (ft)". */
-  function fmtElevVal(e){ const m=Math.round(e), ft=Math.round(e*3.28084); const um=(typeof unitMode!=='undefined')?unitMode:'both'; return um==='imperial'?(ft.toLocaleString()+' ft'):um==='metric'?(m.toLocaleString()+' m'):(m.toLocaleString()+' m ('+ft.toLocaleString()+' ft)'); }
+  /* (#R169) moved verbatim to js/map-readout.js — see Architecture.md §3.1. */
+  /* (#R169) moved verbatim to js/elevation-profile.js — see Architecture.md §3.1. */
+  /* (#R169) moved verbatim to js/map-readout.js — see Architecture.md §3.1. */
   window.fmtElevVal=fmtElevVal;
   function elevText(e){ return e<0 ? `${t('depth')} ${fmtElevVal(Math.abs(e))}` : `${t('elev')} ${fmtElevVal(e)}`; }
-  /* Live weather-layer value at the cursor (#12): Köppen is instant (pixel sample); SST / air-temp
-     are fetched seamlessly from Open-Meteo (debounced + cached per ~0.1°). */
-  let _wxTimer=null; const _wxCache=new Map();
-  function activeWxLayer(){ const on=id=>{ const cb=document.getElementById('dl-'+id); return cb&&cb.checked; }; return on('sst')?'sst':on('temp')?'temp':on('climate')?'climate':null; }
-  function updateLayerReadout(lng,lat){
-    const lyr=activeWxLayer();
-    if(!lyr){ /* no weather layer → show the active numeric choropleth's value at the cursor (#R13c) */
-      let cv=null; try{ cv=window.choroValueAt&&window.choroValueAt(lng,lat); }catch(_){}
-      lastLayerVal = cv||''; return; }
-    if(lyr==='climate'){ let code=null; try{ code=window.sampleKoppenAt&&window.sampleKoppenAt(lng,lat); }catch(_){}
-      /* no leading emoji on the layer value (#34) */
-      lastLayerVal = code ? (code+(window.KNAME&&window.KNAME[code]?' · '+(window.KNAME[code][currentLang]||window.KNAME[code].en):'')) : ''; return; }
-    /* (#R27) Cache on a COARSER 0.25° grid (was 0.1°). SST / air-temp barely change over ~28 km, so a
-       coarser grid means the cursor lands on an ALREADY-cached cell far more often → the value is shown
-       instantly (no fetch) across a whole local area, and far fewer network calls fire. This is the main
-       "数値が変わるのが遅い" lever — the per-cell fetch was the only real latency. */
-    const q=(v)=>(Math.round(v*4)/4);                        /* snap to 0.25° */
-    const qla=q(lat), qlo=q(lng), key=lyr+':'+qla.toFixed(2)+','+qlo.toFixed(2);
-    if(_wxCache.has(key)){ lastLayerVal=_wxCache.get(key); return; }
-    /* (#R25/#R27) Show the nearest already-cached neighbor INSTANTLY so the readout tracks the cursor with
-       no blank/stale gap; the exact fetch refines it below. Tolerance widened (0.6°→1.5°) so the readout
-       stays populated while panning into a new region. */
-    try{ let best=null,bd=1e9;
-      for(const k of _wxCache.keys()){ if(k.slice(0,key.indexOf(':'))!==lyr) continue; const m=k.split(':')[1].split(','); const d=Math.abs(+m[0]-qla)+Math.abs(+m[1]-qlo); if(d<bd){ bd=d; best=k; } }
-      if(best&&bd<=1.5){ lastLayerVal=_wxCache.get(best); } }catch(_){}
-    clearTimeout(_wxTimer);
-    _wxTimer=setTimeout(async()=>{
-      try{
-        let url,pick;   /* fetch the CELL CENTER so the cached value matches the key */
-        if(lyr==='sst'){ url=`https://marine-api.open-meteo.com/v1/marine?latitude=${qla.toFixed(3)}&longitude=${qlo.toFixed(3)}&current=sea_surface_temperature`; pick=j=>j&&j.current&&j.current.sea_surface_temperature; }
-        else { url=`https://api.open-meteo.com/v1/forecast?latitude=${qla.toFixed(3)}&longitude=${qlo.toFixed(3)}&current=temperature_2m`; pick=j=>j&&j.current&&j.current.temperature_2m; }
-        const r=await fetch(url); if(!r.ok) return; const j=await r.json(); const v=pick(j);
-        if(typeof v==='number'){ const um=window.imUnitTemp||'both'; const txt = um==='f' ? (v*9/5+32).toFixed(1)+'°F' : um==='c' ? v.toFixed(1)+'°C' : v.toFixed(1)+'°C ('+(v*9/5+32).toFixed(1)+'°F)'; _wxCache.set(key,txt); lastLayerVal=txt; renderCoordReadout(lng,lat); }   /* unit-aware (#R13c); no leading emoji (#34) */
-      }catch(_){}
-    },30);
-  }
-  /* (#R25) Coalesce the per-move readout to ONE animation frame with the LATEST cursor position, so fast
-     mouse movement can't build a backlog of heavy updateCoord calls (queryRenderedFeatures + DEM + DOM)
-     that made the value/classification visibly lag behind the cursor ("カーソルを動かしているのに遅い"). */
-  let _ucRAF=0,_ucLng=null,_ucLat=null;
-  function updateCoord(lng,lat){ if(isMobile()) return; _ucLng=lng; _ucLat=lat; if(_ucRAF) return;
-    _ucRAF=requestAnimationFrame(()=>{ _ucRAF=0; try{ _updateCoordNow(_ucLng,_ucLat); }catch(_){} }); }
-  function _updateCoordNow(lng,lat){
-    if(isMobile()) return;
-    try{ updateLayerReadout(lng,lat); }catch(_){}
-    /* Instant: read elevation/depth straight from a cached DEM tile (no network). */
-    const dem=demElevAt(lng,lat,()=>{ const d2=demElevAt(lng,lat); if(d2!=null){ lastElev=elevText(d2); renderCoordReadout(lng,lat); } });
-    if(dem!=null){ lastElev=elevText(dem); renderCoordReadout(lng,lat); return; }
-    /* Tile still loading → show coords now, fall back to network elevation briefly. */
-    const ckey=lat.toFixed(2)+','+lng.toFixed(2);
-    lastElev=_elevCache.has(ckey)?_elevCache.get(ckey):'';
-    renderCoordReadout(lng,lat);
-    clearTimeout(elevTimer);
-    if(!_elevCache.has(ckey)) elevTimer=setTimeout(()=>{ fetchElev(lng,lat); },80);
-  }
+  /* (#R169) moved verbatim to js/map-readout.js — see Architecture.md §3.1. */
   /* Warm the DEM tile cache across the visible area once the camera settles, so the
      elevation/depth readout is instant on hover (kills the first-hover network wait). */
   function prefetchDEMViewport(){
@@ -3461,32 +2433,7 @@ window.addEventListener('DOMContentLoaded', () => {
   let _demPrefetchT=null;
   if(map){ map.on('moveend',()=>{ clearTimeout(_demPrefetchT); _demPrefetchT=setTimeout(prefetchDEMViewport,200); });
            map.on('zoomend',()=>{ clearTimeout(_demPrefetchT); _demPrefetchT=setTimeout(prefetchDEMViewport,120); }); }
-  /* GEBCO 2020 bathymetry (real ocean depth) via CORS proxy — Open-Meteo returns 0 over water. */
-  const _bathyCache=new Map();
-  async function fetchBathymetry(lat,lng){
-    const key=lat.toFixed(2)+','+lng.toFixed(2);
-    if(_bathyCache.has(key)) return _bathyCache.get(key);
-    const u=`https://api.opentopodata.org/v1/gebco2020?locations=${lat.toFixed(4)},${lng.toFixed(4)}`;
-    const proxies=[ x=>`https://api.allorigins.win/raw?url=${encodeURIComponent(x)}`, x=>`https://corsproxy.io/?url=${encodeURIComponent(x)}`, x=>`https://api.codetabs.com/v1/proxy/?quest=${encodeURIComponent(x)}` ];
-    for(const mk of proxies){
-      try{ const r=await fetch(mk(u)); if(!r.ok) continue; const j=await r.json(); const v=j&&j.results&&j.results[0]&&j.results[0].elevation; if(typeof v==='number'){ _bathyCache.set(key,v); return v; } }catch(_){}
-    }
-    return null;
-  }
-  async function fetchElev(lng,lat){
-    const rLat=lat, rLng=lng, seq=++_elevSeq;
-    const ckey=rLat.toFixed(2)+','+rLng.toFixed(2);
-    const set=(txt)=>{ _elevCache.set(ckey,txt); if(seq===_elevSeq){ lastElev=txt; renderCoordReadout(rLng,rLat); } };
-    try{
-      const r=await fetch(`https://api.open-meteo.com/v1/elevation?latitude=${rLat.toFixed(4)}&longitude=${rLng.toFixed(4)}`);
-      let e=null; if(r.ok){ const j=await r.json(); e=j&&j.elevation&&j.elevation[0]; }
-      if(typeof e==='number' && e>0.5){ set(elevText(e)); return; }
-      /* At/below sea level → fetch true depth from GEBCO bathymetry. */
-      const d=await fetchBathymetry(rLat,rLng);
-      if(typeof d==='number'){ set(elevText(d)); }
-      else if(typeof e==='number'){ set(elevText(e)); }
-    }catch(_){}
-  }
+  /* (#R169) moved verbatim to js/map-readout.js — see Architecture.md §3.1. */
 
   /* ===== (#R119) IntMapLayers — the COMMON LAYER DATA CONTRACT ("Atlasが表示中レイヤーの実値を読める仕組み").
      Every registered layer exposes the same tiny interface:
@@ -3700,7 +2647,7 @@ window.addEventListener('DOMContentLoaded', () => {
     document.addEventListener('click',(e)=>{ if(c && !c.contains(e.target)) c.classList.remove('open'); });
     ['btn-screenshot','btn-share'].forEach(id=>{ const b=document.getElementById(id); if(b) b.addEventListener('click',()=>window._closeShareMenu&&window._closeShareMenu()); });
   })();
-  function updateCompass(){ const s=document.querySelector('.compass-svg'); if(s&&map)s.style.transform=`rotate(${-map.getBearing()}deg)`; }
+  /* (#R169) moved verbatim to js/map-readout.js — see Architecture.md §3.1. */
   document.getElementById('btn-compass').onclick=()=>map&&map.easeTo({bearing:0,pitch:0,duration:500});
   /* (#R152) DESKTOP: right-click the compass → a popup to type an EXACT bearing / pitch (elevation) / zoom, applied to
      the current view ("方位磁針ボタンを右クリックしたら、方角、視点の仰角等を数値で打ち込めるポップアップ"). Left-click still resets north. */
@@ -3731,185 +2678,7 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   })();
 
-  /* ===== Map-side global place search (Nominatim) + abstract / natural-language pre-processing =====
-   * Handles patterns like:
-   *   - "capital of <country>"
-   *   - "highest mountain in <country>"
-   *   - "largest city in <country>"
-   *   - "<place> nearest to <city>"
-   *   - country names by stat ("country with highest GDP")
-   * For anything we can't pattern-match, we just hand the raw query to Nominatim, which
-   * itself is reasonably forgiving for natural-language queries.
-   */
-  function preprocessNLQuery(q){
-    const ql=q.toLowerCase().trim();
-    /* "capital of <country>" → look up CAPITAL[code] */
-    const mCap=ql.match(/^capital\s+of\s+(.+)$/) || ql.match(/^(.+?)の首都$/);
-    if(mCap){
-      const name=mCap[1].trim();
-      const hit=Object.values(countryStats||{}).find(s=>{
-        const en=(s.nameEn||'').toLowerCase(), jp=s.nameJp||'';
-        return en===name || en.includes(name) || jp.includes(name);
-      });
-      if(hit && hit.capital) return hit.capital+', '+hit.nameEn;
-    }
-    /* "country with the highest <stat>" */
-    const STAT_KEYS={'gdp':'gdp','economy':'gdp','population':'pop','area':'area','hdi':'hdi','democracy':'dem','military':'milSpend','life expectancy':'lifeExp','internet':'internet'};
-    const mHigh=ql.match(/^(?:country|nation)\s+(?:with\s+)?(?:the\s+)?(?:highest|largest|biggest|most)\s+(.+)$/);
-    if(mHigh){
-      const key=Object.keys(STAT_KEYS).find(k=>mHigh[1].includes(k));
-      if(key){ const sk=STAT_KEYS[key]; const top=Object.values(countryStats).filter(s=>s[sk]!=null).sort((a,b)=>b[sk]-a[sk])[0]; if(top) return top.nameEn; }
-    }
-    /* Japanese: "X 最大" / "X 最高" → similar fallback */
-    const mJpHigh=ql.match(/^(.+?)(が|の)?(最大|最多|最高)(?:の国)?$/);
-    if(mJpHigh){
-      const w=mJpHigh[1].trim();
-      const map={'人口':'pop','GDP':'gdp','面積':'area','軍事費':'milSpend','HDI':'hdi'};
-      const sk=map[w]; if(sk){ const top=Object.values(countryStats).filter(s=>s[sk]!=null).sort((a,b)=>b[sk]-a[sk])[0]; if(top) return top.nameEn; }
-    }
-    return q;
-  }
-  /* (#R15) Tiny Levenshtein for tolerant (fuzzy) matching of short queries. */
-  function _lev(a,b){ a=a||'';b=b||''; const m=a.length,n=b.length; if(!m)return n; if(!n)return m;
-    let prev=Array.from({length:n+1},(_,j)=>j), cur=new Array(n+1);
-    for(let i=1;i<=m;i++){ cur[0]=i; for(let j=1;j<=n;j++){ const c=a[i-1]===b[j-1]?0:1; cur[j]=Math.min(prev[j]+1,cur[j-1]+1,prev[j-1]+c); } [prev,cur]=[cur,prev]; }
-    return prev[n]; }
-  /* (#R15 / #34) Local fuzzy place lookup — resolves vague / partial / slightly-misspelled queries
-     against bundled country names, capitals and the built-in gazetteer, so search still works when the
-     external geocoder is slow / rate-limited / too strict for a loose query. Returns scored {name,lng,lat}. */
-  function localFuzzyPlaces(q){
-    const ql=(q||'').toLowerCase().trim(); if(!ql) return [];
-    const out=[];
-    const push=(name,lng,lat,score,kind)=>{ lng=+lng;lat=+lat; if(isNaN(lng)||isNaN(lat))return; out.push({name,lng,lat,score,kind:kind||''}); };   /* (#R46) kind = scale hint (country/capital/city/…) for Atlas zoom */
-    try{ Object.values(countryStats||{}).forEach(s=>{
-      if(!s.latlng) return; const en=(s.nameEn||'').toLowerCase(), jp=(s.nameJp||''), cap=(s.capital||'').toLowerCase();
-      let sc=0, suffix='';
-      if(en===ql||(jp&&jp===q)) sc=100;
-      else if(en.startsWith(ql)) sc=86;
-      else if(cap===ql){ sc=82; suffix=' · '+s.capital; }
-      else if(en.includes(ql)||(jp&&jp.includes(q))) sc=72;
-      else if(en.split(/\s+/).some(w=>w.startsWith(ql))&&ql.length>=3) sc=66;   /* (#R19) word-prefix: "zeal"→New Zealand */
-      else if(cap.includes(ql)&&ql.length>=3){ sc=58; suffix=' · '+s.capital; }
-      else if(ql.length>=4 && _lev(en,ql)<=2) sc=62;
-      else if(ql.length>=5 && cap && _lev(cap,ql)<=2){ sc=56; suffix=' · '+s.capital; }   /* (#R19) misspelled capital */
-      if(sc>0) push(s.nameEn+suffix, s.latlng[1], s.latlng[0], sc, suffix?'capital':'country');
-    }); }catch(_){}
-    try{ const gz=(typeof BUILTIN_GAZETTEER!=='undefined')?BUILTIN_GAZETTEER:null;
-      if(gz) for(const type in gz){ gz[type].forEach(e=>{ const terms=Array.isArray(e.terms)?e.terms.join(' '):String(e.terms||''); const tl=terms.toLowerCase(); const nm=(e.name&&(e.name[currentLang]||e.name.en))||terms;
-        const words=tl.split(/[|,\s]+/);
-        let sc=0; if(words.includes(ql)) sc=88; else if(words.some(w=>w.startsWith(ql))&&ql.length>=3) sc=68;   /* (#R19) prefix */
-        else if(tl.includes(ql)&&ql.length>=3) sc=64;
-        else if(ql.length>=4 && words.some(w=>w.length>=4&&_lev(w,ql)<=2)) sc=58;   /* (#R19) per-word typo tolerance */
-        if(sc>0 && e.loc) push(nm, e.loc[0], e.loc[1], sc, type); }); }
-    }catch(_){}
-    const seen=new Set();
-    return out.sort((a,b)=>b.score-a.score).filter(x=>{ const k=x.name+'|'+x.lng.toFixed(1)+'|'+x.lat.toFixed(1); if(seen.has(k))return false; seen.add(k); return true; }).slice(0,7);
-  }
-  async function doGeocode(){
-    const inp=document.getElementById('ms-input'), q=inp.value.trim(), res=document.getElementById('ms-results'); if(!q)return;
-    res.style.display='block';
-    /* (#R15e) Make sure the bundled country data is loading so local country/capital matches are available
-       (the gazetteer is always loaded; countryStats may not be until Stats is opened). Non-blocking. */
-    try{ if(typeof loadCountryData==='function' && (typeof countryStats==='undefined' || !countryStats || !Object.keys(countryStats).length)) loadCountryData(); }catch(_){}
-    const pq=preprocessNLQuery(q);
-    const local=localFuzzyPlaces(q);
-    const seen=new Set();
-    const addItem=(label,lng,lat,raw)=>{ if(isNaN(lng)||isNaN(lat))return; const key=label+'|'+lng.toFixed(2)+'|'+lat.toFixed(2); if(seen.has(key))return; seen.add(key);
-      const d=document.createElement('div'); d.className='ms-item'; d.textContent=label; d.onclick=()=>{ gotoPlace(lng,lat,label,raw||null); res.style.display='none'; inp.value=String(label).split(',')[0].split(' · ')[0]; }; res.appendChild(d); };
-    /* (#R15e) Show strong LOCAL matches IMMEDIATELY — was awaiting Nominatim with no timeout, so a slow /
-       unreachable geocoder left the box frozen on "Loading…" forever ("結果が出てこない"). Now local
-       (countries/capitals/gazetteer) appear instantly; the external geocoder is merged in with a hard
-       timeout so it can never hang the search. */
-    res.innerHTML='';
-    local.filter(l=>l.score>=72).forEach(l=>addItem(l.name,l.lng,l.lat,null));
-    if(!res.children.length) res.innerHTML=`<div class="ms-loading">${t('loading')}</div>`;
-    /* (#R16) The mobile "no results" bug: under file:// / on mobile networks Nominatim is often rate-limited,
-       blocked (null Origin) or just slow, and on a fresh load countryStats isn't loaded yet, so there was
-       NOTHING to show. Now query TWO CORS-friendly geocoders in PARALLEL behind one hard timeout —
-       **Open-Meteo geocoding** (fast, robust, fuzzy, works where Nominatim doesn't) AND Nominatim (richer
-       coverage). Either one alone yields results, so the search practically never comes back empty. */
-    const ctrl=new AbortController(); const to=setTimeout(()=>{ try{ctrl.abort();}catch(_){} },5000);
-    const omP=fetch(`https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(q)}&count=6&language=${currentLang==='jp'?'ja':'en'}&format=json`,{signal:ctrl.signal})
-      .then(r=>r.ok?r.json():null).then(j=>{ (j&&j.results||[]).forEach(p=>{ if(p.latitude==null||p.longitude==null)return; const adm=[p.admin1,p.country].filter(Boolean).join(', '); addItem(p.name+(adm?', '+adm:''),+p.longitude,+p.latitude,{display_name:p.name,type:p.feature_code,address:{country:p.country}}); }); }).catch(()=>{});
-    const nomP=fetch(`https://nominatim.openstreetmap.org/search?format=jsonv2&limit=6&accept-language=${currentLang==='jp'?'ja':'en'}&q=${encodeURIComponent(pq)}`,{signal:ctrl.signal})
-      .then(r=>r.ok?r.json():[]).then(a=>{ (a||[]).forEach(pl=>addItem(pl.display_name,+pl.lon,+pl.lat,pl)); }).catch(()=>{});
-    /* (#R19) Third parallel geocoder: Photon (komoot) — TYPO-TOLERANT like a search engine
-       ("あいまいな単語を入れても検索できるように"; curl-verified CORS* and that "osakaa" → Osaka). */
-    const phP=fetch(`https://photon.komoot.io/api/?q=${encodeURIComponent(q)}&limit=6&lang=${currentLang==='jp'?'en':'en'}`,{signal:ctrl.signal})
-      .then(r=>r.ok?r.json():null).then(j=>{ (j&&j.features||[]).forEach(f=>{ try{ const p=f.properties||{}, g=f.geometry; if(!g||!g.coordinates) return;
-        const label=[p.name,p.city,p.state,p.country].filter(Boolean).filter((v,i,a)=>a.indexOf(v)===i).join(', ');
-        if(label) addItem(label,+g.coordinates[0],+g.coordinates[1],{display_name:label,type:p.osm_value||p.type,address:{country:p.country}}); }catch(_){} }); }).catch(()=>{});
-    await Promise.allSettled([omP,nomP,phP]); clearTimeout(to);
-    const lo=res.querySelector('.ms-loading'); if(lo) lo.remove();
-    if(!res.querySelector('.ms-item')){ res.innerHTML=''; local.forEach(l=>addItem(l.name,l.lng,l.lat,null)); }   /* weak local fallback */
-    if(!res.querySelector('.ms-item')){ res.innerHTML=`<div class="ms-loading">${t('noMatch')}</div>`; }
-  }
-  let searchCardEl=null, searchCardData=null, searchCardOnMove=null;
-  function closeSearchCard(){
-    if(searchMarker){ searchMarker.remove(); searchMarker=null; }
-    if(searchCardEl){ searchCardEl.remove(); searchCardEl=null; }
-    if(searchCardOnMove && map){ map.off('move',searchCardOnMove); searchCardOnMove=null; }
-    searchCardData=null;
-  }
-  function positionSearchCard(){
-    if(!searchCardEl||!searchCardData||!map) return;
-    const pt=map.project([searchCardData.lng,searchCardData.lat]);
-    searchCardEl.style.left=pt.x+'px';
-    searchCardEl.style.top=pt.y+'px';
-  }
-  async function gotoPlace(lng,lat,displayName,raw){
-    if(!map)return;
-    closeSearchCard();
-    map.flyTo({center:[lng,lat],zoom:9,speed:1.4});
-    /* Build custom HTML pin element */
-    const pinEl=document.createElement('div');
-    pinEl.className='search-pin';
-    pinEl.innerHTML='<div class="sp-body"></div><div class="sp-pulse"></div>';
-    searchMarker=new maplibregl.Marker({element:pinEl,anchor:'bottom'}).setLngLat([lng,lat]).addTo(map);
-    /* Build the result card */
-    searchCardData={lng,lat,name:displayName,raw};
-    searchCardEl=document.createElement('div');
-    searchCardEl.className='search-result-card';
-    document.getElementById('map-container').appendChild(searchCardEl);
-    /* Try to enrich with admin info via reverse geocode (Nominatim) */
-    let admin='', type='', country='';
-    try{
-      if(raw){ admin=raw.display_name||''; type=raw.type||raw.class||''; country=raw.address&&raw.address.country||''; }
-    }catch(_){}
-    const parts=(displayName||'').split(',');
-    const primary=parts[0]||displayName||'';
-    const restAdmin=parts.slice(1,4).map(s=>s.trim()).filter(Boolean).join(', ');
-    searchCardEl.innerHTML=`<button class="src-card-close" title="${t('close')}">✕</button>
-      <div class="src-card">
-        <h4>📍 ${IntMapSafe.html(primary)}</h4>
-        <div class="src-sub">${IntMapSafe.html(restAdmin||country||'')}</div>
-        <div class="src-row"><span>${t('coords')}</span><b>${fmtLL(lng,lat)}</b></div>
-        ${type?`<div class="src-row"><span>${currentLang==='jp'?'種別':currentLang==='de'?'Typ':currentLang==='ru'?'Тип':currentLang==='es'?'Tipo':'Type'}</span><b>${IntMapSafe.html(type)}</b></div>`:''}
-        <div class="src-row"><span>${t('elev')}</span><b id="src-elev">${currentLang==='jp'?'取得中...':currentLang==='de'?'Lädt…':currentLang==='ru'?'Загрузка…':currentLang==='es'?'Cargando…':'Loading...'}</b></div>
-        <div class="src-actions">
-          <button class="primary" id="src-copy">📋 ${t('ctxCopy')}</button>
-          <button id="src-pin">📍 ${t('ctxDropPin')}</button>
-        </div>
-      </div>`;
-    searchCardEl.querySelector('.src-card-close').onclick=closeSearchCard;
-    searchCardEl.querySelector('#src-copy').onclick=()=>{ try{ navigator.clipboard.writeText(`${lat.toFixed(5)}, ${lng.toFixed(5)}`); }catch(_){} };
-    searchCardEl.querySelector('#src-pin').onclick=()=>{ const id=addPin(lng,lat); openPinPopup(id); };
-    /* (#R36) rAF-coalesce the per-move reposition (mobile pan/zoom smoothness #13): `move` can fire several
-       times per frame during inertia, and positionSearchCard does layout (getBoundingClientRect + style writes);
-       collapse it to at most once per frame so it never piles up work mid-gesture. */
-    let _scRAF=0; searchCardOnMove=()=>{ if(_scRAF) return; _scRAF=requestAnimationFrame(()=>{ _scRAF=0; try{ positionSearchCard(); }catch(_){} }); }; map.on('move',searchCardOnMove);
-    positionSearchCard();
-    /* Async elevation / depth */
-    try{
-      const r=await fetch(`https://api.open-meteo.com/v1/elevation?latitude=${lat.toFixed(4)}&longitude=${lng.toFixed(4)}`);
-      let e=null; if(r.ok){ const j=await r.json(); e=j&&j.elevation&&j.elevation[0]; }
-      const el=searchCardEl&&searchCardEl.querySelector('#src-elev');
-      if(el){
-        if(typeof e==='number' && e>0.5){ el.textContent=fmtElevVal(e); }
-        else { const d=await fetchBathymetry(lat,lng); if(typeof d==='number'){ el.textContent = d<0 ? (fmtElevVal(Math.abs(d))+' '+(currentLang==='jp'?'(水深)':currentLang==='de'?'(Tiefe)':currentLang==='ru'?'(глубина)':currentLang==='es'?'(profundidad)':'(depth)')) : fmtElevVal(d); } else if(typeof e==='number'){ el.textContent=fmtElevVal(e); } else el.textContent='—'; }
-      }
-    }catch(_){}
-  }
+  /* (#R169) moved verbatim to js/search-geocode.js — see Architecture.md §3.1. */
   /* (#R15 / #32) Mobile place search was broken: the search field collapses to a 46px circle on phones
      (input width:0, opacity:0) and nothing ever expanded it, so tapping Search just ran doGeocode() on an
      invisible empty input → no results. Now the button expands the field first, then searches. */
@@ -4313,103 +3082,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const lat=(((Math.abs(h>>8))%6000)/100)-30;
     return [lng,lat];
   }
-  /* ===== Scoring model (replaces the old "first geo term wins" loop) =====
-     Every geo entry is scored over the title + description; the highest score is the Subject.
-        title hit          +10   strong signal — the headline names the place
-        description hit     +3    supporting signal from the article snippet
-        type "flashpoint"   +5    conflict zone / chokepoint → high news relevance
-        type "city"         +2    precise locality
-        locational context  +4    "in Gaza" / "ガザで" → the place is the story's setting
-     Ties break toward the more local type (flashpoint > city > country > region). */
-  const TYPE_SCORE={ flashpoint:5, city:2, country:0, region:0 };
-  const TYPE_LOCAL={ flashpoint:4, city:3, country:2, region:1 };
-  function scoreGeo(g,title,desc){
-    let titleHit=false, descHit=false, ctx=false, firstIdx=Infinity;
-    for(const t of g._terms){
-      if(t.jp){ const i=title.indexOf(t.term); if(i>=0){ titleHit=true; if(i<firstIdx) firstIdx=i; if(!ctx&&t.ctxRe.test(title)) ctx=true; } }
-      else { const i=title.search(t.matchRe); if(i>=0){ titleHit=true; if(i<firstIdx) firstIdx=i; if(!ctx&&t.ctxRe.test(title)) ctx=true; } }
-      if(desc&&(t.jp?desc.includes(t.term):t.matchRe.test(desc))){ descHit=true; if(!ctx&&t.ctxRe.test(desc)) ctx=true; }
-    }
-    if(!titleHit&&!descHit) return 0;
-    /* (#R25/#28) Lead-subject bonus: a place named EARLY in the headline is much more likely to be what the
-       story is about (e.g. "Kyiv strikes …" → Kyiv, not a country mentioned at the end). Up to +3. */
-    const tl=title.length||1; const posBonus = titleHit ? Math.max(0, 3-Math.floor((Math.min(firstIdx,tl)/tl)*4)) : 0;
-    /* (#R27) Corroboration bonus: a place named in BOTH the title AND the description is a stronger subject
-       signal (+2). Demonym entries ("Ukrainian"…) are docked 3 so an explicit place name always outranks
-       them — they only win when nothing more specific matched, preserving precision while adding coverage. */
-    const corro = (titleHit&&descHit) ? 2 : 0;
-    /* (#R28) demonyms AND organizations/groups are docked so an explicit place name always outranks them
-       (an "Ukrainian"/"Hamas"/"NATO" mention only places a story that names no explicit city/country). */
-    const demPen = (g.demonym||g.org) ? 3 : 0;
-    return (titleHit?10:0)+(descHit?3:0)+(TYPE_SCORE[g.type]||0)+(ctx?4:0)+posBonus+corro-demPen;
-  }
-  /* (#R107) COUNTRY-LEVEL FALLBACK for the non-AI locator ("more reliable and flawless"): when the gazetteer scored
-     no specific place, anchor a country-level story to the country actually named (its polygon center) instead of a
-     meaningless deterministic scatter point — so far fewer "location unknown" pins, and always a REAL, correct place.
-     Purely ADDITIVE: it only runs when no subject was found, so it can never make an existing result worse. Built once
-     from countryGeo (bbox centers + word-boundary name regexes), memoized; the display name follows the UI language. */
-  let _cfIdx=null;
-  function _cfBuild(){ try{ const cg=window.countryGeo; if(!cg||!cg.features||!cg.features.length) return null;
-    const esc=s=>String(s).replace(/[.*+?^${}()|[\]\\]/g,'\\$&'); const idx=[];
-    for(const f of cg.features){ if(!f.geometry) continue; const p=f.properties||{};
-      let a=180,b=90,c=-180,d=-90; const scan=cs=>{ for(const x of cs){ if(typeof x[0]==='number'){ if(x[0]<a)a=x[0]; if(x[1]<b)b=x[1]; if(x[0]>c)c=x[0]; if(x[1]>d)d=x[1]; } else scan(x); } };
-      try{ scan(f.geometry.coordinates); }catch(_){ continue; } if(!(c>=a&&d>=b)) continue;
-      const names=[p.NAME_EN,p.ADMIN,p.NAME,p.name,p['name:en'],p.NAME_LONG,p.FORMAL_EN].filter(v=>v&&String(v).trim().length>=4);
-      const uniq=[...new Set(names.map(v=>String(v).trim()))]; if(!uniq.length) continue;
-      idx.push({ res:uniq.map(s=>new RegExp('\\b'+esc(s)+'\\b','i')), loc:[(a+c)/2,(b+d)/2], code:(f.id!=null?String(f.id):(p.__code||'')), en:(p.NAME_EN||p.ADMIN||p.NAME||p.name||''), len:Math.max.apply(null,uniq.map(s=>s.length)) }); }
-    return idx.length?idx:null; }catch(_){ return null; } }
-  function _countryFallback(hay){ try{ if(!_cfIdx) _cfIdx=_cfBuild(); if(!_cfIdx) return null;
-    let best=null; for(const c of _cfIdx){ if(c.res.some(re=>re.test(hay))){ if(!best||c.len>best.len) best=c; } }
-    if(!best) return null;
-    let nm=best.en; try{ const s=(typeof countryStats!=='undefined')&&countryStats[best.code]; if(s){ nm=(s.name&&(s.name[currentLang]||s.name.en))||((currentLang==='jp'&&s.nameJp)?s.nameJp:s.nameEn)||s.nameEn||best.en; } }catch(_){}
-    return { loc:best.loc, name:nm }; }catch(_){ return null; } }
-  /* (#R161) NewsGeo kind → the place TYPE the rest of the app already speaks
-     (R123 spreads duplicate pins differently for a country vs a city). */
-  const _NG_KIND={ country:'country', admin1:'region', feature:'region', flashpoint:'flashpoint', city:'city', seat:'city', org:'city' };
-  function analyzeContext(title,publisher,seed,desc){
-    desc=desc||'';
-    const short=currentLang==='jp'?(title.length>20?title.slice(0,20)+'…':title):(title.split(' ').slice(0,5).join(' ')+'…');
-    let subjectLoc=null, subjectName=null, subjectType=null, subjectConf=0;
-    /* ---- (#R161) PRIMARY: the deterministic NewsGeo engine (js/newsgeo.js).
-       It does what a plain gazetteer scan cannot — resolves same-name places from
-       country/region cues, suppresses dateline ("Blinken in Washington … Gaza"),
-       swallows traps ("Paris Hilton", "New York Times"), and boosts a city whose
-       own country is also named. Falls through to the legacy scorer below when it
-       declines to answer or the file did not load, so behaviour never regresses. */
-    try{
-      const NG=window.IntMapNewsGeo;
-      if(NG&&NG.locate){
-        const r=NG.locate(title,{desc,publisher,lang:currentLang});
-        if(r&&isFinite(r.lng)&&isFinite(r.lat)){
-          subjectLoc=[r.lng,r.lat];
-          subjectName=(currentLang==='jp'?(r.name.jp||r.name.en):(r.name.en||r.name.jp))||null;
-          subjectType=_NG_KIND[r.kind]||'city'; subjectConf=r.confidence||0;
-        }
-      }
-    }catch(_){}
-    /* ---- FALLBACK: the in-page gazetteer scorer (also the only path for the
-       admin-curated geo_pins types the engine has no opinion about). ---- */
-    if(!subjectLoc){
-      let best=null, bestScore=0;
-      for(const g of geoDB){
-        const s=scoreGeo(g,title,desc);
-        if(s<=0) continue;
-        if(s>bestScore || (s===bestScore && (!best||(TYPE_LOCAL[g.type]||0)>(TYPE_LOCAL[best.type]||0)))){ best=g; bestScore=s; }
-      }
-      /* name{} only carries en/jp — for de/ru/es fall back to English instead of
-         `undefined`, which used to surface as a blank pin label. */
-      if(best){ subjectLoc=best.loc; subjectName=best.name[currentLang]||best.name.en||best.name.jp||null; subjectType=best.type; }
-    }
-    /* (#R107) no gazetteer hit → try the country actually named (real location beats a random scatter). */
-    if(!subjectLoc){ const cf=_countryFallback(title+' '+desc); if(cf){ subjectLoc=cf.loc; subjectName=cf.name; subjectType='country'; } }
-    /* ---- Publisher HQ (expanded gazetteer, longest-key-first, word-boundary safe) ---- */
-    const pm=matchPublisher(publisher);
-    const pubLoc=pm?pm.loc:null, pubName=pm?((currentLang==='jp'?'発信: ':currentLang==='de'?'Quelle: ':currentLang==='ru'?'Источник: ':currentLang==='es'?'Fuente: ':'Source: ')+pm.label):null;
-    /* Remember title/publisher so the toggle/AI passes can re-seed fallbacks later */
-    const res={ subjectLoc, subjectName, subjectType, subjectConf, pubLoc, pubName, short, _title:title, _pub:publisher };
-    applyPinMode(res);
-    return res;
-  }
+  /* (#R169) moved verbatim to js/news-context.js — see Architecture.md §3.1. */
   /* (#R161) Verification seam — the whole non-AI locator is only trustworthy if it can be checked
      end-to-end from outside, so expose the real function (same pattern as _declutterNewsBands /
      _atlExtractPlaces). Tests call it with a headline and assert the pin it produces. */
@@ -4525,188 +3198,22 @@ window.addEventListener('DOMContentLoaded', () => {
      This is the single source of truth used by startNews so a later data refresh can't re-push stray pins. */
   function _wsNewsHidden(){ try{ if(!document.body.classList.contains('ws-mode')) return false; const w=document.querySelector('.ws-win.ws-news'); return !!(w && w.style.display==='none'); }catch(_){ return false; } }
   window._wsNewsHidden=_wsNewsHidden;
-  function startNews(){
-    const feed=document.getElementById('live-news-feed'); clearMarkers(); feed.innerHTML=''; renderedCount=0;
-    if(globalData.length===0){ feed.innerHTML=`<div class="empty-msg">${t('loading')}</div>`; return; }
-    newsFiltered=computeFilteredNews();
-    if(newsFiltered.length===0){ feed.innerHTML=`<div class="empty-msg">${t('noMatch')}</div>`; return; }
-    /* Pin every filtered news item on the map IMMEDIATELY, even items not yet rendered in sidebar.
-       This fixes "few pins on map despite many in sidebar". */
-    newsFeatures=[];
-    newsFiltered.forEach(item=>{
-      if(item.analysis && item.analysis.loc){
-        const fid='n_'+Math.random().toString(36).slice(2,10);
-        const mappedStr = item.analysis.mapped===true?'true':(item.analysis.mapped==='publisher'?'publisher':'none');
-        newsFeatures.push({type:'Feature',id:fid,geometry:{type:'Point',coordinates:item.analysis.loc},properties:{
-          fid, mapped:mappedStr, ptype:item.analysis.ptype||'', title:item.title, name:item.analysis.name||'',
-          short:item.analysis.short||'', publisher:item.publisher, link:item.link, pubDate:item.pubDate
-        }});
-      }
-    });
-    _spreadDupNewsPins(newsFeatures);   /* (#R122) fan out pins sharing an anchor so each is individually clickable */
-    if(map&&map.isStyleLoaded()) setupIntelLayers();
-    /* (#R79b) don't paint pins for a hidden News window (they'd appear with no window controlling them) */
-    if(map&&map.getSource('news-points')){ map.getSource('news-points').setData({type:'FeatureCollection',features:_wsNewsHidden()?[]:newsFeatures}); try{scheduleNewsDeclutter();}catch(_){} }
-    appendNewsBatch(); updateOcclusion();
-    maybeAutoEnrich();
-  }
+  /* (#R169) moved verbatim to js/news-feed.js — see Architecture.md §3.1. */
   /* Optional automatic AI passes (debounced so rapid re-renders don't stack runs).
      Gated on Settings (AI location = automatic / News languages = all) AND a saved API key. */
   let _autoEnrichT=null;
-  function maybeAutoEnrich(){
-    /* (#R29) News location analysis now runs ENTIRELY server-side (refresh-news pre-AI-locates every
-       en/jp article into current_news; the dictionary is the server's fallback). The browser never
-       calls the AI for news geocoding anymore, so there is no client auto-enrich pass to run here.
-       Kept as a no-op hook so existing callers (startNews) stay intact.
-       (#R15) Titles are still translated ONLY on the explicit "Translate titles" button. */
-  }
-  /* ===== AI title translation (multi-language news mode) =====
-     Foreign-language headlines (non-English in EN UI / non-Japanese in JP UI) are translated
-     into the UI language by the AI, with the original language noted on the card. */
-  const LANG_JP={German:'ドイツ語',French:'フランス語',Spanish:'スペイン語',Italian:'イタリア語',Portuguese:'ポルトガル語',Russian:'ロシア語',Arabic:'アラビア語',Chinese:'中国語',Korean:'韓国語',Japanese:'日本語',English:'英語',Dutch:'オランダ語',Turkish:'トルコ語',Hindi:'ヒンディー語',Persian:'ペルシャ語',Hebrew:'ヘブライ語',Ukrainian:'ウクライナ語',Polish:'ポーランド語',Swedish:'スウェーデン語',Greek:'ギリシャ語',Indonesian:'インドネシア語',Thai:'タイ語',Vietnamese:'ベトナム語'};
-  function localizeLangName(en){ if(!en) return ''; return currentLang==='jp'?(LANG_JP[en]||en):en; }
-  /* Update only the title cells of already-rendered cards (keeps scroll position). */
-  function rerenderNewsFeedTitles(){
-    (newsFiltered||[]).forEach(item=>{ const el=item._cardEl; if(el&&el.isConnected){ const tt=el.querySelector('.news-title'); if(tt) tt.innerHTML=newsTitleHTML(item); } });
-  }
-  let _translateBusy=false;
-  async function aiTranslateTitles(){
-    if(_translateBusy) return;
-    if(!aiGate()) return;
-    const target=currentLang==='jp'?'Japanese':currentLang==='de'?'German':currentLang==='ru'?'Russian':currentLang==='es'?'Spanish':'English';
-    const todo=computeFilteredNews().filter(it=>it.analysis && !it.analysis._titleTried).slice(0,120);
-    /* (#R9/#20) Spinner + progress + result toast — mirrors the AI-locate "detecting" UI so it's
-       obvious the translation is running and when it finished. */
-    const btn=document.getElementById('ai-translate-btn');
-    if(!todo.length){ aiToast(t('aiTransNone')); return; }
-    _translateBusy=true;
-    aiSetBtnBusy(btn,true,t('aiTransBusy'));
-    const sys=`You translate news headlines. The UI language is ${target}. For EACH numbered headline: if it is ALREADY written in ${target}, skip it entirely. Otherwise translate it into natural ${target}. Reply with ONLY a JSON array containing one object for each headline that NEEDED translation: {"i":<index number>,"lang":"<original language name in English, e.g. German>","t":"<the ${target} translation>"}. No commentary, no code fences.`;
-    const BATCH=15; let done=0, hit=0;
-    try{
-      for(let i=0;i<todo.length;i+=BATCH){
-        const chunk=todo.slice(i,i+BATCH);
-        const list=chunk.map((it,k)=>`${k}. ${it.title}`).join('\n');
-        let arr=null;
-        try{ arr=await askAIJSON('Headlines:\n'+list, sys); }catch(e){ break; }
-        if(Array.isArray(arr)) arr.forEach(o=>{
-          if(!o||typeof o.i!=='number'||!o.t) return;
-          const it=chunk[o.i]; if(!it||!it.analysis) return;
-          it.analysis.titleTranslated=String(o.t);
-          it.analysis.titleOrigLang=o.lang||'';
-          it.analysis.titleOrigLangLabel=localizeLangName(o.lang||'');
-          hit++;
-        });
-        chunk.forEach(it=>{ if(it.analysis) it.analysis._titleTried=true; });
-        done+=chunk.length;
-        aiSetBtnBusy(btn,true,t('aiTransBusy')+' '+done+'/'+todo.length);
-        if(currentMode==='news'||currentMode==='saved') rerenderNewsFeedTitles();
-      }
-    } finally { _translateBusy=false; aiSetBtnBusy(btn,false); }
-    aiToast(hit? t('aiTransDone').replace('{n}',hit) : t('aiTransNone'));
-  }
+  /* (#R169) moved verbatim to js/news-feed.js — see Architecture.md §3.1. */
   document.getElementById('live-news-feed').addEventListener('scroll',(e)=>{
     if(currentMode!=='news'&&currentMode!=='saved') return;
     const f=e.target;
     if(f.scrollTop+f.clientHeight>=f.scrollHeight-120 && renderedCount<newsFiltered.length) appendNewsBatch();
   });
 
-  /* ===== Shared helper: strip HTML to plain text (used by the news ingest) ===== */
-  function stripHTML(s){ const d=document.createElement('div'); d.innerHTML=s||''; return d.textContent||d.innerText||''; }
+  /* (#R169) moved verbatim to js/news-feed.js — see Architecture.md §3.1. */
   /* ===== In-sidebar article reader (the sidebar becomes the reading zone) ===== */
   let readerOpen=false, readerCurrent=null;
   function escForReader(s){ const d=document.createElement('div'); d.textContent=(s==null?'':String(s)); return d.innerHTML.replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }   /* (#R138 SEC) textContent escapes &<> but NOT quotes; this helper is used in attribute context (href/src) too, so quote-escape as well (prevents attribute breakout / srcdoc injection) */
-  const READER_NOISE=new Set(['edit','[edit]','skip to content','watch live','sign in','log in','menu','advertisement','home','news','sport','business','technology','more','share','save','reuters','associated press','follow us','related topics','watch','listen']);
-  function cleanReaderMarkdown(md){
-    let firstImg=''; let text=md||'';
-    const im=text.match(/!\[[^\]]*\]\((https?:\/\/[^)\s]+)\)/);
-    if(im) firstImg=im[1];
-    text=text.replace(/```[\s\S]*?```/g,' ');                 /* code fences */
-    text=text.replace(/`([^`]+)`/g,'$1');                     /* inline code */
-    text=text.replace(/!\[[^\]]*\]\([^)]*\)/g,'');            /* strip images */
-    text=text.replace(/\[([^\]]+)\]\([^)]*\)/g,'$1');         /* links -> text */
-    text=text.replace(/\\([\\_*\[\]()#~`>+.!-])/g,'$1');      /* unescape md */
-    text=text.replace(/\*\*([^*]+)\*\*/g,'$1').replace(/__([^_]+)__/g,'$1'); /* bold */
-    text=text.replace(/\*([^*]+)\*/g,'$1');                   /* italic */
-    const lines=text.split(/\n/); const blocks=[]; let buf=[];
-    const isNoise=s=>READER_NOISE.has(s.toLowerCase().replace(/^[•§]\s*/,'').trim());
-    const flush=()=>{ if(buf.length){ const p=buf.join(' ').replace(/\s+/g,' ').trim(); if(p&&p.length>1&&!isNoise(p)) blocks.push({t:'p',v:p}); buf=[]; } };
-    for(const raw of lines){
-      const line=raw.replace(/\s+$/,'');
-      if(/^\s*#{1,6}\s+/.test(line)){ flush(); const h=line.replace(/^\s*#{1,6}\s+/,'').trim(); if(h&&!isNoise(h)) blocks.push({t:'h',v:h}); continue; }
-      if(/^\s*>\s?/.test(line)){ flush(); const q=line.replace(/^\s*>\s?/,'').trim(); if(q&&!isNoise(q)) buf.push(q); continue; }
-      if(/^\s*[-*+]\s+/.test(line)){ flush(); const li=line.replace(/^\s*[-*+]\s+/,'').trim(); if(li.length>=30&&!isNoise(li)) blocks.push({t:'p',v:'• '+li}); continue; }
-      if(line.trim()===''){ flush(); continue; }
-      if(/^[=*_\-|>#`~]{1,}$/.test(line.trim())) continue;   /* skip rule/noise lines */
-      buf.push(line.trim());
-    }
-    flush();
-    return {hero:firstImg, blocks};
-  }
-  async function fetchReadable(item){
-    /* Strategy 1: r.jina.ai reader — clean article text, CORS-friendly (works from file://). */
-    try{
-      const ctrl=new AbortController(); const to=setTimeout(()=>ctrl.abort(),12000);
-      const r=await fetch('https://r.jina.ai/'+item.link,{signal:ctrl.signal});
-      clearTimeout(to);
-      if(r.ok){
-        let txt=await r.text();
-        if(txt&&txt.length>200){
-          const mc=txt.indexOf('Markdown Content:');
-          if(mc>=0) txt=txt.slice(mc+'Markdown Content:'.length);
-          const parsed=cleanReaderMarkdown(txt);
-          if(parsed.blocks.length>=2) return {blocks:parsed.blocks, hero:parsed.hero, ok:true};
-        }
-      }
-    }catch(_){}
-    /* Strategy 2: proxy raw HTML -> extract <article>/<p> text or og:description. */
-    try{
-      const html=await fetchViaProxy(item.link);
-      if(html){
-        const doc=new DOMParser().parseFromString(html,'text/html');
-        let hero=''; const ogi=doc.querySelector('meta[property="og:image"]'); if(ogi) hero=ogi.getAttribute('content')||'';
-        const scope=doc.querySelector('article')||doc.querySelector('main')||doc.body;
-        const ps=[...scope.querySelectorAll('p')].map(p=>p.textContent.trim()).filter(t=>t.length>40);
-        if(ps.length>=2) return {blocks:ps.slice(0,50).map(v=>({t:'p',v})), hero, ok:true};
-        const desc=doc.querySelector('meta[property="og:description"],meta[name="description"]');
-        if(desc) return {blocks:[{t:'p',v:desc.getAttribute('content')||''}], hero, ok:false};
-      }
-    }catch(_){}
-    return {blocks:[], hero:'', ok:false};
-  }
-  function openArticleInSidebar(item){
-    readerOpen=true; readerCurrent=item;
-    /* (#R80) vision §2 — Atlas must know the ARTICLE the user is reading right now (not just that the News tab is
-       open), so follow-ups like "この記事について詳しく"/"translate this"/"背景は？"/"where did this happen" resolve.
-       globalData is closure-scoped, so bridge the open article onto window (same pattern as window._imLayerDates). */
-    try{ const _a=(item&&item.analysis)||{}; window._imReader={ open:true, title:item&&item.title||'', publisher:item&&item.publisher||'', link:item&&item.link||'', pubDate:item&&item.pubDate||'', loc:(_a.loc&&isFinite(_a.loc[0]))?[_a.loc[0],_a.loc[1]]:null, place:_a.name||'' }; }catch(_){ }
-    /* (#R160) reveal the sidebar to show the article reader. The sidebar overlays a fixed full-width map, so this
-       can't move the map — just drop `collapsed` and let the search-pill layout recompute; no anchor, no resize. */
-    try{ const _sb=document.getElementById('sidebar'); if(_sb&&_sb.classList.contains('collapsed')){ _sb.classList.remove('collapsed'); window.dispatchEvent(new Event('intmap-sidebar-resize')); } }catch(_){}
-    try{ if(window.matchMedia('(max-width:768px)').matches && window.__setDetent) window.__setDetent('full'); }catch(_){}
-    const cp=document.querySelector('.control-panel'); if(cp) cp.style.display='none';
-    const sbBar=document.getElementById('sidebar-search-bar'); if(sbBar) sbBar.style.display='none';   /* (#R79e) by ID, not .search-bar (see renderUI note) */
-    const pt=document.getElementById('news-pin-toggle'); if(pt) pt.style.display='none';
-    ['live-news-feed','info-dashboard','community-feed'].forEach(id=>{ const e=document.getElementById(id); if(e) e.style.display='none'; });
-    const pane=document.getElementById('news-reader-pane'); pane.style.display='flex';
-    const back=currentLang==='jp'?'ニュースへ戻る':currentLang==='de'?'Zurück zu den News':currentLang==='ru'?'Назад к новостям':currentLang==='es'?'Volver a noticias':'Back to news';
-    pane.innerHTML=`<div class="nrp-bar"><button class="nrp-back" id="nrp-back-btn">‹ ${back}</button><span class="nrp-src">${escForReader(item.publisher)}</span></div>
-      <div class="nrp-loading"><div class="nrp-spinner"></div>${currentLang==='jp'?'記事を読み込み中…':currentLang==='de'?'Artikel lädt…':currentLang==='ru'?'Загрузка статьи…':currentLang==='es'?'Cargando artículo…':'Loading article…'}</div>`;
-    pane.querySelector('#nrp-back-btn').onclick=closeArticleReader;
-    pane.scrollTop=0;
-    fetchReadable(item).then(res=>{ if(readerOpen&&readerCurrent===item) renderReader(item,res);
-      /* (#R118) ARTICLE-BODY bridge: Atlas can now READ the open article's extracted text ("この記事の根拠を
-         整理して / この段落を翻訳して" work on the real body, not just the headline). Capped to ~6k chars. */
-      try{ if(window._imReader&&res&&Array.isArray(res.blocks)&&res.blocks.length){
-        window._imReader.body=res.blocks.map(b=>String((b&&(b.v!=null?b.v:(b.text!=null?b.text:b)))||'')).filter(Boolean).join('\n\n').slice(0,6000); } }catch(_){ } });
-  }
-  function renderReader(item,res){
-    const pane=document.getElementById('news-reader-pane'); if(!pane) return;
-    /* If we extracted real body text, default to the clean Reader; otherwise show the
-       in-sidebar mini-browser (iframe) so the user can always read the page. */
-    const hasText=res.blocks&&res.blocks.length>=2;
-    renderReaderMode(item,res, hasText?'reader':'web');
-  }
+  /* (#R169) moved verbatim to js/article-reader.js — see Architecture.md §3.1. */
   /* ===== AI FEATURE 2: in-reader translation to Japanese =====
      Translates the extracted reader text (res.blocks); toggles original/translated and
      caches the result on `res` so flipping back and forth is instant. */
@@ -5022,150 +3529,14 @@ window.addEventListener('DOMContentLoaded', () => {
     OS.setNow=function(opts){ _when=null; return broadcast((opts||{}).source), OS; };
     return OS;
   })();
-  function dateRangeQualifier(d){
-    /* ±3 day window for that date */
-    const start=new Date(d.getTime()-3*864e5), end=new Date(d.getTime()+3*864e5);
-    return ` after:${ymdISO(start)} before:${ymdISO(end)}`;
-  }
-  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
-  const {NEWS_EDITIONS_MULTI,NEWS_COUNTRY_EDITIONS}=window.IntMapTables;
-  function feedUrls(){
-    /* (#R37) per-language Google News locale so DE/RU get German/Russian feeds (not the JP feed via the old else). */
-    const p=({en:'hl=en-US&gl=US&ceid=US:en', jp:'hl=ja&gl=JP&ceid=JP:ja', de:'hl=de&gl=DE&ceid=DE:de', ru:'hl=ru&gl=RU&ceid=RU:ru', es:'hl=es&gl=ES&ceid=ES:es'})[currentLang]||'hl=en-US&gl=US&ceid=US:en';   /* (#R40) +Spanish news edition */
-    if(newsDate){
-      /* Google News search supports after:/before: operators. Headlines endpoints don't,
-         so a date-filtered query goes through search. */
-      const q=(activeSearchQuery||'world')+dateRangeQualifier(newsDate);
-      return [`https://news.google.com/rss/search?q=${encodeURIComponent(q)}&${p}`];
-    }
-    if(activeSearchQuery) return[`https://news.google.com/rss/search?q=${encodeURIComponent(activeSearchQuery)}&${p}`];
-    let base;
-    if(newsLangMode==='multi'){
-      /* (#R9 / #29) In multi-language mode show ONLY the languages ticked in Settings. The UI-language
-         WORLD/BUSINESS base feeds are added only when the UI language is among the selections — so
-         selecting e.g. just Russian no longer also leaks the English base feed. */
-      base=[];
-      const sel=(Array.isArray(newsLangs)&&newsLangs.length)?newsLangs:[currentLang];
-      if(sel.includes(currentLang)) base.push(`https://news.google.com/rss/headlines/section/topic/WORLD?${p}`,`https://news.google.com/rss/headlines/section/topic/BUSINESS?${p}`);
-      NEWS_EDITIONS_MULTI.filter(ed=>ed.lang!==currentLang && sel.includes(ed.lang)).forEach(ed=>base.push(`https://news.google.com/rss/headlines/section/topic/WORLD?${ed.q}`));
-      if(!base.length) base.push(`https://news.google.com/rss/headlines/section/topic/WORLD?${p}`);  /* never fetch nothing */
-    } else {
-      base=[`https://news.google.com/rss/headlines/section/topic/WORLD?${p}`,`https://news.google.com/rss/headlines/section/topic/BUSINESS?${p}`];
-    }
-    /* National media editions chosen in Settings (#29) — multiple allowed. */
-    try{ (window.imNewsCountries||[]).forEach(code=>{ const ed=NEWS_COUNTRY_EDITIONS[code]; if(ed && !base.some(u=>u.includes(ed))) base.push(`https://news.google.com/rss/headlines/section/topic/WORLD?${ed}`); }); }catch(_){}
-    /* Pro "RU·CN local primary-source intel" overlay — pulls the Russian + Chinese editions. */
-    if(window.proIntelOn && window.imIsPro && window.imIsPro()){
-      ['hl=ru&gl=RU&ceid=RU:ru','hl=zh-CN&gl=CN&ceid=CN:zh-Hans'].forEach(ed=>{ if(!base.some(u=>u.includes(ed))) base.push(`https://news.google.com/rss/headlines/section/topic/WORLD?${ed}`); });
-    }
-    return base;
-  }
-  /* News cache → instant render on load/return, refreshed in the background. */
-  function loadNewsCache(){
-    try{ const c=JSON.parse(localStorage.getItem('intmap_news_cache')||'null');
-      if(c && c.lang===currentLang && !activeSearchQuery && !newsDate && Array.isArray(c.data) && c.data.length && (Date.now()-c.ts < 6*3600e3)) return c.data; }catch(_){}
-    return null;
-  }
-  function saveNewsCache(){
-    try{ if(!activeSearchQuery && !newsDate) localStorage.setItem('intmap_news_cache', JSON.stringify({ts:Date.now(), lang:currentLang, data:globalData.slice(0,120)})); }catch(_){}
-  }
-  function buildItems(byLink){
-    let uniq=[...byLink.values()].sort((a,b)=>parseDate(b.pubDate)-parseDate(a.pubDate));
-    /* (#R107) TIME-TRAVEL: when a past instant is set, keep ONLY items actually dated near it. Google News ignores
-       after:/before: for dates outside its recent window and returns TODAY's headlines, which then wrongly showed as
-       "past" news ("時間を過去に設定しても最新ニュースが表示される"). Filtering by pubDate drops that leakage, and
-       undated items too — so the feed shows genuine period news around that date, or NOTHING (never latest-as-past). */
-    try{ if(typeof newsDate!=='undefined' && newsDate){ const t0=newsDate.getTime(), win=8*864e5;   /* ±8 days (the fetch query uses ±3; allow timezone slack) */
-      uniq=uniq.filter(it=>{ const pd=parseDate(it.pubDate); return pd && isFinite(pd) && Math.abs(pd-t0)<=win; }); } }catch(_){}
-    return uniq.slice(0,150).map(it=>{ const sp=it.title.split(' - '); const publisher=sp.length>1?sp.pop():(({en:'News',jp:'報道',de:'Nachrichten',ru:'Новости'})[currentLang]||'News'); const title=sp.join(' - '); const desc=it.desc||''; return { title, publisher, link:it.link, pubDate:it.pubDate, desc, analysis:analyzeContext(title,publisher,it.link,desc) }; });
-  }
-  /* ===== Server-baked news (FAST PATH) =====
-     The `refresh-news` Edge Function pre-fetches + pre-analyses the default feeds every
-     ~20 min into `current_news`, so the browser just runs ONE SELECT (a few ms) instead of
-     proxy-fetching 150 articles and scoring them against the whole gazetteer at startup.
-     A server row already carries subject/publisher coords, so we skip analyzeContext entirely.
-     Used only for the default feed in single-language mode; search / time-travel / multi-language
-     keep the live-RSS path below (the server only bakes the WORLD+BUSINESS UI-language editions). */
-  /* (#R124) detect whether a subject NAME is a whole COUNTRY (vs a city / region). The default news feed comes from
-     the server, which carries no subject_type, so a "USA"-classified cluster had an EMPTY ptype and relied on a
-     fragile bbox-centre heuristic (Alaska skews the US bbox north → never detected as country-level → pins stayed
-     clustered instead of spreading across the country). Deriving the type from the name makes the R123 region-aware
-     spread actually fire for real pins. */
-  let _ctryNameSet=null;
-  function _isCountrySubject(nm){ if(!nm) return false;
-    if(!_ctryNameSet){ _ctryNameSet=new Set();
-      try{ if(typeof countryStats==='object'&&countryStats){ for(const cd in countryStats){ const s=countryStats[cd]; if(!s) continue; [s.nameEn,s.nameJp].forEach(n=>{ if(n) _ctryNameSet.add(String(n).toLowerCase().trim().replace(/^the\s+/,'')); }); } } }catch(_){}
-      ['usa','u.s.','u.s.a.','us','america','united states','united states of america','uk','u.k.','britain','great britain','south korea','north korea','russia','uae','drc','dr congo','czechia','ivory coast','burma','swaziland','turkey','türkiye','holland'].forEach(a=>_ctryNameSet.add(a)); }
-    const k=String(nm).toLowerCase().trim().replace(/^the\s+/,'').replace(/\s+\(.*\)$/,'');
-    return _ctryNameSet.has(k); }
-  function serverRowToItem(r){
-    const subjectLoc=(r.subject_lng!=null&&r.subject_lat!=null)?[r.subject_lng,r.subject_lat]:null;
-    const pubLoc=(r.pub_lng!=null&&r.pub_lat!=null)?[r.pub_lng,r.pub_lat]:null;
-    const subjectName=currentLang==='jp'?(r.subject_name_jp||r.subject_name_en):(r.subject_name_en||r.subject_name_jp);
-    const pubName=r.pub_label?((currentLang==='jp'?'発信: ':currentLang==='de'?'Quelle: ':currentLang==='ru'?'Источник: ':currentLang==='es'?'Fuente: ':'Source: ')+r.pub_label):null;
-    const short=currentLang==='jp'?(r.short_jp||r.short_en||''):(r.short_en||r.short_jp||'');
-    const subjectType=r.subject_type||((_isCountrySubject(r.subject_name_en)||_isCountrySubject(subjectName))?'country':'');   /* (#R124) derive country-type from the name when the server omits it */
-    const analysis={ subjectLoc, subjectName, subjectType, pubLoc, pubName, short, _title:r.title, _pub:r.publisher||'' };
-    applyPinMode(analysis);   /* sets loc/name/mapped for the current Subject/Publisher toggle */
-    return { title:r.title, publisher:r.publisher||'', link:r.link, pubDate:r.pub_date||'', desc:r.description||'', analysis };
-  }
-  async function loadNewsFromSupabase(){
-    if(!DB || activeSearchQuery || newsDate || newsLangMode==='multi') return false;
-    try{
-      const { data, error } = await DB.from('current_news')
-        .select('title,publisher,link,pub_date,description,subject_lng,subject_lat,subject_name_en,subject_name_jp,pub_lng,pub_lat,pub_label,short_en,short_jp')
-        .eq('lang',currentLang).order('pub_date',{ascending:false}).limit(150);
-      if(error) throw error;
-      if(!data||!data.length) return false;          /* not seeded yet → fall through to live RSS */
-      globalData=data.map(serverRowToItem);
-      saveNewsCache();
-      if(currentMode==='news'||currentMode==='saved') startNews();
-      return true;
-    }catch(e){ console.warn('[IntMap] current_news unavailable, using live RSS:', e&&e.message); return false; }
-  }
+  /* (#R169) moved verbatim to js/news-feed.js — see Architecture.md §3.1. */
   /* (#R40) TEMPORARY per request ("AIで解析済みのニュースをサーバーから取得というシステムは一時的に停止し、
      フロントエンドでの非AI地点解析システムのみを使って。全言語で"): force the client-side, non-AI gazetteer
      locator for EVERY language by skipping the Supabase current_news fast-path. Flip this back to true to
      re-enable the pre-analysed server feed. The realtime current_news subscription is gated on the same flag. */
   const USE_SERVER_NEWS = false;
   window.__IM_USE_SERVER_NEWS = USE_SERVER_NEWS;
-  async function fetchData(){
-    const feed=document.getElementById('live-news-feed');
-    /* 1) Instant: show cached headlines immediately while fresh ones load. */
-    if(globalData.length===0){ const cached=loadNewsCache(); if(cached&&cached.length){ globalData=cached; if(currentMode==='news'||currentMode==='saved') startNews(); } }
-    if((currentMode==='news'||currentMode==='saved')&&feed&&globalData.length===0) feed.innerHTML=`<div class="empty-msg">${t('loading')}</div>`;
-    /* 1b) FAST PATH: pre-analyzed news from Supabase. If it returns rows we're done — no client scoring.
-       (#R40) TEMPORARILY DISABLED via USE_SERVER_NEWS — always fall through to the client non-AI locator. */
-    if(USE_SERVER_NEWS && await loadNewsFromSupabase()) return;
-    /* 2) FALLBACK: live RSS via CORS proxies + client-side analysis (function not deployed, or search/time-travel/multi-lang). */
-    const parser=new DOMParser(); const byLink=new Map(); let any=false;
-    const ingest=(txt)=>{
-      if(!txt) return;
-      const xml=parser.parseFromString(txt,'text/xml');
-      xml.querySelectorAll('item, entry').forEach(it=>{
-        const le=it.querySelector('link'); const link=(le&&(le.textContent||le.getAttribute('href')))||'';
-        if(!link||byLink.has(link))return;
-        /* RSS <description>, else Atom <summary>/<content>; HTML stripped to plain text for analysis. */
-        const descNode=it.querySelector('description')||it.querySelector('summary')||it.querySelector('content');
-        /* Google News packs each related article as <a>headline</a><font>publisher</font>.
-           Drop the <font> publisher names first — otherwise "The Washington Post" etc. leak
-           false city matches ("Washington") into the scorer. The <a> headline text is kept. */
-        const descHtml=(descNode?.textContent||'').replace(/<font\b[^>]*>[\s\S]*?<\/font>/gi,' ');
-        byLink.set(link,{
-          title:it.querySelector('title')?.textContent||'',
-          link,
-          pubDate:it.querySelector('pubDate, published, updated')?.textContent||'',
-          desc:stripHTML(descHtml)
-        });
-      });
-      if(byLink.size){ globalData=buildItems(byLink); any=true; if(currentMode==='news'||currentMode==='saved') startNews(); }
-    };
-    try{
-      await Promise.all(feedUrls().map(async u=>{ try{ ingest(await fetchViaProxy(u)); }catch(_){} }));
-      if(!any && globalData.length===0) throw new Error('no items');
-      if(any) saveNewsCache();
-    }catch(e){ if(globalData.length===0&&feed&&(currentMode==='news'||currentMode==='saved')) feed.innerHTML=`<div class="empty-msg" style="color:var(--threat-unmapped);">${t('networkError')}</div>`; console.warn('fetchData failed:',e); }
-  }
+  /* (#R169) moved verbatim to js/news-feed.js — see Architecture.md §3.1. */
 
   /* ===== Search =====
      Stats & Information filter live as you type (#27). News & Saved wait for the button /
@@ -5847,28 +4218,7 @@ window.addEventListener('DOMContentLoaded', () => {
   let commCollapsed={};              /* postId -> true when its comment thread is collapsed */
   /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
   const {COMM_CATEGORIES}=window.IntMapTables;
-  const commCatById=(id)=>COMM_CATEGORIES.find(c=>c.id===id)||COMM_CATEGORIES[0];
-  const commCatLabel=(id)=>{ const c=commCatById(id); return c.label[currentLang]||c.label.en; };
-  /* Deterministic avatar (colored initial) from a display name. */
-  function commAvatar(name){
-    const s=(name||'?').trim(); let h=0; for(let i=0;i<s.length;i++) h=(h*31+s.charCodeAt(i))|0;
-    const hue=Math.abs(h)%360, init=escapeHtml(s.slice(0,/[A-Za-z0-9]/.test(s[0]||'')?2:1).toUpperCase()||'?');
-    return `<span class="comm-avatar" style="background:hsl(${hue},58%,46%)">${init}</span>`;
-  }
-  /* Compact relative time ("5m", "3h", "2d" / 「5分前」). */
-  function relTime(ts){
-    const s=Math.max(0,(Date.now()-ts)/1000);
-    if(currentLang==='jp'){
-      if(s<60) return 'たった今'; if(s<3600) return Math.floor(s/60)+'分前'; if(s<86400) return Math.floor(s/3600)+'時間前';
-      if(s<604800) return Math.floor(s/86400)+'日前'; if(s<2629800) return Math.floor(s/604800)+'週間前';
-      return new Date(ts).toLocaleDateString('ja-JP');
-    }
-    if(s<60) return 'now'; if(s<3600) return Math.floor(s/60)+'m'; if(s<86400) return Math.floor(s/3600)+'h';
-    if(s<604800) return Math.floor(s/86400)+'d'; if(s<2629800) return Math.floor(s/604800)+'w';
-    return new Date(ts).toLocaleDateString('en-US');
-  }
-  /* "Hot" ranking — recent + upvoted + discussed floats to the top (Reddit-style decay). */
-  function hotScore(p){ const ageH=(Date.now()-p.ts)/3.6e6; return ((p.votes||0)+0.5*((p.comments||[]).length)+1)/Math.pow(ageH+2,1.3); }
+  /* (#R169) moved verbatim to js/community-board.js — see Architecture.md §3.1. */
   function compressImage(file, maxDim=1100, quality=0.72){
     return new Promise((resolve,reject)=>{
       const fr=new FileReader();
@@ -5926,52 +4276,7 @@ window.addEventListener('DOMContentLoaded', () => {
     if(!wrap||!thumb) return;
     if(src){ thumb.src=src; wrap.style.display='inline-block'; } else { thumb.removeAttribute('src'); wrap.style.display='none'; }
   }
-  function setupCommunityLayer(){
-    if(!map||!map.isStyleLoaded()) return;
-    if(!map.getSource('community-points')){
-      /* Color pins by post category (falls back to green for un-categorised). */
-      const catColor=['match',['get','cat']].concat(COMM_CATEGORIES.flatMap(c=>[c.id,c.color])).concat(['#34c759']);
-      map.addSource('community-points',{type:'geojson',data:{type:'FeatureCollection',features:[]},promoteId:'fid'});
-      map.addLayer({id:'community-pulse',type:'circle',source:'community-points',paint:{
-        'circle-radius':['interpolate',['linear'],['zoom'],0,8,4,14,10,20],
-        'circle-color':catColor,'circle-opacity':0.2,'circle-stroke-width':0
-      }});
-      map.addLayer({id:'community-dots',type:'circle',source:'community-points',paint:{
-        'circle-radius':['case',['boolean',['feature-state','hover'],false],11,8],
-        'circle-color':catColor,'circle-stroke-width':2.5,'circle-stroke-color':'#ffffff'
-      }});
-      map.addLayer({id:'community-labels',type:'symbol',source:'community-points',layout:{
-        'text-field':['get','short'],'text-size':11,'text-font':['literal',['Noto Sans Regular']],
-        'text-anchor':'left','text-offset':[1.1,0],'text-allow-overlap':false,'text-optional':true,'text-max-width':14
-      },paint:{'text-color':'#0a6b32','text-halo-color':'rgba(255,255,255,0.95)','text-halo-width':2.0,'text-opacity':0.95}});
-      let hoverComm=null;
-      map.on('mousemove','community-dots',e=>{
-        if(!e.features.length) return;
-        map.getCanvas().style.cursor='pointer';
-        const f=e.features[0];
-        if(hoverComm!==f.id){
-          if(hoverComm!=null) try{map.setFeatureState({source:'community-points',id:hoverComm},{hover:false});}catch(_){}
-          hoverComm=f.id;
-          try{map.setFeatureState({source:'community-points',id:hoverComm},{hover:true});}catch(_){}
-        }
-        const el=ensureMapTooltip(); el.style.display='block';
-        const p=f.properties;
-        el.innerHTML=`<div style="color:#34c759;font-weight:600;font-size:13px;">💬 ${IntMapSafe.html(p.title)}</div><div style="line-height:1.4;margin-top:4px;color:var(--text-muted);font-size:11px;">${IntMapSafe.html(p.body||'')}</div>`;   /* (#R138 SEC) community post title/body are user-generated → escape (stored XSS on pin hover) */
-        positionTooltip(e.point);
-      });
-      map.on('mouseleave','community-dots',()=>{
-        if(hoverComm!=null){ try{map.setFeatureState({source:'community-points',id:hoverComm},{hover:false});}catch(_){} hoverComm=null; }
-        map.getCanvas().style.cursor=''; if(mapTooltipEl) mapTooltipEl.style.display='none';
-      });
-      map.on('click','community-dots',e=>{
-        if(!e.features.length) return;
-        const id=e.features[0].properties.fid;
-        if(currentMode!=='community'){ setMode('community','btn-community'); }
-        setTimeout(()=>{ const card=document.getElementById('comm-post-'+id); if(card) card.scrollIntoView({behavior:'smooth',block:'center'}); },200);
-      });
-    }
-    pushCommunityFeatures();
-  }
+  /* (#R169) moved verbatim to js/community-board.js — see Architecture.md §3.1. */
   function pushCommunityFeatures(){
     if(!map||!map.getSource('community-points')) return;
     /* Community pins are shown ONLY while the Community tab is active; selecting another
@@ -5982,91 +4287,7 @@ window.addEventListener('DOMContentLoaded', () => {
     })) : [];
     map.getSource('community-points').setData({type:'FeatureCollection',features:feats});
   }
-  /* Posts after the active search / category / in-view filters (drives both feed + pins). */
-  function visibleCommunityPosts(){
-    let list=communityPosts.slice();
-    if(commCatFilter!=='all') list=list.filter(p=>(p.category||'general')===commCatFilter);
-    if(commSearch){ const q=commSearch.toLowerCase(); list=list.filter(p=>((p.title||'')+' '+(p.body||'')+' '+(p.author||'')).toLowerCase().includes(q)); }
-    if(commInView && map){ try{ const b=map.getBounds(); list=list.filter(p=>b.contains([p.lng,p.lat])); }catch(_){} }
-    return list;
-  }
-  /* Escape + auto-link URLs (body/comment text). */
-  function linkify(s){ return escapeHtml(s||'').replace(/(https?:\/\/[^\s<]+)/g,'<a href="$1" target="_blank" rel="noopener" class="comm-link">$1</a>'); }
-
-  /* Fills only #comm-list (so the search box above never loses focus while typing). */
-  function renderCommList(){
-    const list=document.getElementById('comm-list'); if(!list) return;
-    const posts=visibleCommunityPosts();
-    posts.sort((a,b)=> communitySort==='top' ? (((b.votes||0)-(a.votes||0))||(b.ts-a.ts))
-                     : communitySort==='hot' ? (hotScore(b)-hotScore(a))
-                     : (b.ts-a.ts));
-    if(communityPosts.length===0) list.innerHTML=`<div class="empty-msg">${t('commEmpty')}</div>`;
-    else if(posts.length===0)     list.innerHTML=`<div class="empty-msg">${t('commNoMatch')}</div>`;
-    else                          list.innerHTML=posts.map(postCardHTML).join('');
-    wireCommList(list);
-    try{ pushCommunityFeatures(); }catch(_){}
-  }
-  function postCardHTML(post){
-    const jp=currentLang==='jp', mine=currentUser&&post.userId===currentUser.id;
-    const canDel = currentUser && (mine || currentUser.isAdmin);
-    const cat=commCatById(post.category||'general');
-    const imgHtml=post.img?`<img class="comm-post-img" src="${IntMapSafe.html(IntMapSafe.url(post.img,{allowData:true}))}" data-id="${post.id}" alt="">`:'';   /* (#R138 SEC) post.img is user-controlled (direct Supabase insert) → scheme-validate + quote-escape (stored XSS, auto-fires on feed render) */
-    const edited=post.editedTs?` · <span class="comm-edited">${t('commEdited')}</span>`:'';
-    const cmts=post.comments||[];
-    return `<div class="comm-post" id="comm-post-${post.id}">
-      <div class="comm-post-top">
-        <span class="comm-author-link" data-uid="${post.userId||''}" data-author="${escapeHtml(post.author||'')}" style="display:flex;align-items:center;gap:10px;cursor:pointer;min-width:0;flex:1;">
-        ${commAvatar(post.author)}
-        <div class="comm-post-idn">
-          <div class="comm-post-author">${escapeHtml(post.author||(jp?'匿名':'Anonymous'))}</div>
-          <div class="comm-post-sub">${relTime(post.ts)}${edited} · <span class="comm-post-loc" data-lat="${post.lat}" data-lng="${post.lng}">📍 ${post.lat.toFixed(1)}°, ${post.lng.toFixed(1)}°</span></div>
-        </div></span>
-        <span class="comm-cat-tag" style="--cc:${cat.color}">${cat.emoji} ${commCatLabel(post.category||'general')}</span>
-      </div>
-      ${post.title?`<div class="comm-post-title">${escapeHtml(post.title)}</div>`:''}
-      ${imgHtml}
-      ${post.body?`<div class="comm-post-body">${linkify(post.body)}</div>`:''}
-      <div class="comm-post-actions">
-        <button class="vote-btn ${post.voted?'voted':''}" data-id="${post.id}" title="${jp?'役に立った':'Upvote'}">▲ ${post.votes||0}</button>
-        <button class="cmt-toggle" data-id="${post.id}">💬 ${cmts.length}</button>
-        <button class="locate-btn" data-id="${post.id}">🌐 ${t('commLocate')}</button>
-        ${mine?`<button class="edit-btn" data-id="${post.id}">${t('commEdit')}</button>`:''}
-        <button class="report-btn" data-id="${post.id}" title="${jp?'通報':'Report'}">⚑</button>
-        ${canDel?`<button class="del-btn" data-id="${post.id}">${t('commDelete')}</button>`:''}
-      </div>
-      <div class="comm-comments ${commCollapsed[post.id]?'collapsed':''}" data-cwrap="${post.id}">
-        ${threadHTML(post)}
-        ${currentUser?`<div class="comm-comment-add">
-          <input type="text" placeholder="${t('commWrite')}" data-pid="${post.id}" maxlength="280">
-          <button data-pid="${post.id}">${t('commPost')}</button></div>`:''}
-      </div>
-    </div>`;
-  }
-  function threadHTML(post){
-    const cmts=post.comments||[]; if(!cmts.length) return '';
-    const byId={}; cmts.forEach(c=>byId[c.id]=c);
-    const rootOf=(c)=>{ let cur=c,hop=0; while(cur.parentId&&byId[cur.parentId]&&hop<8){ cur=byId[cur.parentId]; hop++; } return cur; };
-    const roots=cmts.filter(c=>!c.parentId||!byId[c.parentId]).sort((a,b)=>a.ts-b.ts);
-    return roots.map(r=>{
-      const kids=cmts.filter(c=>c.parentId&&c.id!==r.id&&rootOf(c).id===r.id).sort((a,b)=>a.ts-b.ts);
-      return commentHTML(r,false)+kids.map(k=>commentHTML(k,true)).join('');
-    }).join('');
-  }
-  function commentHTML(c,isReply){
-    const mine=currentUser&&c.userId===currentUser.id, canDel=currentUser&&(mine||currentUser.isAdmin);
-    const edited=c.editedTs?` · ${t('commEdited')}`:'';
-    const cv=commCaps&&commCaps.commentVotes, th=commCaps&&commCaps.threads;
-    return `<div class="comm-comment ${isReply?'reply':''}" id="comm-c-${c.id}">
-      <div class="comm-comment-meta">${commAvatar(c.author)} <b>${escapeHtml(c.author||'')}</b> · ${relTime(c.ts)}${edited}</div>
-      <div class="comm-comment-body">${linkify(c.text)}</div>
-      <div class="comm-comment-actions">
-        ${cv?`<button class="cvote-btn ${c.voted?'voted':''}" data-cid="${c.id}">▲ ${c.votes||0}</button>`:''}
-        ${th&&currentUser?`<button class="creply-btn" data-cid="${c.id}" data-pid="${c.postId}">${t('commReply')}</button>`:''}
-        ${mine?`<button class="cedit-btn" data-cid="${c.id}">${t('commEdit')}</button>`:''}
-        ${canDel?`<button class="cdel-btn" data-cid="${c.id}">${t('commDelete')}</button>`:''}
-      </div>
-    </div>`;
-  }
+  /* (#R169) moved verbatim to js/community-board.js — see Architecture.md §3.1. */
   function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
   /* When add-mode is armed, map-click drops a community post pin and opens the compose modal */
   if(map){
@@ -6079,40 +4300,7 @@ window.addEventListener('DOMContentLoaded', () => {
       openComposeModal();
     });
   }
-  function renderComposeCats(){
-    const wrap=document.getElementById('compose-cats'); if(!wrap) return;
-    wrap.innerHTML=COMM_CATEGORIES.map(c=>`<button type="button" class="comm-cat-chip ${composeCat===c.id?'active':''}" data-cc="${c.id}" style="--cc:${c.color}">${c.emoji} ${commCatLabel(c.id)}</button>`).join('');
-    wrap.querySelectorAll('[data-cc]').forEach(b=>b.onclick=()=>{ composeCat=b.dataset.cc; renderComposeCats(); });
-  }
-  function openComposeModal(editPost){
-    const m=document.getElementById('compose-modal'), jp=currentLang==='jp';
-    composeEditId = editPost ? editPost.id : null;
-    composeCat = editPost ? (editPost.category||'general') : 'general';
-    if(editPost) pendingPostLoc=[editPost.lng,editPost.lat];
-    document.getElementById('compose-title').textContent = editPost ? t('commEditPost') : t('commPostNew');
-    document.getElementById('compose-post-title').value = editPost ? (editPost.title||'') : '';
-    document.getElementById('compose-post-body').value = editPost ? (editPost.body||'') : '';
-    document.getElementById('compose-post-title').placeholder=t('commTitle');
-    document.getElementById('compose-post-body').placeholder=t('commBody');
-    document.getElementById('compose-cancel').textContent=t('commCancel');
-    document.getElementById('compose-submit').textContent = editPost ? t('commSaveEdit') : t('commPost');
-    pendingImg = editPost ? (editPost.img||'') : ''; showComposeImgPreview(pendingImg);
-    document.getElementById('compose-img-label').textContent=jp?'画像を追加':'Add image';
-    document.getElementById('compose-place-label').textContent=jp?'地図でピンを移動':'Move pin on map';
-    /* Category picker — shown unless schema-detection proved the column is missing. */
-    const showCat = !commCaps || commCaps.category;
-    const catLabel=document.getElementById('compose-cat-label'), catWrap=document.getElementById('compose-cats');
-    if(catLabel){ catLabel.textContent=t('commCat'); catLabel.style.display=showCat?'block':'none'; }
-    if(catWrap){ catWrap.style.display=showCat?'flex':'none'; if(showCat) renderComposeCats(); }
-    if(pendingPostLoc){
-      document.getElementById('compose-coord-hint').textContent=
-        `${t('commPlacedAt')}: ${pendingPostLoc[1].toFixed(3)}°, ${pendingPostLoc[0].toFixed(3)}°`;
-    } else {
-      document.getElementById('compose-coord-hint').textContent=
-        jp?'地図をクリックして位置を指定してください。':'Click on the map to place a location.';
-    }
-    m.classList.add('active');
-  }
+  /* (#R169) moved verbatim to js/community-board.js — see Architecture.md §3.1. */
   document.getElementById('compose-cancel').onclick=()=>{
     document.getElementById('compose-modal').classList.remove('active'); pendingPostLoc=null; composeEditId=null;
     if(currentMode==='community') renderCommunity();
@@ -6232,92 +4420,14 @@ window.addEventListener('DOMContentLoaded', () => {
     /* Sidebar EN/JP toggle shows only when logged OUT; logged-in users switch language in Settings. */
     const lt=document.querySelector('.lang-toggle'); if(lt) lt.style.display = currentUser ? 'none' : 'flex';
   }
-  /* Public profile card (#28) — tap a community author to see their name, avatar & bio. */
-  async function imViewProfile(uid,author){
-    let m=document.getElementById('profile-modal');
-    if(!m){ m=document.createElement('div'); m.id='profile-modal'; m.style.cssText='position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;z-index:5200;padding:20px;'; m.onclick=e=>{ if(e.target===m) m.style.display='none'; }; document.body.appendChild(m); }
-    let bio='', avatar='', name=author||'';
-    if(uid && DB){ try{
-      /* (#R134) Read the PUBLIC-safe projection (profiles_public = id/display_name/bio/avatar_url only) so a
-         viewer never receives another user's email/is_admin/plan. Falls back to profiles for a database that
-         has not applied the profiles_public view yet (forward+backward compatible with the DB migration). */
-      let r=await DB.from('profiles_public').select('display_name,bio,avatar_url').eq('id',uid).maybeSingle();
-      if(r.error) r=await DB.from('profiles').select('display_name,bio,avatar_url').eq('id',uid).maybeSingle();
-      const data=r.data; if(data){ name=data.display_name||name; bio=data.bio||''; avatar=data.avatar_url||''; }
-    }catch(_){} }
-    let h=0; for(let i=0;i<name.length;i++) h=(h*31+name.charCodeAt(i))|0;
-    const ava = avatar?`<div style="width:66px;height:66px;border-radius:50%;background:url('${IntMapSafe.html(IntMapSafe.url(avatar,{allowData:true}))}') center/cover;margin:0 auto 10px;"></div>`:`<div style="width:66px;height:66px;border-radius:50%;margin:0 auto 10px;display:flex;align-items:center;justify-content:center;font-size:27px;font-weight:700;color:#fff;background:hsl(${Math.abs(h)%360},58%,46%)">${escapeHtml((name[0]||'?').toUpperCase())}</div>`;   /* (#R138 SEC) another user's avatar_url is attacker-controllable → scheme-validate + quote-escape (stored XSS via CSS background breakout) */
-    m.innerHTML=`<div style="background:var(--card-bg);color:var(--text-main);border-radius:16px;box-shadow:var(--shadow);padding:24px;width:100%;max-width:320px;text-align:center;">${ava}<h2 style="margin:0 0 6px;font-size:18px;">${escapeHtml(name||'?')}</h2><p style="color:var(--text-muted);font-size:13px;line-height:1.55;white-space:pre-wrap;margin:0 0 16px;">${bio?escapeHtml(bio):(currentLang==='jp'?'自己紹介はまだありません。':currentLang==='de'?'Noch keine Bio.':currentLang==='ru'?'Пока без описания.':currentLang==='es'?'Aún sin biografía.':'No bio yet.')}</p><button id="pm-close" style="width:100%;background:var(--input-bg);color:var(--text-main);border:none;padding:10px;border-radius:9px;font-weight:600;cursor:pointer;">${currentLang==='jp'?'閉じる':currentLang==='de'?'Schließen':currentLang==='ru'?'Закрыть':currentLang==='es'?'Cerrar':'Close'}</button></div>`;
-    m.querySelector('#pm-close').onclick=()=>{ m.style.display='none'; };
-    m.style.display='flex';
-  }
+  /* (#R169) moved verbatim to js/community-board.js — see Architecture.md §3.1. */
   window.imViewProfile=imViewProfile;
   document.addEventListener('click',e=>{ const a=e.target.closest&&e.target.closest('.comm-author-link'); if(a && !(e.target.closest&&e.target.closest('.comm-post-loc'))){ e.preventDefault(); imViewProfile(a.getAttribute('data-uid'),a.getAttribute('data-author')); } });
 
 
   /* ---------- COMMUNITY (cloud) ---------- */
   function requireLogin(){ if(!currentUser){ openAuthModal(); return false; } return true; }
-  /* Detect which v2 columns/tables exist so the UI degrades gracefully on an un-migrated DB.
-     (Same tolerant pattern as refreshCurrentUser's is_pro probe.) Runs once, then cached. */
-  async function detectCommCaps(){
-    if(commCaps) return commCaps;
-    const caps={ category:false, threads:false, commentVotes:false, edited:false };
-    if(DB){
-      const ok=async(tbl,cols)=>{ try{ const {error}=await DB.from(tbl).select(cols).limit(1); return !error; }catch(_){ return false; } };
-      const postsRich=await ok('community_posts','id,category,edited_at');
-      caps.category = postsRich || await ok('community_posts','id,category');
-      const cmtsRich = await ok('community_comments','id,parent_id,edited_at');
-      caps.threads = cmtsRich || await ok('community_comments','id,parent_id');
-      caps.commentVotes = await ok('community_comment_votes','comment_id');
-      caps.edited = postsRich && cmtsRich;
-    }
-    commCaps=caps; return caps;
-  }
-  function commSelectStr(){
-    const c=commCaps||{};
-    const pExtra=(c.category?',category':'')+(c.edited?',edited_at':'');
-    const cExtra=(c.threads?',parent_id':'')+(c.edited?',edited_at':'')+(c.commentVotes?',community_comment_votes(user_id)':'');
-    return `id,user_id,author_name,title,body,img,lat,lng,created_at${pExtra},community_comments(id,user_id,author_name,body,created_at${cExtra}),community_votes(user_id)`;
-  }
-  const LEGACY_COMM_SELECT='id,user_id,author_name,title,body,img,lat,lng,created_at,community_comments(id,user_id,author_name,body,created_at),community_votes(user_id)';
-  async function loadCommunity(){
-    if(!DB){ communityPosts=[]; renderCommunity(); return; }
-    await detectCommCaps();
-    const uid=currentUser?currentUser.id:null;
-    let res=await DB.from('community_posts').select(commSelectStr()).order('created_at',{ascending:false});
-    if(res.error){ /* rich select failed (partial migration) → fall back to the legacy shape */
-      commCaps={category:false,threads:false,commentVotes:false,edited:false};
-      res=await DB.from('community_posts').select(LEGACY_COMM_SELECT).order('created_at',{ascending:false});
-    }
-    if(res.error){ console.warn('[IntMap] community load:', res.error.message); communityPosts=[]; renderCommunity(); return; }
-    communityPosts=(res.data||[]).map(p=>({
-      id:p.id, userId:p.user_id, title:p.title||'', body:p.body||'', img:p.img||'', lat:p.lat, lng:p.lng,
-      ts:Date.parse(p.created_at)||Date.now(), editedTs:p.edited_at?Date.parse(p.edited_at):0,
-      author:p.author_name||'', category:p.category||'general',
-      votes:(p.community_votes||[]).length,
-      voted: uid?(p.community_votes||[]).some(v=>v.user_id===uid):false,
-      comments:(p.community_comments||[]).slice().sort((a,b)=>(Date.parse(a.created_at)||0)-(Date.parse(b.created_at)||0))
-                .map(c=>({ id:c.id, postId:p.id, userId:c.user_id, text:c.body, author:c.author_name||'',
-                          ts:Date.parse(c.created_at)||Date.now(), editedTs:c.edited_at?Date.parse(c.edited_at):0,
-                          parentId:c.parent_id||null,
-                          votes:(c.community_comment_votes||[]).length,
-                          voted: uid?(c.community_comment_votes||[]).some(v=>v.user_id===uid):false }))
-    }));
-    pushCommunityFeatures(); renderCommunity();
-  }
-  async function cmAddPost(title,body,img,lat,lng,category){
-    const row={ user_id:currentUser.id, author_name:currentUser.name, title:title||null, body:body||null, img:img||null, lat, lng };
-    if(commCaps&&commCaps.category&&category) row.category=category;
-    let {error}=await DB.from('community_posts').insert(row);
-    if(error && row.category!==undefined){ delete row.category; ({error}=await DB.from('community_posts').insert(row)); } /* retry w/o category if column missing */
-    if(error) throw error;
-  }
-  async function cmEditPost(id,f){
-    const patch={ title:f.title||null, body:f.body||null, img:f.img||null, lat:f.lat, lng:f.lng };
-    if(commCaps&&commCaps.category) patch.category=f.category||'general';
-    if(commCaps&&commCaps.edited) patch.edited_at=new Date().toISOString();
-    const {error}=await DB.from('community_posts').update(patch).eq('id',id); if(error) throw error;
-  }
+  /* (#R169) moved verbatim to js/community-board.js — see Architecture.md §3.1. */
 
 
   /* (#R27) Count a genuine, user-initiated login (email submit success OR an OAuth return — NOT a
@@ -7029,11 +5139,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }catch(_){}
   };
 
-  /* ===== (#R9b/#46) Elevation cross-section under a measured line (area uses its perimeter). Below 0 m
-     gets a faint blue band so sub-sea segments are obvious. Samples the cached terrarium DEM. ===== */
-  /* (#R11) Map cursor that mirrors the hovered point on the elevation chart. */
-  function _elevCursor(coord){ try{ if(!map.getSource('elev-cursor')){ map.addSource('elev-cursor',{type:'geojson',data:{type:'FeatureCollection',features:[]}}); map.addLayer({id:'elev-cursor-pt',type:'circle',source:'elev-cursor',paint:{'circle-radius':7,'circle-color':'#ff3b30','circle-opacity':0.55,'circle-stroke-color':'#fff','circle-stroke-width':2}}); }
-    map.getSource('elev-cursor').setData({type:'FeatureCollection',features:coord?[{type:'Feature',geometry:{type:'Point',coordinates:coord},properties:{}}]:[]}); }catch(_){} }
+  /* (#R169) moved verbatim to js/elevation-profile.js — see Architecture.md §3.1. */
   /* (#R154) reusable core — profile ANY [lng,lat][] path (≥2 pts). Extracted from _elevationProfile so the freehand
      Draw tool can reach it too ("DrawでもElevation profileを使えるように"). Same densify → sample → DEM → chart pipeline. */
   window._profileFromCoords=function(pts){
@@ -7053,60 +5159,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const pts = (toolMode==='area')?[...measurePoints,measurePoints[0]]:measurePoints;
     window._profileFromCoords(pts);
   };
-  function _openProfilePanel(samples,dist){
-    let p=document.getElementById('elev-profile-panel');
-    if(!p){ p=document.createElement('div'); p.id='elev-profile-panel'; p.className='tool-panel'; (document.getElementById('map-container')||document.body).appendChild(p); }
-    p.style.cssText='display:block;left:50%;top:auto;bottom:26px;right:auto;transform:translateX(-50%);width:min(560px,calc(100vw - 40px));z-index:1600;';
-    const j=currentLang==='jp';
-    p.innerHTML='<div class="tp-header"><span class="tp-title">📈 '+(j?'標高断面':'Elevation profile')+'</span><button class="tp-close" title="'+t('close')+'">✕</button></div><div id="elev-profile-body" style="font-size:12px;color:var(--text-muted);padding:8px 2px;">'+(j?'標高を取得中…':'Sampling elevation…')+'</div>';
-    p.querySelector('.tp-close').onclick=()=>{ p.style.display='none'; _elevCursor(null); };
-    try{ makeDraggable(p,p.querySelector('.tp-header')); }catch(_){}
-    /* (#R12) Sample the LOCAL terrarium DEM (includes ocean bathymetry → negative below sea level) so
-       the profile is drawn under water too, instead of Open-Meteo elevation which returns 0 over sea. */
-    const _z=_demZoomForSpan(dist[dist.length-1]||50);
-    demSampleAll(samples,_z).then(els=>{ _drawProfile(p.querySelector('#elev-profile-body'), samples, dist, els); });
-  }
-  function _drawProfile(box, samples, dist, els){
-    if(!box) return; const j=currentLang==='jp';
-    const known=els.filter(e=>e!=null && !isNaN(e));
-    if(!known.length){ box.textContent=j?'標高データを取得できませんでした':'No elevation data available'; return; }
-    let minE=Math.min(...known,0), maxE=Math.max(...known,0); if(maxE===minE) maxE=minE+1;
-    const cont=document.getElementById('map-container')||document.body;
-    const W=Math.min(520, Math.max(280, cont.clientWidth-60)), H=176, padL=46,padR=10,padT=12,padB=26;
-    const total=dist[dist.length-1]||1;
-    const X=i=>padL+(dist[i]/total)*(W-padL-padR);
-    const Y=e=>padT+(1-(e-minE)/(maxE-minE))*(H-padT-padB);
-    let dPath=''; for(let i=0;i<els.length;i++){ const e=els[i]; if(e==null||isNaN(e)) continue; dPath+=(dPath?'L':'M')+X(i).toFixed(1)+' '+Y(e).toFixed(1)+' '; }
-    const y0=Y(0);
-    const area=dPath?('M'+X(0).toFixed(1)+' '+y0.toFixed(1)+' '+dPath.replace(/^M/,'L')+'L'+X(els.length-1).toFixed(1)+' '+y0.toFixed(1)+' Z'):'';
-    /* (#R12) Blue water band drawn OVER the green fill so sub-sea terrain reads as underwater. */
-    const seaBand=(minE<0)?'<rect x="'+padL+'" y="'+y0.toFixed(1)+'" width="'+(W-padL-padR)+'" height="'+Math.max(0,(H-padB-y0)).toFixed(1)+'" fill="rgba(38,118,200,0.30)"/>':'';
-    /* (#R13c) unit-aware compact labels for the elevation profile (imperial → ft / mi). */
-    const _um=(typeof unitMode!=='undefined')?unitMode:'both';
-    const elevC=(m)=>_um==='imperial'?(Math.round(m*3.28084).toLocaleString()+' ft'):(Math.round(m).toLocaleString()+' m');
-    const distC=(km)=>_um==='imperial'?((km*0.621371).toFixed(km*0.621371<10?1:0)+' mi'):(km.toFixed(km<10?1:0)+' km');
-    const svg='<svg id="elev-svg" width="'+W+'" height="'+H+'" viewBox="0 0 '+W+' '+H+'" style="display:block;max-width:100%;cursor:crosshair;">'
-      +(area?'<path d="'+area+'" fill="rgba(120,170,90,0.28)"/>':'')
-      +seaBand
-      +'<line x1="'+padL+'" y1="'+y0.toFixed(1)+'" x2="'+(W-padR)+'" y2="'+y0.toFixed(1)+'" stroke="rgba(40,120,200,0.85)" stroke-dasharray="3 3"/>'
-      +(dPath?'<path d="'+dPath+'" fill="none" stroke="#5aa02c" stroke-width="1.6"/>':'')
-      +'<line id="elev-vline" x1="0" y1="'+padT+'" x2="0" y2="'+(H-padB)+'" stroke="#ff3b30" stroke-width="1" style="display:none;"/>'
-      +'<circle id="elev-vdot" r="3.5" fill="#ff3b30" stroke="#fff" stroke-width="1.5" style="display:none;"/>'
-      +'<text x="3" y="'+(Y(maxE)+3).toFixed(1)+'" font-size="9" fill="currentColor">'+elevC(maxE)+'</text>'
-      +'<text x="3" y="'+(Y(minE)).toFixed(1)+'" font-size="9" fill="currentColor">'+elevC(minE)+'</text>'
-      +(minE<0?'<text x="3" y="'+(y0-2).toFixed(1)+'" font-size="9" fill="rgba(60,140,210,1)">0</text>':'')
-      +'</svg>';
-    box.innerHTML=svg+'<div id="elev-readout" style="display:flex;justify-content:space-between;color:var(--text-muted);font-size:10.5px;margin-top:2px;"><span>'+distC(0)+'</span><span id="elev-hover" style="color:var(--text-main);font-weight:600;"></span><span>'+distC(total)+'</span></div>';
-    /* Hover: vertical cursor on the chart + a synced marker on the map (#R11). */
-    const svgEl=box.querySelector('#elev-svg'), vline=box.querySelector('#elev-vline'), vdot=box.querySelector('#elev-vdot'), hov=box.querySelector('#elev-hover');
-    if(svgEl){ const move=(ev)=>{ const r=svgEl.getBoundingClientRect(); const cx=ev.touches?ev.touches[0].clientX:ev.clientX; let xv=(cx-r.left)/r.width*W; xv=Math.max(padL,Math.min(W-padR,xv)); const frac=(xv-padL)/(W-padL-padR); let idx=Math.round(frac*(samples.length-1)); idx=Math.max(0,Math.min(samples.length-1,idx)); const e=els[idx];
-        vline.setAttribute('x1',X(idx)); vline.setAttribute('x2',X(idx)); vline.style.display='block';
-        if(e!=null&&!isNaN(e)){ vdot.setAttribute('cx',X(idx)); vdot.setAttribute('cy',Y(e)); vdot.style.display='block'; if(hov) hov.textContent=distC(dist[idx])+' · '+elevC(e)+(e<0?' '+(j?'(海中)':'(below sea)'):''); }
-        _elevCursor(samples[idx]); };
-      svgEl.addEventListener('mousemove',move); svgEl.addEventListener('touchmove',move,{passive:true});
-      svgEl.addEventListener('mouseleave',()=>{ vline.style.display='none'; vdot.style.display='none'; if(hov) hov.textContent=''; _elevCursor(null); });
-    }
-  }
+  /* (#R169) moved verbatim to js/elevation-profile.js — see Architecture.md §3.1. */
 
   /* ===== (#R9b/#53) Country isolation — show only the selected country; mask the rest with the globe-style
      background. A floating "Exit isolation" pill restores the full map. ===== */

--- a/js/ai-core.js
+++ b/js/ai-core.js
@@ -1,0 +1,252 @@
+/* ============================================================================
+ *  IntMap · Atlas AI transport, quota and settings  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.aiCore=function(map,HOST){
+  const saveAIConfig=()=>{ try{ localStorage.setItem('intmap_ai_config',JSON.stringify(HOST.aiConfig)); }catch(_){} };
+  /* (#R27) Account-based AI: the first-party server proxy is ALWAYS configured (see INTMAP_AI_PROXY
+     below), so the engine is always "ready" to RECEIVE a click. The real gate — login required + the
+     per-day free quota — is enforced in aiGate() at click time and authoritatively re-checked on the
+     server. Buttons therefore never appear greyed-out as "needs key" (BYOK is retired). */
+  function aiReady(){ return (typeof aiProxyOn==='function') ? aiProxyOn() : true; }
+  function aiVisionReady(){ return aiReady(); }
+  function aiErrSnippet(txt){ try{ const j=JSON.parse(txt); return (j.error&&(j.error.message||j.error.code))||JSON.stringify(j).slice(0,180); }catch(_){ return String(txt||'').slice(0,180); } }
+  function aiProxyOn(){ try{ return !!(window.INTMAP_AI_PROXY && window.INTMAP_AI_PROXY.url); }catch(_){ return false; } }
+  const aiJP=()=>(typeof HOST.lang!=='undefined'&&HOST.lang==='jp');
+  function aiToday(){ try{ return new Date().toISOString().slice(0,10); }catch(_){ return ''; } }
+  /* (#R31) Developer = unlimited AI. Enabled by localStorage intmap_dev='1' or the owner's account email.
+     This lifts the CLIENT-side gate; for a truly unlimited server quota, the ai-proxy function also grants
+     the dev user id/email an unlimited plan (DEV_USER_IDS / DEV_EMAILS secret) — see DEV-NOTES. */
+  function aiDev(){ try{ if(localStorage.getItem('intmap_dev')==='1') return true;
+    /* (#R36) ROOT CAUSE of "開発者なのに無制限が設定欄のグラフに反映されない（まだ変わっていない）": the dev flag was
+       only set by logging in with the owner email, but the developer runs this build LOCALLY (file:// or
+       localhost) without logging in → aiDev() stayed false → the graph showed the 5/day quota. Treat the local
+       dev environment itself as the developer context. The PUBLIC site is served from its real domain, so
+       end-users on the deployed site are unaffected (their quota is unchanged). */
+    const proto=location.protocol, h=location.hostname;
+    if(proto==='file:'||h==='localhost'||h==='127.0.0.1'||h==='[::1]'||h===''){ try{ localStorage.setItem('intmap_dev','1'); }catch(_){} return true; }
+    const e=(typeof HOST.user!=='undefined'&&HOST.user&&HOST.user.email)||''; return /2ppzc4kk6r@privaterelay\.appleid\.com/i.test(e); }catch(_){ return false; } }
+  function aiDailyLimit(){ return (HOST.aiUsage && HOST.aiUsage.limit) || HOST.AI_FREE_DAILY; }
+  function aiUsesLeft(){ if(aiDev()) return Infinity; if(HOST.aiUsage.date!==aiToday()) return aiDailyLimit(); return Math.max(0, aiDailyLimit() - (HOST.aiUsage.used||0)); }
+  function aiSetUsage(used, limit){
+    HOST.aiUsage.date=aiToday();
+    if(typeof used==='number') HOST.aiUsage.used=used;
+    if(typeof limit==='number' && limit>0) HOST.aiUsage.limit=limit;
+    try{ aiRenderSettings(); }catch(_){}
+  }
+  function aiLoginMsg(){ return aiJP()?'AI機能を使うにはログインが必要です。':'Please log in to use AI features.'; }
+  function aiLimitMsg(){ return aiJP()?'本日の無料AI使用回数に達しました。':'You have reached today’s free AI limit.'; }
+  /* Fetch today's usage for the logged-in user (RLS lets a user read only their own row). Lets the
+     gate block + the Settings panel show "残り N/5" BEFORE any AI request is spent. */
+  async function aiFetchUsage(){
+    try{
+      if(!HOST.user || !window.sb){ return; }
+      const { data } = await window.sb.from('ai_usage').select('count').eq('user_id',HOST.user.id).eq('usage_date',aiToday()).maybeSingle();
+      aiSetUsage(data && typeof data.count==='number' ? data.count : 0, aiDailyLimit());
+    }catch(_){}
+  }
+  /* The single click-time gate every AI feature runs FIRST. Extensible: future paid plans only need to
+     raise the limit the server returns (aiUsage.limit) — no per-feature change. */
+  function aiGate(){
+    if(typeof HOST.user==='undefined' || !HOST.user){ try{ HOST.openAuthModal(aiLoginMsg()); }catch(_){ try{ aiToast(aiLoginMsg()); }catch(__){} } return false; }
+    if(HOST.aiUsage.date===aiToday() && aiUsesLeft()<=0){ try{ aiToast(aiLimitMsg()); }catch(_){} return false; }
+    return true;
+  }
+  /* (#R113) Map a typed PROVIDER error (ai-proxy 502/503) to a clear, localized message. These are DISTINCT from
+     the IntMap daily free-use limit (HTTP 429) — a Google-side 429 must never be shown as "out of free uses". */
+  function aiProviderErrMsg(code, message){
+    const _pl=(en,jp,de,ru,es)=>HOST.lang==='jp'?jp:HOST.lang==='de'?de:HOST.lang==='ru'?ru:HOST.lang==='es'?(es||en):en;
+    const M={
+      provider_rate_limit:_pl('The AI service is busy right now — please try again in a moment (this is not your IntMap usage limit).','AIサービスが混雑しています。少し待って再試行してください（IntMapの利用回数上限ではありません）。','Der KI-Dienst ist gerade ausgelastet — bitte gleich erneut versuchen (nicht Ihr IntMap-Limit).','Сервис ИИ сейчас перегружен — повторите через мгновение (это не ваш лимит IntMap).','El servicio de IA está ocupado — inténtalo de nuevo en un momento (no es tu límite de IntMap).'),
+      provider_quota:_pl('The AI provider quota was reached — this is separate from your IntMap free uses. Please try again later.','AIプロバイダ側の利用上限に達しました（あなたのIntMap無料利用枠とは別です）。後ほど再試行してください。','Das Kontingent des KI-Anbieters ist erschöpft — getrennt von Ihren IntMap-Freinutzungen. Später erneut versuchen.','Достигнут лимит провайдера ИИ — это отдельно от бесплатных использований IntMap. Повторите позже.','Se alcanzó la cuota del proveedor de IA — es independiente de tus usos gratuitos de IntMap. Inténtalo más tarde.'),
+      provider_empty:_pl('The AI returned an empty response — please try again.','AIが空の応答を返しました。もう一度お試しください。','Die KI lieferte eine leere Antwort — bitte erneut versuchen.','ИИ вернул пустой ответ — повторите попытку.','La IA devolvió una respuesta vacía — inténtalo de nuevo.'),
+      provider_malformed:_pl('The AI response was malformed — please try again.','AIの応答が不正な形式でした。もう一度お試しください。','Die KI-Antwort war fehlerhaft — bitte erneut versuchen.','Ответ ИИ был некорректным — повторите попытку.','La respuesta de la IA fue incorrecta — inténtalo de nuevo.'),
+      provider_blocked:_pl('The AI safety filter blocked that. Try rephrasing it as a public-information, broad-area analysis (e.g. an approximate zone or reach rings for defence/preparedness) rather than precise targeting.','AIの安全フィルタによりブロックされました。正確な標的指定ではなく、公開情報に基づく広域の分析（例：おおよそのゾーンや到達圏の表示など、防災・脅威評価目的）として言い換えてお試しください。','Der KI-Sicherheitsfilter hat das blockiert. Formulieren Sie es als öffentlich-informationsbasierte, großräumige Analyse (z. B. eine ungefähre Zone oder Reichweitenringe für Verteidigung/Vorsorge) statt als präzise Zielerfassung.','Фильтр безопасности ИИ заблокировал это. Переформулируйте как анализ по открытым данным для широкой области (например, приблизительная зона или кольца досягаемости для обороны/готовности), а не точное целеуказание.','El filtro de seguridad de la IA lo bloqueó. Reformúlalo como un análisis de información pública y de área amplia (p. ej., una zona aproximada o anillos de alcance para defensa/preparación) en lugar de una localización precisa de objetivos.'),
+      provider_unavailable:_pl('The AI service is temporarily unavailable — please try again shortly.','AIサービスが一時的に利用できません。少し後に再試行してください。','Der KI-Dienst ist vorübergehend nicht verfügbar — bitte gleich erneut versuchen.','Сервис ИИ временно недоступен — повторите вскоре.','El servicio de IA no está disponible temporalmente — inténtalo pronto.'),
+      invalid_structured_output:_pl('The AI structured output was invalid — please try again.','AIの構造化出力が不正でした。もう一度お試しください。','Die strukturierte KI-Ausgabe war ungültig — bitte erneut versuchen.','Структурированный вывод ИИ был неверным — повторите попытку.','La salida estructurada de la IA no era válida — inténtalo de nuevo.')
+    };
+    return M[code] || ('AI: '+(message||code||'error'));
+  }
+  /* (#R132) FULL-envelope server call: returns {text, meta, citations} for a SINGLE call (no reliance on the global
+     window._aiLastMeta, which a concurrent call can overwrite) and accepts opts.signal for real AbortController
+     cancellation (a timed-out / cancelled region-resolution call now aborts the underlying fetch instead of leaving
+     it running in the background). aiCallServer stays a thin text-only wrapper so every existing caller is unchanged. */
+  async function aiCallServerFull(prompt, system, imgs, opts){
+    const cfg=window.INTMAP_AI_PROXY||{};
+    const headers={'Content-Type':'application/json'};
+    if(cfg.headerName && cfg.headerValue) headers[cfg.headerName]=cfg.headerValue;
+    /* Attach the Supabase session JWT + anon apikey so the function can identify the user + enforce quota. */
+    let token='';
+    try{ const r=await window.sb.auth.getSession(); token=(r&&r.data&&r.data.session&&r.data.session.access_token)||''; }catch(_){}
+    if(window.SUPABASE_ANON_KEY){ headers['apikey']=window.SUPABASE_ANON_KEY; if(!token) headers['Authorization']='Bearer '+window.SUPABASE_ANON_KEY; }
+    if(token) headers['Authorization']='Bearer '+token;
+    const body={ prompt, system:system||'', images:(imgs||[]), lang:(typeof HOST.lang!=='undefined'?HOST.lang:'en') };
+    /* (#R113) task-aware contract: tell the proxy WHICH feature this is (output budget / JSON+structured-output
+       mode / web policy are chosen per-task server-side) instead of one MAX_TOKENS + one boolean for everything. */
+    if(opts){
+      if(opts.task) body.task=String(opts.task);
+      /* webMode: 'off' | 'auto' | 'required'. Back-compat: a bare {web:true} maps to 'auto'. */
+      body.webMode = opts.webMode ? String(opts.webMode) : (opts.web ? 'auto' : 'off');
+      if(body.webMode!=='off') body.web=true;   /* keep the legacy boolean in sync for the Anthropic native-search path */
+      if(opts.requestedCount!=null && isFinite(+opts.requestedCount)) body.requestedCount=+opts.requestedCount;
+      if(opts.schema && typeof opts.schema==='object') body.schema=opts.schema;
+      if(opts.effortHint) body.effortHint=String(opts.effortHint);   /* (#R117) complexity hint → planner/analysis may think at "high" server-side */
+      if(opts.imageDetail) body.imageDetail=String(opts.imageDetail);   /* (#R156) "high" → OpenAI input_image detail:high (small-text/math OCR); server clamps by task */
+    }
+    const fetchOpts={method:'POST',headers,body:JSON.stringify(body)};
+    if(opts&&opts.signal) fetchOpts.signal=opts.signal;   /* (#R132) real Abort */
+    const r=await fetch(cfg.url,fetchOpts);
+    if(r.status===401){ try{ HOST.openAuthModal(aiLoginMsg()); }catch(_){} throw new Error(aiLoginMsg()); }
+    if(r.status===429){ let j=null; try{ j=await r.json(); }catch(_){} if(j&&typeof j.used==='number') aiSetUsage(j.used, j.limit); else { HOST.aiUsage.date=aiToday(); HOST.aiUsage.used=aiDailyLimit(); } throw new Error(aiLimitMsg()); }
+    if(!r.ok){
+      /* (#R113) a typed PROVIDER error (502/503) is NOT the IntMap daily limit — surface a clear, distinct message
+         (and never mislabel a Google-side 429 as "out of free uses"). */
+      let ej=null; try{ ej=await r.json(); }catch(_){}
+      if(ej&&ej.error) throw new Error(aiProviderErrMsg(ej.error, ej.message));
+      throw new Error('AI '+r.status+': '+aiErrSnippet(await r.text().catch(()=>'')));
+    }
+    const j=await r.json().catch(()=>null);
+    if(j==null) return {text:'',meta:null,citations:[]};
+    if(typeof j.used==='number') aiSetUsage(j.used, j.limit);
+    const meta=(j&&typeof j==='object'&&j.meta&&typeof j.meta==='object')?j.meta:null;
+    const citations=(j&&typeof j==='object'&&Array.isArray(j.citations))?j.citations:[];
+    /* (#R114/#R131) still mirror to the globals for the many existing readers, but the ENVELOPE is authoritative per call. */
+    try{ window._aiLastMeta=meta; }catch(_){}
+    try{ window._aiLastCitations=citations; }catch(_){}
+    let text='';
+    if(typeof j==='string') text=j;
+    else if(typeof j.text==='string') text=j.text;
+    else if(j.content&&Array.isArray(j.content)) text=j.content.map(b=>b.text||'').join('');
+    else if(j.choices&&j.choices[0]) text=(j.choices[0].message&&j.choices[0].message.content)||j.choices[0].text||'';
+    return {text, meta, citations};
+  }
+  async function aiCallServer(prompt, system, imgs, opts){ return (await aiCallServerFull(prompt, system, imgs, opts)).text; }
+  /* ---- Unified entry point used by every AI feature ---- */
+  async function askAI(prompt, systemPrompt, imageDatas, opts){
+    const imgs=(imageDatas||[]).filter(Boolean);
+    /* Account-based path (always on). Gate first so we never spend a network round-trip when the user
+       is logged out / over quota, and so the auth modal opens immediately. */
+    if(!HOST.user){ try{ HOST.openAuthModal(aiLoginMsg()); }catch(_){} throw new Error(aiLoginMsg()); }
+    if(HOST.aiUsage.date===aiToday() && aiUsesLeft()<=0){ throw new Error(aiLimitMsg()); }
+    if(aiProxyOn()) return aiCallServer(prompt, systemPrompt, imgs, opts);
+    throw new Error(aiLimitMsg());
+  }
+  async function askAIJSON(prompt, systemPrompt, imageDatas, opts){ opts=opts||{}; if(!opts.task) opts.task='json_extract';   /* (#R113) JSON call → server JSON/structured-output mode by default */
+    return aiParseJSON(await askAI(prompt, systemPrompt, imageDatas, opts)); }
+  /* (#R132) ENVELOPE variants — same gating as askAI/askAIJSON but return {text|data, meta, citations} for a SINGLE
+     call (no reliance on the global window._aiLastMeta a concurrent call could clobber) and forward opts.signal for
+     real AbortController cancellation. Used by the region resolver so one resolve reads exactly its own meta/citations. */
+  async function askAIEnvelope(prompt, systemPrompt, imageDatas, opts){
+    const imgs=(imageDatas||[]).filter(Boolean);
+    if(!HOST.user){ try{ HOST.openAuthModal(aiLoginMsg()); }catch(_){} throw new Error(aiLoginMsg()); }
+    if(HOST.aiUsage.date===aiToday() && aiUsesLeft()<=0){ throw new Error(aiLimitMsg()); }
+    if(aiProxyOn()) return aiCallServerFull(prompt, systemPrompt, imgs, opts);
+    throw new Error(aiLimitMsg()); }
+  async function askAIJSONEnvelope(prompt, systemPrompt, imageDatas, opts){ opts=opts||{}; if(!opts.task) opts.task='json_extract';
+    const env=await askAIEnvelope(prompt, systemPrompt, imageDatas, opts);
+    return { data:aiParseJSON(env.text), text:env.text, meta:env.meta, citations:env.citations }; }
+  function aiParseJSON(raw){
+    if(raw==null) return null;
+    let s=String(raw).trim();
+    const fence=s.match(/```(?:json)?\s*([\s\S]*?)```/i); if(fence) s=fence[1].trim();
+    const seg=s.match(/[\[{][\s\S]*[\]}]/); if(seg) s=seg[0];
+    try{ return JSON.parse(s); }catch(_){ try{ return JSON.parse(s.replace(/,\s*([\]}])/g,'$1')); }catch(__){ return null; } }
+  }
+  /* ---- Shared UI: toast + report popup (used by all four features) ---- */
+  function aiToast(msg){
+    let el=document.getElementById('ai-toast');
+    if(!el){ el=document.createElement('div'); el.id='ai-toast'; el.className='sat-toast'; document.body.appendChild(el); }
+    el.textContent=msg; el.classList.add('show');
+    clearTimeout(aiToast._t); aiToast._t=setTimeout(()=>el.classList.remove('show'),4600);
+  }
+  function aiEsc(s){ return String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+  /* Generic report popup. opts:{title, sub, images:[{src,caption}]}. Returns an api
+     with setLoading()/setBody(text)/setError(msg,onRetry)/close(). */
+  function aiReport(opts){
+    opts=opts||{};
+    let ov=document.getElementById('ai-report-modal');
+    if(!ov){ ov=document.createElement('div'); ov.id='ai-report-modal'; ov.className='modal-overlay'; document.body.appendChild(ov);
+      ov.addEventListener('click',e=>{ if(e.target===ov) ov.style.display='none'; }); }
+    const imgsHtml=(opts.images&&opts.images.length)?`<div class="ai-report-imgs">${opts.images.map(im=>`<figure><img src="${aiEsc(im.src)}">${im.caption?`<figcaption>${aiEsc(im.caption)}</figcaption>`:''}</figure>`).join('')}</div>`:'';
+    ov.innerHTML=`<div class="modal-content">
+      <div class="ai-report-head">✨ <span>${aiEsc(opts.title||'AI')}</span></div>
+      ${opts.sub?`<div class="ai-report-sub">${aiEsc(opts.sub)}</div>`:''}
+      ${imgsHtml}
+      <div class="ai-report-body loading" id="ai-report-body"><span class="ai-spin"></span><span>${aiEsc(HOST.t('aiThinking'))}</span></div>
+      <div class="ai-report-actions" id="ai-report-actions"></div>
+    </div>`;
+    ov.style.display='flex';
+    const bodyEl=ov.querySelector('#ai-report-body'), actEl=ov.querySelector('#ai-report-actions');
+    const api={
+      el:ov,
+      close(){ ov.style.display='none'; },
+      setLoading(msg){ bodyEl.className='ai-report-body loading'; bodyEl.innerHTML=`<span class="ai-spin"></span><span>${aiEsc(msg||HOST.t('aiThinking'))}</span>`; actEl.innerHTML=''; },
+      setBody(text){ bodyEl.className='ai-report-body'; bodyEl.textContent=String(text||'');
+        actEl.innerHTML=`<button id="ai-rep-copy">${aiEsc(HOST.t('aiCopy'))}</button><button class="primary" id="ai-rep-close">${aiEsc(HOST.t('aiClose'))}</button>`;
+        actEl.querySelector('#ai-rep-close').onclick=api.close;
+        actEl.querySelector('#ai-rep-copy').onclick=ev=>{ try{ navigator.clipboard.writeText(String(text||'')); ev.target.textContent=HOST.t('aiCopied'); }catch(_){} };
+      },
+      setError(msg,onRetry){ bodyEl.className='ai-report-body'; bodyEl.innerHTML=`<span style="color:#ff453a">⚠ ${aiEsc(HOST.t('aiError'))}</span><br><span style="font-size:12px;color:var(--text-muted)">${aiEsc(msg||'')}</span>`;
+        actEl.innerHTML=(onRetry?`<button id="ai-rep-retry">${aiEsc(HOST.t('aiRetry'))}</button>`:'')+`<button class="primary" id="ai-rep-close">${aiEsc(HOST.t('aiClose'))}</button>`;
+        actEl.querySelector('#ai-rep-close').onclick=api.close;
+        const rb=actEl.querySelector('#ai-rep-retry'); if(rb) rb.onclick=()=>{ api.setLoading(); onRetry(); };
+      }
+    };
+    return api;
+  }
+  /* ---- (#R27) Settings modal: AI section — account-based, NO key/provider/model picker ----
+     Built-in AI: nothing to configure. We only show login state + today's free-use counter. */
+  function aiRenderSettings(){
+    const wrap=document.getElementById('ai-settings-body'); if(!wrap) return;
+    const jp=aiJP();
+    /* (#R34) DEV = UNLIMITED — check this FIRST. It used to sit BELOW the "not logged in" early-return, so a
+       developer (intmap_dev flag, or logged in but currentUser not yet populated) saw the login prompt instead
+       of the unlimited state ("開発者なので無制限に / 設定欄のグラフに反映されていない"). */
+    if(aiDev()){
+      wrap.innerHTML=
+        /* (#R101) the "✨ Built-in AI is ready…" line duplicated the section hint above — removed (de-dup + no ✨). */
+        `<div class="ai-row" style="font-size:13px;color:var(--text-main);font-weight:600;">`+
+          aiEsc(jp?'開発者アカウント — AI利用は無制限です。':'Developer account — unlimited AI usage.')+
+          `<div style="height:7px;border-radius:5px;background:var(--input-bg);overflow:hidden;margin-top:8px;"><div style="height:100%;width:100%;background:linear-gradient(90deg,#34c759,#0a84ff);"></div></div>`+
+        `</div>`;
+      return;
+    }
+    if(typeof HOST.user==='undefined' || !HOST.user){
+      wrap.innerHTML=
+        /* (#R33) The in-Settings "Log in / Sign up" button was removed as redundant (use the account button
+           top-right). Only the explanatory line remains. */
+        `<div class="ai-row" style="font-size:12px;color:var(--text-muted);line-height:1.5;">`+
+          aiEsc(jp?'AI機能（要約・翻訳・位置解析・画像比較など）は、右上のアカウントからログインすると無料でご利用いただけます（1日'+HOST.AI_FREE_DAILY+'回まで）。APIキーは不要です。'
+                  :'AI features (summaries, translation, locating, image compare…) are free once you log in from the account button (top-right) — up to '+HOST.AI_FREE_DAILY+' uses per day. No API key needed.')+
+        `</div>`;
+      return;
+    }
+    const left=aiUsesLeft(), lim=aiDailyLimit(), used=Math.max(0, lim-left);
+    const pct=lim>0?Math.round((used/lim)*100):0;
+    const bar=`<div style="height:7px;border-radius:5px;background:var(--input-bg);overflow:hidden;margin-top:8px;"><div style="height:100%;width:${pct}%;background:${left>0?'var(--primary-color)':'#ff453a'};transition:width .25s;"></div></div>`;
+    wrap.innerHTML=
+      /* (#R101) the "✨ Built-in AI is ready…" line duplicated the section hint above — removed (de-dup + no ✨). */
+      `<div class="ai-row" style="font-size:13px;color:var(--text-main);font-weight:600;">`+
+        aiEsc(jp?('本日の無料利用： 残り '+left+' / '+lim+' 回')
+                :('Today’s free uses: '+left+' / '+lim+' left'))+
+        bar+
+        (left<=0?`<div style="font-size:11.5px;color:#ff453a;margin-top:7px;font-weight:500;">`+aiEsc(aiLimitMsg())+`</div>`:'')+
+      `</div>`;
+  }
+  function aiSaveSettings(){ saveAIConfig(); try{ aiSyncFeatureButtons(); }catch(_){} }
+  function aiSyncFeatureButtons(){ HOST.aiButtonSyncers.forEach(fn=>{ try{ fn(); }catch(_){} }); }
+  /* Toggle a busy spinner + disabled state on an .ai-action-btn (shared by all features). */
+  function aiSetBtnBusy(btn,busy,label){
+    if(!btn) return;
+    if(busy){ if(!btn.dataset.olabel) btn.dataset.olabel=btn.textContent; btn.disabled=true; btn.innerHTML='<span class="ai-spin"></span><span>'+aiEsc(label||btn.dataset.olabel)+'</span>'; }
+    else { btn.disabled=false; if(btn.dataset.olabel!=null){ btn.textContent=btn.dataset.olabel; delete btn.dataset.olabel; } }
+  }
+  function aiWaitMapIdle(timeout){ return new Promise(res=>{ if(!map){ res(); return; } let done=false; const fin=()=>{ if(done)return; done=true; try{ map.off('idle',fin); }catch(_){} res(); }; try{ map.on('idle',fin); }catch(_){ } setTimeout(fin,timeout||4500); }); }
+  return { aiDev, aiEsc, aiFetchUsage, aiGate, aiLimitMsg, aiLoginMsg, aiParseJSON, aiReady, aiRenderSettings, aiReport, aiSaveSettings, aiSetBtnBusy, aiSyncFeatureButtons, aiToast, aiToday, aiUsesLeft, aiVisionReady, aiWaitMapIdle, askAI, askAIJSON, askAIJSONEnvelope };
+};

--- a/js/article-reader.js
+++ b/js/article-reader.js
@@ -1,0 +1,113 @@
+/* ============================================================================
+ *  IntMap · In-sidebar article reader  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ *
+ *  FINDING (#R169), recorded rather than silently "fixed": nothing calls openArticleInSidebar().
+ *  #R11 ("revert Read->external") pointed the news card's Read button back at the original site, and
+ *  the in-sidebar reader has been unreachable ever since — the chain openArticleInSidebar ->
+ *  fetchReadable -> renderReader -> IM_NEWS_UI.renderReaderMode has no live entry point. Nothing here
+ *  is deleted and nothing is re-wired: that is a product decision, not a refactoring one. The code is
+ *  moved out of index.html unchanged, with its single entry point still exported (so index.html keeps
+ *  exactly the declared-but-uncalled function it had before), and the finding is written up in
+ *  DEV-NOTES R169 for a decision: re-wire the Read button to it, or delete the feature.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.articleReader=function(map,HOST){
+  const READER_NOISE=new Set(['edit','[edit]','skip to content','watch live','sign in','log in','menu','advertisement','home','news','sport','business','technology','more','share','save','reuters','associated press','follow us','related topics','watch','listen']);
+  function cleanReaderMarkdown(md){
+    let firstImg=''; let text=md||'';
+    const im=text.match(/!\[[^\]]*\]\((https?:\/\/[^)\s]+)\)/);
+    if(im) firstImg=im[1];
+    text=text.replace(/```[\s\S]*?```/g,' ');                 /* code fences */
+    text=text.replace(/`([^`]+)`/g,'$1');                     /* inline code */
+    text=text.replace(/!\[[^\]]*\]\([^)]*\)/g,'');            /* strip images */
+    text=text.replace(/\[([^\]]+)\]\([^)]*\)/g,'$1');         /* links -> text */
+    text=text.replace(/\\([\\_*\[\]()#~`>+.!-])/g,'$1');      /* unescape md */
+    text=text.replace(/\*\*([^*]+)\*\*/g,'$1').replace(/__([^_]+)__/g,'$1'); /* bold */
+    text=text.replace(/\*([^*]+)\*/g,'$1');                   /* italic */
+    const lines=text.split(/\n/); const blocks=[]; let buf=[];
+    const isNoise=s=>READER_NOISE.has(s.toLowerCase().replace(/^[•§]\s*/,'').trim());
+    const flush=()=>{ if(buf.length){ const p=buf.join(' ').replace(/\s+/g,' ').trim(); if(p&&p.length>1&&!isNoise(p)) blocks.push({t:'p',v:p}); buf=[]; } };
+    for(const raw of lines){
+      const line=raw.replace(/\s+$/,'');
+      if(/^\s*#{1,6}\s+/.test(line)){ flush(); const h=line.replace(/^\s*#{1,6}\s+/,'').trim(); if(h&&!isNoise(h)) blocks.push({t:'h',v:h}); continue; }
+      if(/^\s*>\s?/.test(line)){ flush(); const q=line.replace(/^\s*>\s?/,'').trim(); if(q&&!isNoise(q)) buf.push(q); continue; }
+      if(/^\s*[-*+]\s+/.test(line)){ flush(); const li=line.replace(/^\s*[-*+]\s+/,'').trim(); if(li.length>=30&&!isNoise(li)) blocks.push({t:'p',v:'• '+li}); continue; }
+      if(line.trim()===''){ flush(); continue; }
+      if(/^[=*_\-|>#`~]{1,}$/.test(line.trim())) continue;   /* skip rule/noise lines */
+      buf.push(line.trim());
+    }
+    flush();
+    return {hero:firstImg, blocks};
+  }
+  async function fetchReadable(item){
+    /* Strategy 1: r.jina.ai reader — clean article text, CORS-friendly (works from file://). */
+    try{
+      const ctrl=new AbortController(); const to=setTimeout(()=>ctrl.abort(),12000);
+      const r=await fetch('https://r.jina.ai/'+item.link,{signal:ctrl.signal});
+      clearTimeout(to);
+      if(r.ok){
+        let txt=await r.text();
+        if(txt&&txt.length>200){
+          const mc=txt.indexOf('Markdown Content:');
+          if(mc>=0) txt=txt.slice(mc+'Markdown Content:'.length);
+          const parsed=cleanReaderMarkdown(txt);
+          if(parsed.blocks.length>=2) return {blocks:parsed.blocks, hero:parsed.hero, ok:true};
+        }
+      }
+    }catch(_){}
+    /* Strategy 2: proxy raw HTML -> extract <article>/<p> text or og:description. */
+    try{
+      const html=await HOST.fetchViaProxy(item.link);
+      if(html){
+        const doc=new DOMParser().parseFromString(html,'text/html');
+        let hero=''; const ogi=doc.querySelector('meta[property="og:image"]'); if(ogi) hero=ogi.getAttribute('content')||'';
+        const scope=doc.querySelector('article')||doc.querySelector('main')||doc.body;
+        const ps=[...scope.querySelectorAll('p')].map(p=>p.textContent.trim()).filter(t=>t.length>40);
+        if(ps.length>=2) return {blocks:ps.slice(0,50).map(v=>({t:'p',v})), hero, ok:true};
+        const desc=doc.querySelector('meta[property="og:description"],meta[name="description"]');
+        if(desc) return {blocks:[{t:'p',v:desc.getAttribute('content')||''}], hero, ok:false};
+      }
+    }catch(_){}
+    return {blocks:[], hero:'', ok:false};
+  }
+  function openArticleInSidebar(item){
+    HOST.readerOpen=true; HOST.readerCurrent=item;
+    /* (#R80) vision §2 — Atlas must know the ARTICLE the user is reading right now (not just that the News tab is
+       open), so follow-ups like "この記事について詳しく"/"translate this"/"背景は？"/"where did this happen" resolve.
+       globalData is closure-scoped, so bridge the open article onto window (same pattern as window._imLayerDates). */
+    try{ const _a=(item&&item.analysis)||{}; window._imReader={ open:true, title:item&&item.title||'', publisher:item&&item.publisher||'', link:item&&item.link||'', pubDate:item&&item.pubDate||'', loc:(_a.loc&&isFinite(_a.loc[0]))?[_a.loc[0],_a.loc[1]]:null, place:_a.name||'' }; }catch(_){ }
+    /* (#R160) reveal the sidebar to show the article reader. The sidebar overlays a fixed full-width map, so this
+       can't move the map — just drop `collapsed` and let the search-pill layout recompute; no anchor, no resize. */
+    try{ const _sb=document.getElementById('sidebar'); if(_sb&&_sb.classList.contains('collapsed')){ _sb.classList.remove('collapsed'); window.dispatchEvent(new Event('intmap-sidebar-resize')); } }catch(_){}
+    try{ if(window.matchMedia('(max-width:768px)').matches && window.__setDetent) window.__setDetent('full'); }catch(_){}
+    const cp=document.querySelector('.control-panel'); if(cp) cp.style.display='none';
+    const sbBar=document.getElementById('sidebar-search-bar'); if(sbBar) sbBar.style.display='none';   /* (#R79e) by ID, not .search-bar (see renderUI note) */
+    const pt=document.getElementById('news-pin-toggle'); if(pt) pt.style.display='none';
+    ['live-news-feed','info-dashboard','community-feed'].forEach(id=>{ const e=document.getElementById(id); if(e) e.style.display='none'; });
+    const pane=document.getElementById('news-reader-pane'); pane.style.display='flex';
+    const back=HOST.lang==='jp'?'ニュースへ戻る':HOST.lang==='de'?'Zurück zu den News':HOST.lang==='ru'?'Назад к новостям':HOST.lang==='es'?'Volver a noticias':'Back to news';
+    pane.innerHTML=`<div class="nrp-bar"><button class="nrp-back" id="nrp-back-btn">‹ ${back}</button><span class="nrp-src">${HOST.escForReader(item.publisher)}</span></div>
+      <div class="nrp-loading"><div class="nrp-spinner"></div>${HOST.lang==='jp'?'記事を読み込み中…':HOST.lang==='de'?'Artikel lädt…':HOST.lang==='ru'?'Загрузка статьи…':HOST.lang==='es'?'Cargando artículo…':'Loading article…'}</div>`;
+    pane.querySelector('#nrp-back-btn').onclick=HOST.closeArticleReader;
+    pane.scrollTop=0;
+    fetchReadable(item).then(res=>{ if(HOST.readerOpen&&HOST.readerCurrent===item) renderReader(item,res);
+      /* (#R118) ARTICLE-BODY bridge: Atlas can now READ the open article's extracted text ("この記事の根拠を
+         整理して / この段落を翻訳して" work on the real body, not just the headline). Capped to ~6k chars. */
+      try{ if(window._imReader&&res&&Array.isArray(res.blocks)&&res.blocks.length){
+        window._imReader.body=res.blocks.map(b=>String((b&&(b.v!=null?b.v:(b.text!=null?b.text:b)))||'')).filter(Boolean).join('\n\n').slice(0,6000); } }catch(_){ } });
+  }
+  function renderReader(item,res){
+    const pane=document.getElementById('news-reader-pane'); if(!pane) return;
+    /* If we extracted real body text, default to the clean Reader; otherwise show the
+       in-sidebar mini-browser (iframe) so the user can always read the page. */
+    const hasText=res.blocks&&res.blocks.length>=2;
+    HOST.renderReaderMode(item,res, hasText?'reader':'web');
+  }
+  return { openArticleInSidebar };
+};

--- a/js/community-board.js
+++ b/js/community-board.js
@@ -1,0 +1,279 @@
+/* ============================================================================
+ *  IntMap · Community board: list, cards, compose and the map layer  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.communityBoard=function(map,HOST){
+  const commCatById=(id)=>HOST.COMM_CATEGORIES.find(c=>c.id===id)||HOST.COMM_CATEGORIES[0];
+  const commCatLabel=(id)=>{ const c=commCatById(id); return c.label[HOST.lang]||c.label.en; };
+  /* Deterministic avatar (colored initial) from a display name. */
+  function commAvatar(name){
+    const s=(name||'?').trim(); let h=0; for(let i=0;i<s.length;i++) h=(h*31+s.charCodeAt(i))|0;
+    const hue=Math.abs(h)%360, init=HOST.escapeHtml(s.slice(0,/[A-Za-z0-9]/.test(s[0]||'')?2:1).toUpperCase()||'?');
+    return `<span class="comm-avatar" style="background:hsl(${hue},58%,46%)">${init}</span>`;
+  }
+  /* Compact relative time ("5m", "3h", "2d" / 「5分前」). */
+  function relTime(ts){
+    const s=Math.max(0,(Date.now()-ts)/1000);
+    if(HOST.lang==='jp'){
+      if(s<60) return 'たった今'; if(s<3600) return Math.floor(s/60)+'分前'; if(s<86400) return Math.floor(s/3600)+'時間前';
+      if(s<604800) return Math.floor(s/86400)+'日前'; if(s<2629800) return Math.floor(s/604800)+'週間前';
+      return new Date(ts).toLocaleDateString('ja-JP');
+    }
+    if(s<60) return 'now'; if(s<3600) return Math.floor(s/60)+'m'; if(s<86400) return Math.floor(s/3600)+'h';
+    if(s<604800) return Math.floor(s/86400)+'d'; if(s<2629800) return Math.floor(s/604800)+'w';
+    return new Date(ts).toLocaleDateString('en-US');
+  }
+  /* "Hot" ranking — recent + upvoted + discussed floats to the top (Reddit-style decay). */
+  function hotScore(p){ const ageH=(Date.now()-p.ts)/3.6e6; return ((p.votes||0)+0.5*((p.comments||[]).length)+1)/Math.pow(ageH+2,1.3); }
+  function setupCommunityLayer(){
+    if(!map||!map.isStyleLoaded()) return;
+    if(!map.getSource('community-points')){
+      /* Color pins by post category (falls back to green for un-categorised). */
+      const catColor=['match',['get','cat']].concat(HOST.COMM_CATEGORIES.flatMap(c=>[c.id,c.color])).concat(['#34c759']);
+      map.addSource('community-points',{type:'geojson',data:{type:'FeatureCollection',features:[]},promoteId:'fid'});
+      map.addLayer({id:'community-pulse',type:'circle',source:'community-points',paint:{
+        'circle-radius':['interpolate',['linear'],['zoom'],0,8,4,14,10,20],
+        'circle-color':catColor,'circle-opacity':0.2,'circle-stroke-width':0
+      }});
+      map.addLayer({id:'community-dots',type:'circle',source:'community-points',paint:{
+        'circle-radius':['case',['boolean',['feature-state','hover'],false],11,8],
+        'circle-color':catColor,'circle-stroke-width':2.5,'circle-stroke-color':'#ffffff'
+      }});
+      map.addLayer({id:'community-labels',type:'symbol',source:'community-points',layout:{
+        'text-field':['get','short'],'text-size':11,'text-font':['literal',['Noto Sans Regular']],
+        'text-anchor':'left','text-offset':[1.1,0],'text-allow-overlap':false,'text-optional':true,'text-max-width':14
+      },paint:{'text-color':'#0a6b32','text-halo-color':'rgba(255,255,255,0.95)','text-halo-width':2.0,'text-opacity':0.95}});
+      let hoverComm=null;
+      map.on('mousemove','community-dots',e=>{
+        if(!e.features.length) return;
+        map.getCanvas().style.cursor='pointer';
+        const f=e.features[0];
+        if(hoverComm!==f.id){
+          if(hoverComm!=null) try{map.setFeatureState({source:'community-points',id:hoverComm},{hover:false});}catch(_){}
+          hoverComm=f.id;
+          try{map.setFeatureState({source:'community-points',id:hoverComm},{hover:true});}catch(_){}
+        }
+        const el=HOST.ensureMapTooltip(); el.style.display='block';
+        const p=f.properties;
+        el.innerHTML=`<div style="color:#34c759;font-weight:600;font-size:13px;">💬 ${IntMapSafe.html(p.title)}</div><div style="line-height:1.4;margin-top:4px;color:var(--text-muted);font-size:11px;">${IntMapSafe.html(p.body||'')}</div>`;   /* (#R138 SEC) community post title/body are user-generated → escape (stored XSS on pin hover) */
+        HOST.positionTooltip(e.point);
+      });
+      map.on('mouseleave','community-dots',()=>{
+        if(hoverComm!=null){ try{map.setFeatureState({source:'community-points',id:hoverComm},{hover:false});}catch(_){} hoverComm=null; }
+        map.getCanvas().style.cursor=''; if(HOST.mapTooltipEl) HOST.mapTooltipEl.style.display='none';
+      });
+      map.on('click','community-dots',e=>{
+        if(!e.features.length) return;
+        const id=e.features[0].properties.fid;
+        if(HOST.mode!=='community'){ HOST.setMode('community','btn-community'); }
+        setTimeout(()=>{ const card=document.getElementById('comm-post-'+id); if(card) card.scrollIntoView({behavior:'smooth',block:'center'}); },200);
+      });
+    }
+    HOST.pushCommunityFeatures();
+  }
+  /* Posts after the active search / category / in-view filters (drives both feed + pins). */
+  function visibleCommunityPosts(){
+    let list=HOST.communityPosts.slice();
+    if(HOST.commCatFilter!=='all') list=list.filter(p=>(p.category||'general')===HOST.commCatFilter);
+    if(HOST.commSearch){ const q=HOST.commSearch.toLowerCase(); list=list.filter(p=>((p.title||'')+' '+(p.body||'')+' '+(p.author||'')).toLowerCase().includes(q)); }
+    if(HOST.commInView && map){ try{ const b=map.getBounds(); list=list.filter(p=>b.contains([p.lng,p.lat])); }catch(_){} }
+    return list;
+  }
+  /* Escape + auto-link URLs (body/comment text). */
+  function linkify(s){ return HOST.escapeHtml(s||'').replace(/(https?:\/\/[^\s<]+)/g,'<a href="$1" target="_blank" rel="noopener" class="comm-link">$1</a>'); }
+  /* Fills only #comm-list (so the search box above never loses focus while typing). */
+  function renderCommList(){
+    const list=document.getElementById('comm-list'); if(!list) return;
+    const posts=visibleCommunityPosts();
+    posts.sort((a,b)=> HOST.communitySort==='top' ? (((b.votes||0)-(a.votes||0))||(b.ts-a.ts))
+                     : HOST.communitySort==='hot' ? (hotScore(b)-hotScore(a))
+                     : (b.ts-a.ts));
+    if(HOST.communityPosts.length===0) list.innerHTML=`<div class="empty-msg">${HOST.t('commEmpty')}</div>`;
+    else if(posts.length===0)     list.innerHTML=`<div class="empty-msg">${HOST.t('commNoMatch')}</div>`;
+    else                          list.innerHTML=posts.map(postCardHTML).join('');
+    HOST.wireCommList(list);
+    try{ HOST.pushCommunityFeatures(); }catch(_){}
+  }
+  function postCardHTML(post){
+    const jp=HOST.lang==='jp', mine=HOST.user&&post.userId===HOST.user.id;
+    const canDel = HOST.user && (mine || HOST.user.isAdmin);
+    const cat=commCatById(post.category||'general');
+    const imgHtml=post.img?`<img class="comm-post-img" src="${IntMapSafe.html(IntMapSafe.url(post.img,{allowData:true}))}" data-id="${post.id}" alt="">`:'';   /* (#R138 SEC) post.img is user-controlled (direct Supabase insert) → scheme-validate + quote-escape (stored XSS, auto-fires on feed render) */
+    const edited=post.editedTs?` · <span class="comm-edited">${HOST.t('commEdited')}</span>`:'';
+    const cmts=post.comments||[];
+    return `<div class="comm-post" id="comm-post-${post.id}">
+      <div class="comm-post-top">
+        <span class="comm-author-link" data-uid="${post.userId||''}" data-author="${HOST.escapeHtml(post.author||'')}" style="display:flex;align-items:center;gap:10px;cursor:pointer;min-width:0;flex:1;">
+        ${commAvatar(post.author)}
+        <div class="comm-post-idn">
+          <div class="comm-post-author">${HOST.escapeHtml(post.author||(jp?'匿名':'Anonymous'))}</div>
+          <div class="comm-post-sub">${relTime(post.ts)}${edited} · <span class="comm-post-loc" data-lat="${post.lat}" data-lng="${post.lng}">📍 ${post.lat.toFixed(1)}°, ${post.lng.toFixed(1)}°</span></div>
+        </div></span>
+        <span class="comm-cat-tag" style="--cc:${cat.color}">${cat.emoji} ${commCatLabel(post.category||'general')}</span>
+      </div>
+      ${post.title?`<div class="comm-post-title">${HOST.escapeHtml(post.title)}</div>`:''}
+      ${imgHtml}
+      ${post.body?`<div class="comm-post-body">${linkify(post.body)}</div>`:''}
+      <div class="comm-post-actions">
+        <button class="vote-btn ${post.voted?'voted':''}" data-id="${post.id}" title="${jp?'役に立った':'Upvote'}">▲ ${post.votes||0}</button>
+        <button class="cmt-toggle" data-id="${post.id}">💬 ${cmts.length}</button>
+        <button class="locate-btn" data-id="${post.id}">🌐 ${HOST.t('commLocate')}</button>
+        ${mine?`<button class="edit-btn" data-id="${post.id}">${HOST.t('commEdit')}</button>`:''}
+        <button class="report-btn" data-id="${post.id}" title="${jp?'通報':'Report'}">⚑</button>
+        ${canDel?`<button class="del-btn" data-id="${post.id}">${HOST.t('commDelete')}</button>`:''}
+      </div>
+      <div class="comm-comments ${HOST.commCollapsed[post.id]?'collapsed':''}" data-cwrap="${post.id}">
+        ${threadHTML(post)}
+        ${HOST.user?`<div class="comm-comment-add">
+          <input type="text" placeholder="${HOST.t('commWrite')}" data-pid="${post.id}" maxlength="280">
+          <button data-pid="${post.id}">${HOST.t('commPost')}</button></div>`:''}
+      </div>
+    </div>`;
+  }
+  function threadHTML(post){
+    const cmts=post.comments||[]; if(!cmts.length) return '';
+    const byId={}; cmts.forEach(c=>byId[c.id]=c);
+    const rootOf=(c)=>{ let cur=c,hop=0; while(cur.parentId&&byId[cur.parentId]&&hop<8){ cur=byId[cur.parentId]; hop++; } return cur; };
+    const roots=cmts.filter(c=>!c.parentId||!byId[c.parentId]).sort((a,b)=>a.ts-b.ts);
+    return roots.map(r=>{
+      const kids=cmts.filter(c=>c.parentId&&c.id!==r.id&&rootOf(c).id===r.id).sort((a,b)=>a.ts-b.ts);
+      return commentHTML(r,false)+kids.map(k=>commentHTML(k,true)).join('');
+    }).join('');
+  }
+  function commentHTML(c,isReply){
+    const mine=HOST.user&&c.userId===HOST.user.id, canDel=HOST.user&&(mine||HOST.user.isAdmin);
+    const edited=c.editedTs?` · ${HOST.t('commEdited')}`:'';
+    const cv=HOST.commCaps&&HOST.commCaps.commentVotes, th=HOST.commCaps&&HOST.commCaps.threads;
+    return `<div class="comm-comment ${isReply?'reply':''}" id="comm-c-${c.id}">
+      <div class="comm-comment-meta">${commAvatar(c.author)} <b>${HOST.escapeHtml(c.author||'')}</b> · ${relTime(c.ts)}${edited}</div>
+      <div class="comm-comment-body">${linkify(c.text)}</div>
+      <div class="comm-comment-actions">
+        ${cv?`<button class="cvote-btn ${c.voted?'voted':''}" data-cid="${c.id}">▲ ${c.votes||0}</button>`:''}
+        ${th&&HOST.user?`<button class="creply-btn" data-cid="${c.id}" data-pid="${c.postId}">${HOST.t('commReply')}</button>`:''}
+        ${mine?`<button class="cedit-btn" data-cid="${c.id}">${HOST.t('commEdit')}</button>`:''}
+        ${canDel?`<button class="cdel-btn" data-cid="${c.id}">${HOST.t('commDelete')}</button>`:''}
+      </div>
+    </div>`;
+  }
+  function renderComposeCats(){
+    const wrap=document.getElementById('compose-cats'); if(!wrap) return;
+    wrap.innerHTML=HOST.COMM_CATEGORIES.map(c=>`<button type="button" class="comm-cat-chip ${HOST.composeCat===c.id?'active':''}" data-cc="${c.id}" style="--cc:${c.color}">${c.emoji} ${commCatLabel(c.id)}</button>`).join('');
+    wrap.querySelectorAll('[data-cc]').forEach(b=>b.onclick=()=>{ HOST.composeCat=b.dataset.cc; renderComposeCats(); });
+  }
+  function openComposeModal(editPost){
+    const m=document.getElementById('compose-modal'), jp=HOST.lang==='jp';
+    HOST.composeEditId = editPost ? editPost.id : null;
+    HOST.composeCat = editPost ? (editPost.category||'general') : 'general';
+    if(editPost) HOST.pendingPostLoc=[editPost.lng,editPost.lat];
+    document.getElementById('compose-title').textContent = editPost ? HOST.t('commEditPost') : HOST.t('commPostNew');
+    document.getElementById('compose-post-title').value = editPost ? (editPost.title||'') : '';
+    document.getElementById('compose-post-body').value = editPost ? (editPost.body||'') : '';
+    document.getElementById('compose-post-title').placeholder=HOST.t('commTitle');
+    document.getElementById('compose-post-body').placeholder=HOST.t('commBody');
+    document.getElementById('compose-cancel').textContent=HOST.t('commCancel');
+    document.getElementById('compose-submit').textContent = editPost ? HOST.t('commSaveEdit') : HOST.t('commPost');
+    HOST.pendingImg = editPost ? (editPost.img||'') : ''; HOST.showComposeImgPreview(HOST.pendingImg);
+    document.getElementById('compose-img-label').textContent=jp?'画像を追加':'Add image';
+    document.getElementById('compose-place-label').textContent=jp?'地図でピンを移動':'Move pin on map';
+    /* Category picker — shown unless schema-detection proved the column is missing. */
+    const showCat = !HOST.commCaps || HOST.commCaps.category;
+    const catLabel=document.getElementById('compose-cat-label'), catWrap=document.getElementById('compose-cats');
+    if(catLabel){ catLabel.textContent=HOST.t('commCat'); catLabel.style.display=showCat?'block':'none'; }
+    if(catWrap){ catWrap.style.display=showCat?'flex':'none'; if(showCat) renderComposeCats(); }
+    if(HOST.pendingPostLoc){
+      document.getElementById('compose-coord-hint').textContent=
+        `${HOST.t('commPlacedAt')}: ${HOST.pendingPostLoc[1].toFixed(3)}°, ${HOST.pendingPostLoc[0].toFixed(3)}°`;
+    } else {
+      document.getElementById('compose-coord-hint').textContent=
+        jp?'地図をクリックして位置を指定してください。':'Click on the map to place a location.';
+    }
+    m.classList.add('active');
+  }
+  /* Public profile card (#28) — tap a community author to see their name, avatar & bio. */
+  async function imViewProfile(uid,author){
+    let m=document.getElementById('profile-modal');
+    if(!m){ m=document.createElement('div'); m.id='profile-modal'; m.style.cssText='position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;z-index:5200;padding:20px;'; m.onclick=e=>{ if(e.target===m) m.style.display='none'; }; document.body.appendChild(m); }
+    let bio='', avatar='', name=author||'';
+    if(uid && HOST.DB){ try{
+      /* (#R134) Read the PUBLIC-safe projection (profiles_public = id/display_name/bio/avatar_url only) so a
+         viewer never receives another user's email/is_admin/plan. Falls back to profiles for a database that
+         has not applied the profiles_public view yet (forward+backward compatible with the DB migration). */
+      let r=await HOST.DB.from('profiles_public').select('display_name,bio,avatar_url').eq('id',uid).maybeSingle();
+      if(r.error) r=await HOST.DB.from('profiles').select('display_name,bio,avatar_url').eq('id',uid).maybeSingle();
+      const data=r.data; if(data){ name=data.display_name||name; bio=data.bio||''; avatar=data.avatar_url||''; }
+    }catch(_){} }
+    let h=0; for(let i=0;i<name.length;i++) h=(h*31+name.charCodeAt(i))|0;
+    const ava = avatar?`<div style="width:66px;height:66px;border-radius:50%;background:url('${IntMapSafe.html(IntMapSafe.url(avatar,{allowData:true}))}') center/cover;margin:0 auto 10px;"></div>`:`<div style="width:66px;height:66px;border-radius:50%;margin:0 auto 10px;display:flex;align-items:center;justify-content:center;font-size:27px;font-weight:700;color:#fff;background:hsl(${Math.abs(h)%360},58%,46%)">${HOST.escapeHtml((name[0]||'?').toUpperCase())}</div>`;   /* (#R138 SEC) another user's avatar_url is attacker-controllable → scheme-validate + quote-escape (stored XSS via CSS background breakout) */
+    m.innerHTML=`<div style="background:var(--card-bg);color:var(--text-main);border-radius:16px;box-shadow:var(--shadow);padding:24px;width:100%;max-width:320px;text-align:center;">${ava}<h2 style="margin:0 0 6px;font-size:18px;">${HOST.escapeHtml(name||'?')}</h2><p style="color:var(--text-muted);font-size:13px;line-height:1.55;white-space:pre-wrap;margin:0 0 16px;">${bio?HOST.escapeHtml(bio):(HOST.lang==='jp'?'自己紹介はまだありません。':HOST.lang==='de'?'Noch keine Bio.':HOST.lang==='ru'?'Пока без описания.':HOST.lang==='es'?'Aún sin biografía.':'No bio yet.')}</p><button id="pm-close" style="width:100%;background:var(--input-bg);color:var(--text-main);border:none;padding:10px;border-radius:9px;font-weight:600;cursor:pointer;">${HOST.lang==='jp'?'閉じる':HOST.lang==='de'?'Schließen':HOST.lang==='ru'?'Закрыть':HOST.lang==='es'?'Cerrar':'Close'}</button></div>`;
+    m.querySelector('#pm-close').onclick=()=>{ m.style.display='none'; };
+    m.style.display='flex';
+  }
+  /* Detect which v2 columns/tables exist so the UI degrades gracefully on an un-migrated DB.
+     (Same tolerant pattern as refreshCurrentUser's is_pro probe.) Runs once, then cached. */
+  async function detectCommCaps(){
+    if(HOST.commCaps) return HOST.commCaps;
+    const caps={ category:false, threads:false, commentVotes:false, edited:false };
+    if(HOST.DB){
+      const ok=async(tbl,cols)=>{ try{ const {error}=await HOST.DB.from(tbl).select(cols).limit(1); return !error; }catch(_){ return false; } };
+      const postsRich=await ok('community_posts','id,category,edited_at');
+      caps.category = postsRich || await ok('community_posts','id,category');
+      const cmtsRich = await ok('community_comments','id,parent_id,edited_at');
+      caps.threads = cmtsRich || await ok('community_comments','id,parent_id');
+      caps.commentVotes = await ok('community_comment_votes','comment_id');
+      caps.edited = postsRich && cmtsRich;
+    }
+    HOST.commCaps=caps; return caps;
+  }
+  function commSelectStr(){
+    const c=HOST.commCaps||{};
+    const pExtra=(c.category?',category':'')+(c.edited?',edited_at':'');
+    const cExtra=(c.threads?',parent_id':'')+(c.edited?',edited_at':'')+(c.commentVotes?',community_comment_votes(user_id)':'');
+    return `id,user_id,author_name,title,body,img,lat,lng,created_at${pExtra},community_comments(id,user_id,author_name,body,created_at${cExtra}),community_votes(user_id)`;
+  }
+  const LEGACY_COMM_SELECT='id,user_id,author_name,title,body,img,lat,lng,created_at,community_comments(id,user_id,author_name,body,created_at),community_votes(user_id)';
+  async function loadCommunity(){
+    if(!HOST.DB){ HOST.communityPosts=[]; HOST.renderCommunity(); return; }
+    await detectCommCaps();
+    const uid=HOST.user?HOST.user.id:null;
+    let res=await HOST.DB.from('community_posts').select(commSelectStr()).order('created_at',{ascending:false});
+    if(res.error){ /* rich select failed (partial migration) → fall back to the legacy shape */
+      HOST.commCaps={category:false,threads:false,commentVotes:false,edited:false};
+      res=await HOST.DB.from('community_posts').select(LEGACY_COMM_SELECT).order('created_at',{ascending:false});
+    }
+    if(res.error){ console.warn('[IntMap] community load:', res.error.message); HOST.communityPosts=[]; HOST.renderCommunity(); return; }
+    HOST.communityPosts=(res.data||[]).map(p=>({
+      id:p.id, userId:p.user_id, title:p.title||'', body:p.body||'', img:p.img||'', lat:p.lat, lng:p.lng,
+      ts:Date.parse(p.created_at)||Date.now(), editedTs:p.edited_at?Date.parse(p.edited_at):0,
+      author:p.author_name||'', category:p.category||'general',
+      votes:(p.community_votes||[]).length,
+      voted: uid?(p.community_votes||[]).some(v=>v.user_id===uid):false,
+      comments:(p.community_comments||[]).slice().sort((a,b)=>(Date.parse(a.created_at)||0)-(Date.parse(b.created_at)||0))
+                .map(c=>({ id:c.id, postId:p.id, userId:c.user_id, text:c.body, author:c.author_name||'',
+                          ts:Date.parse(c.created_at)||Date.now(), editedTs:c.edited_at?Date.parse(c.edited_at):0,
+                          parentId:c.parent_id||null,
+                          votes:(c.community_comment_votes||[]).length,
+                          voted: uid?(c.community_comment_votes||[]).some(v=>v.user_id===uid):false }))
+    }));
+    HOST.pushCommunityFeatures(); HOST.renderCommunity();
+  }
+  async function cmAddPost(title,body,img,lat,lng,category){
+    const row={ user_id:HOST.user.id, author_name:HOST.user.name, title:title||null, body:body||null, img:img||null, lat, lng };
+    if(HOST.commCaps&&HOST.commCaps.category&&category) row.category=category;
+    let {error}=await HOST.DB.from('community_posts').insert(row);
+    if(error && row.category!==undefined){ delete row.category; ({error}=await HOST.DB.from('community_posts').insert(row)); } /* retry w/o category if column missing */
+    if(error) throw error;
+  }
+  async function cmEditPost(id,f){
+    const patch={ title:f.title||null, body:f.body||null, img:f.img||null, lat:f.lat, lng:f.lng };
+    if(HOST.commCaps&&HOST.commCaps.category) patch.category=f.category||'general';
+    if(HOST.commCaps&&HOST.commCaps.edited) patch.edited_at=new Date().toISOString();
+    const {error}=await HOST.DB.from('community_posts').update(patch).eq('id',id); if(error) throw error;
+  }
+  return { cmAddPost, cmEditPost, commCatLabel, imViewProfile, loadCommunity, openComposeModal, renderCommList, setupCommunityLayer, visibleCommunityPosts };
+};

--- a/js/elevation-profile.js
+++ b/js/elevation-profile.js
@@ -1,0 +1,73 @@
+/* ============================================================================
+ *  IntMap · Elevation profile panel  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.elevationProfile=function(map,HOST){
+  async function demSampleAll(points, z, timeoutMs, onProgress){ await HOST.warmDEMTiles(points, z, timeoutMs, onProgress); return points.map(p=>{ if(!p) return null; const v=HOST.demElevAt(p[0],p[1],null,z); return (v==null)?null:v; }); }
+  /* ===== (#R9b/#46) Elevation cross-section under a measured line (area uses its perimeter). Below 0 m
+     gets a faint blue band so sub-sea segments are obvious. Samples the cached terrarium DEM. ===== */
+  /* (#R11) Map cursor that mirrors the hovered point on the elevation chart. */
+  function _elevCursor(coord){ try{ if(!map.getSource('elev-cursor')){ map.addSource('elev-cursor',{type:'geojson',data:{type:'FeatureCollection',features:[]}}); map.addLayer({id:'elev-cursor-pt',type:'circle',source:'elev-cursor',paint:{'circle-radius':7,'circle-color':'#ff3b30','circle-opacity':0.55,'circle-stroke-color':'#fff','circle-stroke-width':2}}); }
+    map.getSource('elev-cursor').setData({type:'FeatureCollection',features:coord?[{type:'Feature',geometry:{type:'Point',coordinates:coord},properties:{}}]:[]}); }catch(_){} }
+  function _openProfilePanel(samples,dist){
+    let p=document.getElementById('elev-profile-panel');
+    if(!p){ p=document.createElement('div'); p.id='elev-profile-panel'; p.className='tool-panel'; (document.getElementById('map-container')||document.body).appendChild(p); }
+    p.style.cssText='display:block;left:50%;top:auto;bottom:26px;right:auto;transform:translateX(-50%);width:min(560px,calc(100vw - 40px));z-index:1600;';
+    const j=HOST.lang==='jp';
+    p.innerHTML='<div class="tp-header"><span class="tp-title">📈 '+(j?'標高断面':'Elevation profile')+'</span><button class="tp-close" title="'+HOST.t('close')+'">✕</button></div><div id="elev-profile-body" style="font-size:12px;color:var(--text-muted);padding:8px 2px;">'+(j?'標高を取得中…':'Sampling elevation…')+'</div>';
+    p.querySelector('.tp-close').onclick=()=>{ p.style.display='none'; _elevCursor(null); };
+    try{ HOST.makeDraggable(p,p.querySelector('.tp-header')); }catch(_){}
+    /* (#R12) Sample the LOCAL terrarium DEM (includes ocean bathymetry → negative below sea level) so
+       the profile is drawn under water too, instead of Open-Meteo elevation which returns 0 over sea. */
+    const _z=HOST._demZoomForSpan(dist[dist.length-1]||50);
+    demSampleAll(samples,_z).then(els=>{ _drawProfile(p.querySelector('#elev-profile-body'), samples, dist, els); });
+  }
+  function _drawProfile(box, samples, dist, els){
+    if(!box) return; const j=HOST.lang==='jp';
+    const known=els.filter(e=>e!=null && !isNaN(e));
+    if(!known.length){ box.textContent=j?'標高データを取得できませんでした':'No elevation data available'; return; }
+    let minE=Math.min(...known,0), maxE=Math.max(...known,0); if(maxE===minE) maxE=minE+1;
+    const cont=document.getElementById('map-container')||document.body;
+    const W=Math.min(520, Math.max(280, cont.clientWidth-60)), H=176, padL=46,padR=10,padT=12,padB=26;
+    const total=dist[dist.length-1]||1;
+    const X=i=>padL+(dist[i]/total)*(W-padL-padR);
+    const Y=e=>padT+(1-(e-minE)/(maxE-minE))*(H-padT-padB);
+    let dPath=''; for(let i=0;i<els.length;i++){ const e=els[i]; if(e==null||isNaN(e)) continue; dPath+=(dPath?'L':'M')+X(i).toFixed(1)+' '+Y(e).toFixed(1)+' '; }
+    const y0=Y(0);
+    const area=dPath?('M'+X(0).toFixed(1)+' '+y0.toFixed(1)+' '+dPath.replace(/^M/,'L')+'L'+X(els.length-1).toFixed(1)+' '+y0.toFixed(1)+' Z'):'';
+    /* (#R12) Blue water band drawn OVER the green fill so sub-sea terrain reads as underwater. */
+    const seaBand=(minE<0)?'<rect x="'+padL+'" y="'+y0.toFixed(1)+'" width="'+(W-padL-padR)+'" height="'+Math.max(0,(H-padB-y0)).toFixed(1)+'" fill="rgba(38,118,200,0.30)"/>':'';
+    /* (#R13c) unit-aware compact labels for the elevation profile (imperial → ft / mi). */
+    const _um=(typeof HOST.unitMode!=='undefined')?HOST.unitMode:'both';
+    const elevC=(m)=>_um==='imperial'?(Math.round(m*3.28084).toLocaleString()+' ft'):(Math.round(m).toLocaleString()+' m');
+    const distC=(km)=>_um==='imperial'?((km*0.621371).toFixed(km*0.621371<10?1:0)+' mi'):(km.toFixed(km<10?1:0)+' km');
+    const svg='<svg id="elev-svg" width="'+W+'" height="'+H+'" viewBox="0 0 '+W+' '+H+'" style="display:block;max-width:100%;cursor:crosshair;">'
+      +(area?'<path d="'+area+'" fill="rgba(120,170,90,0.28)"/>':'')
+      +seaBand
+      +'<line x1="'+padL+'" y1="'+y0.toFixed(1)+'" x2="'+(W-padR)+'" y2="'+y0.toFixed(1)+'" stroke="rgba(40,120,200,0.85)" stroke-dasharray="3 3"/>'
+      +(dPath?'<path d="'+dPath+'" fill="none" stroke="#5aa02c" stroke-width="1.6"/>':'')
+      +'<line id="elev-vline" x1="0" y1="'+padT+'" x2="0" y2="'+(H-padB)+'" stroke="#ff3b30" stroke-width="1" style="display:none;"/>'
+      +'<circle id="elev-vdot" r="3.5" fill="#ff3b30" stroke="#fff" stroke-width="1.5" style="display:none;"/>'
+      +'<text x="3" y="'+(Y(maxE)+3).toFixed(1)+'" font-size="9" fill="currentColor">'+elevC(maxE)+'</text>'
+      +'<text x="3" y="'+(Y(minE)).toFixed(1)+'" font-size="9" fill="currentColor">'+elevC(minE)+'</text>'
+      +(minE<0?'<text x="3" y="'+(y0-2).toFixed(1)+'" font-size="9" fill="rgba(60,140,210,1)">0</text>':'')
+      +'</svg>';
+    box.innerHTML=svg+'<div id="elev-readout" style="display:flex;justify-content:space-between;color:var(--text-muted);font-size:10.5px;margin-top:2px;"><span>'+distC(0)+'</span><span id="elev-hover" style="color:var(--text-main);font-weight:600;"></span><span>'+distC(total)+'</span></div>';
+    /* Hover: vertical cursor on the chart + a synced marker on the map (#R11). */
+    const svgEl=box.querySelector('#elev-svg'), vline=box.querySelector('#elev-vline'), vdot=box.querySelector('#elev-vdot'), hov=box.querySelector('#elev-hover');
+    if(svgEl){ const move=(ev)=>{ const r=svgEl.getBoundingClientRect(); const cx=ev.touches?ev.touches[0].clientX:ev.clientX; let xv=(cx-r.left)/r.width*W; xv=Math.max(padL,Math.min(W-padR,xv)); const frac=(xv-padL)/(W-padL-padR); let idx=Math.round(frac*(samples.length-1)); idx=Math.max(0,Math.min(samples.length-1,idx)); const e=els[idx];
+        vline.setAttribute('x1',X(idx)); vline.setAttribute('x2',X(idx)); vline.style.display='block';
+        if(e!=null&&!isNaN(e)){ vdot.setAttribute('cx',X(idx)); vdot.setAttribute('cy',Y(e)); vdot.style.display='block'; if(hov) hov.textContent=distC(dist[idx])+' · '+elevC(e)+(e<0?' '+(j?'(海中)':'(below sea)'):''); }
+        _elevCursor(samples[idx]); };
+      svgEl.addEventListener('mousemove',move); svgEl.addEventListener('touchmove',move,{passive:true});
+      svgEl.addEventListener('mouseleave',()=>{ vline.style.display='none'; vdot.style.display='none'; if(hov) hov.textContent=''; _elevCursor(null); });
+    }
+  }
+  return { _openProfilePanel };
+};

--- a/js/map-readout.js
+++ b/js/map-readout.js
@@ -1,0 +1,370 @@
+/* ============================================================================
+ *  IntMap · Map readouts (coords / elevation / layer value / compass) and the graticule  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.mapReadout=function(map,HOST){
+  /* ===== Grid (zoom-adaptive, red equator) ===== */
+  function gridStepForZoom(z){
+    if(z<1.5) return {major:30,minor:10};
+    if(z<3)   return {major:15,minor:5};
+    if(z<5)   return {major:10,minor:2};
+    if(z<7)   return {major:5, minor:1};
+    if(z<9)   return {major:2, minor:0.5};
+    if(z<11)  return {major:1, minor:0.25};
+    if(z<13)  return {major:0.5,minor:0.1};
+    return    {major:0.1,minor:0.025};
+  }
+  function buildGridFeatures(){
+    if(!HOST.hasTurf()) return [];
+    const z=map?map.getZoom():2;
+    const {major,minor}=gridStepForZoom(z);
+    const b=map?map.getBounds():null;
+    let minLng=-180,maxLng=180,minLat=-80,maxLat=80;
+    if(b){
+      const pad=Math.max(major*2,2);
+      minLng=Math.max(-180,Math.floor(b.getWest()/major)*major-pad);
+      maxLng=Math.min(180, Math.ceil(b.getEast()/major)*major+pad);
+      minLat=Math.max(-85, Math.floor(b.getSouth()/major)*major-pad);
+      maxLat=Math.min(85,  Math.ceil(b.getNorth()/major)*major+pad);
+    }
+    const f=[];
+    /* Cap vertices PER LINE (scales with the visible span instead of a fixed dense step) — far
+       fewer points to build + upload, so the grid appears much faster (#15). On globe a line still
+       gets enough points to look curved; on flat it's nearly straight anyway. */
+    const latSpan=maxLat-minLat, lngSpan=maxLng-minLng;
+    const latStep=Math.max(minor, latSpan/30), lngStep=Math.max(minor, lngSpan/36);
+    const majLatStep=Math.max(major/2, latSpan/40), majLngStep=Math.max(major/2, lngSpan/48);
+    /* Minor lines */
+    for(let lng=Math.ceil(minLng/minor)*minor; lng<=maxLng; lng+=minor){
+      if(Math.abs(lng%major)<1e-6) continue;
+      const pts=[]; for(let la=minLat; la<=maxLat; la+=latStep) pts.push([lng,la]); pts.push([lng,maxLat]);
+      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'minor'}});
+    }
+    for(let lat=Math.ceil(minLat/minor)*minor; lat<=maxLat; lat+=minor){
+      if(Math.abs(lat%major)<1e-6 || Math.abs(lat)<1e-6) continue;
+      const pts=[]; for(let lo=minLng; lo<=maxLng; lo+=lngStep) pts.push([lo,lat]); pts.push([maxLng,lat]);
+      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'minor'}});
+    }
+    /* Major lines */
+    for(let lng=Math.ceil(minLng/major)*major; lng<=maxLng; lng+=major){
+      const pts=[]; for(let la=minLat; la<=maxLat; la+=majLatStep) pts.push([lng,la]); pts.push([lng,maxLat]);
+      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'major'}});
+    }
+    for(let lat=Math.ceil(minLat/major)*major; lat<=maxLat; lat+=major){
+      if(Math.abs(lat)<1e-6) continue; /* equator drawn separately in red */
+      const pts=[]; for(let lo=minLng; lo<=maxLng; lo+=majLngStep) pts.push([lo,lat]); pts.push([maxLng,lat]);
+      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'major'}});
+    }
+    /* Red equator */
+    if(minLat<=0 && maxLat>=0){
+      const pts=[]; const step=Math.max(major/4,1);
+      for(let lo=minLng; lo<=maxLng; lo+=step) pts.push([lo,0]);
+      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'equator'}});
+    }
+    /* Prime meridian */
+    if(minLng<=0 && maxLng>=0){
+      const pts=[]; const step=Math.max(major/4,1);
+      for(let la=minLat; la<=maxLat; la+=step) pts.push([0,la]);
+      if(pts.length>1) f.push({type:'Feature',geometry:{type:'LineString',coordinates:pts},properties:{kind:'prime'}});
+    }
+    /* Edge labels (along axes) */
+    const labelStep=major;
+    const c=map?map.getCenter():{lng:0,lat:0};
+    const baseLng=Math.max(minLng+major*0.5,Math.min(maxLng-major*0.5,c.lng));
+    const baseLat=Math.max(minLat+major*0.5,Math.min(maxLat-major*0.5,c.lat));
+    for(let lat=Math.ceil(minLat/labelStep)*labelStep; lat<=maxLat; lat+=labelStep){
+      if(Math.abs(lat)>85) continue;
+      f.push({type:'Feature',geometry:{type:'Point',coordinates:[baseLng,lat]},properties:{label:degLabel(+lat.toFixed(3),'lat')}});
+    }
+    for(let lng=Math.ceil(minLng/labelStep)*labelStep; lng<=maxLng; lng+=labelStep){
+      f.push({type:'Feature',geometry:{type:'Point',coordinates:[lng,baseLat]},properties:{label:degLabel(+lng.toFixed(3),'lng')}});
+    }
+    /* Intersection labels at major grid crossings — sparse so they don't clutter */
+    const crossStep=major*2;
+    for(let lat=Math.ceil(minLat/crossStep)*crossStep; lat<=maxLat; lat+=crossStep){
+      if(Math.abs(lat)>80) continue;
+      for(let lng=Math.ceil(minLng/crossStep)*crossStep; lng<=maxLng; lng+=crossStep){
+        if(Math.abs(lat)<1e-6 && Math.abs(lng)<1e-6) continue;
+        f.push({type:'Feature',geometry:{type:'Point',coordinates:[lng,lat]},properties:{kind:'cross',label:`${degLabel(+lat.toFixed(3),'lat')} ${degLabel(+lng.toFixed(3),'lng')}`}});
+      }
+    }
+    return f;
+  }
+  let gridRebuildTimer=null, _gridKey='';
+  function refreshGrid(){
+    if(!HOST.isGridOn||!map||!map.getSource('grid-source')) return;
+    clearTimeout(gridRebuildTimer);
+    gridRebuildTimer=setTimeout(()=>{
+      try{
+        /* Skip the rebuild if the zoom-step + rounded viewport haven't really changed (#15) — avoids
+           re-tessellating the whole grid on every tiny pan/rotate of the globe. */
+        const z=map.getZoom(), {major,minor}=gridStepForZoom(z), b=map.getBounds();
+        const key=major+'/'+minor+'/'+(b?[b.getWest(),b.getEast(),b.getSouth(),b.getNorth()].map(v=>Math.round(v/Math.max(major,1))).join(','):'');
+        if(key===_gridKey) return; _gridKey=key;
+        map.getSource('grid-source').setData({type:'FeatureCollection',features:buildGridFeatures()});
+      }catch(e){}
+    },90);
+  }
+  /* (#R38) ROOT FIX for "Grid & labels が何度消しても自動的にチェックされる": toggleGrid() used to blindly FLIP
+     isGridOn on every checkbox change. The R36 async-race guard re-dispatches a `change` on a box that went OFF
+     (idempotent for normal layers, which READ e.target.checked) — but the flip made that re-dispatch turn Grid
+     back ON ~500ms later. Split into an IDEMPOTENT setGrid(on) (drives state FROM the box) + a toggleGrid() for
+     the toolbar button. The checkbox change now calls setGrid(checked), so a stray/duplicate change can never
+     re-enable Grid. */
+  function setGrid(on){
+    on=!!on; HOST.isGridOn=on;
+    const gb=document.getElementById('btn-tool-grid'); if(gb) gb.classList.toggle('tool-on',HOST.isGridOn);
+    const gcb=document.getElementById('cb-grid'); if(gcb && gcb.checked!==HOST.isGridOn) gcb.checked=HOST.isGridOn;   /* (#R10) Grid now lives in the Layers menu */
+    document.querySelectorAll('[data-proxy="cb-grid"]').forEach(x=>x.classList.toggle('active',HOST.isGridOn));
+    _gridKey='';
+    if(!map||!map.getSource('grid-source'))return;
+    if(HOST.isGridOn) map.getSource('grid-source').setData({type:'FeatureCollection',features:buildGridFeatures()});
+    else map.getSource('grid-source').setData({type:'FeatureCollection',features:[]});
+  }
+  function degLabel(v,k){ if(v===0)return'0°'; const d=k==='lat'?(v>0?'N':'S'):(v>0?'E':'W'); return Math.abs(v)+'°'+d; }
+  function showMeasureTip(pt,txt){ const el=document.getElementById('measure-tooltip'); if(!el) return; el.innerText=txt; el.style.display='block';
+    /* (#R14/#7) keep the measure tooltip inside the map — it's drawn translate(12px,-50%), so flip it to
+       the LEFT of the point near the right edge and clamp Y, instead of overflowing off-screen. */
+    try{ const mc=document.getElementById('map-container').getBoundingClientRect(); const w=el.offsetWidth||120, h=el.offsetHeight||24;
+      el.style.transform=(pt.x+12+w > mc.width-6)?('translate(-'+(w+12)+'px,-50%)'):'translate(12px,-50%)';
+      el.style.left=Math.max(6,Math.min(mc.width-6,pt.x))+'px';
+      el.style.top=Math.max(h/2+6,Math.min(mc.height-h/2-6,pt.y))+'px';
+    }catch(_){ el.style.left=pt.x+'px'; el.style.top=pt.y+'px'; }
+  }
+  function handleMapClick(lng,lat,point,viaBtn){
+    if(window.__scpPick) return;   /* (#R86) Compare "pick a country on the map" mode owns the click */
+    /* (#R7-draw) The freehand Draw tool owns the map gesture while it is active. */
+    if(window.DrawTool && window.DrawTool.active()) return;
+    /* Köppen click-to-highlight (#25): when the climate layer is on, clicking the map highlights
+       (toggles) the climate zone at that point. Works whether or not a measurement tool is active. */
+    try{
+      const climCb=document.getElementById('dl-climate');
+      if(climCb && climCb.checked && window.sampleKoppenAt){
+        /* (#R122) do NOT also toggle/highlight the climate zone when the tap is opening a place-label popup —
+           the click landed on a place name, not on empty climate raster ("地名ラベルをクリックする際、その
+           クリック地点の気候区分までクリックされ…ないように"). */
+        let onLabel=false;
+        try{ const pt=point||(map&&map.project([lng,lat]));
+          if(pt&&map){ const ls=['ofm-country','ofm-city','ofm-other','geo-sea','ofm-water','ofm-water2','ofm-river','ofm-peak'].filter(id=>map.getLayer(id));
+            if(ls.length){ const pad=(typeof HOST.isMobile==='function'&&HOST.isMobile())?15:6; const near=map.queryRenderedFeatures([[pt.x-pad,pt.y-pad],[pt.x+pad,pt.y+pad]],{layers:ls}); if(near&&near.length) onLabel=true; } } }catch(_){}
+        if(!onLabel){ const code=window.sampleKoppenAt(lng,lat);
+          if(code && window.kSelected){
+            window.kSelected.has(code)?window.kSelected.delete(code):window.kSelected.add(code);
+            if(window._buildKoppenLegend) window._buildKoppenLegend();
+            if(window._refreshKoppenImage) window._refreshKoppenImage();
+          }
+        }
+      }
+    }catch(_){}
+    /* On phones, tapping the map outside a legend collapses any expanded legend so it stops
+       covering the map (#29). */
+    try{ if(HOST.isMobile() && window._minimizeOpenLegends) window._minimizeOpenLegends(); }catch(_){}
+    if(!HOST.toolMode||!HOST.hasTurf())return;
+    /* (#R11) On mobile, measuring is center-fixed: a tap does NOT add a point — only the "Add point"
+       button (which calls this with viaBtn=true) adds the map-center coordinate. */
+    if(HOST.isMobile() && !viaBtn) return;
+    /* Polar safety (#10): the poles AND their surroundings are singular for great-circle / area
+       math and make turf emit NaN or globe-wrapping geometry. Clamp out of the polar caps. */
+    lat=Math.max(-88,Math.min(88,lat));
+    /* Don't add a measure point if the click landed on an existing pin or intel marker */
+    if(point && map){
+      try{
+        const hit=map.queryRenderedFeatures(point,{layers:['user-pin-dot','news-dots','dash-dots'].filter(l=>map.getLayer(l))});
+        if(hit&&hit.length) return;
+      }catch(e){}
+    }
+    if(HOST.toolMode==='radius'){
+      const rid='r_'+Date.now()+'_'+Math.random().toString(36).slice(2,6);
+      HOST.radiusItems.push({id:rid,center:[lng,lat],radiusKm: HOST.radiusKm,color:HOST.radiusColor,opacity:HOST.radiusOpacity}); window._activeRadiusId=rid;
+      HOST.refreshTool(); HOST.updateToolPanel(); return;
+    }
+    /* === Auto-close for the Measure tool: if 3+ points and the new click lands within
+       SNAP_PX of the start point (the highlighted vertex), close into AREA mode. The same
+       threshold drives the on-map highlight so "add vs. close" is unambiguous (#47). */
+    if(HOST.toolMode==='measure' && HOST.measurePoints.length>=3 && point){
+      try{
+        const pStart=map.project(HOST.measurePoints[0]);
+        const dx=pStart.x-point.x, dy=pStart.y-point.y;
+        if(Math.hypot(dx,dy)<HOST.SNAP_PX){
+          HOST.toolMode='area'; HOST.measureSnapClose=false;
+          document.getElementById('measure-tooltip').classList.remove('closing');
+          HOST._syncToolBtns();
+          HOST.refreshTool(); HOST.updateToolPanel();
+          return;
+        }
+      }catch(_){}
+    }
+    HOST.measurePoints.push([lng,lat]); HOST.refreshTool(); HOST.updateToolPanel();
+  }
+  const _elevCache=new Map();
+  function fmtLL(lng,lat){ return `${Math.abs(lat).toFixed(3)}°${lat>=0?'N':'S'}  ${Math.abs(lng).toFixed(3)}°${lng>=0?'E':'W'}`; }
+  function renderCoordReadout(lng,lat){
+    const el=document.getElementById('coord-readout'); if(!el) return;
+    if(lng!=null){ HOST._crLng=lng; HOST._crLat=lat; }
+    if(HOST._crLng==null){ el.style.display='none'; return; }
+    const parts=[];
+    parts.push(`<span>${fmtLL(HOST._crLng,HOST._crLat)}</span>`); parts.push(`<span class="cr-elev">${HOST.lastElev||'·····'}</span>`);
+    if(HOST.lastLayerVal) parts.push(`<span class="cr-sat">${HOST.lastLayerVal}</span>`);
+    /* (#R8c) Live wind speed/direction under the cursor while the Wind layer is on. */
+    /* (#R19) No emoji in the always-on readout ("🌬みたいな絵文字は…いらない") — value + direction only. */
+    try{ if(window.Wind&&window.Wind.on&&window.Wind.on()){ const w=window.Wind.sampleAt(HOST._crLng,HOST._crLat); if(w){ const card=['N','NE','E','SE','S','SW','W','NW'][Math.round(w.dir/45)%8]; const sp=window.fmtWindSpeed?window.fmtWindSpeed(w.speed):(w.speed.toFixed(1)+' m/s'); parts.push(`<span class="cr-wind">${sp} ${card}</span>`); } } }catch(_){}
+    /* Satellite-imagery chip removed from the readout per request — coords + elevation only. */
+    if(!parts.length){ el.style.display='none'; return; }
+    el.style.display='flex';
+    el.innerHTML=parts.join('');
+  }
+  /* === Instant elevation/depth from cached terrarium DEM tiles (includes ocean bathymetry) === */
+  const _demCache=new Map();
+  function _demCacheTrim(){ if(_demCache.size<=HOST._DEM_CACHE_MAX) return;
+    for(const k of _demCache.keys()){ if(_demCache.size<=HOST._DEM_CACHE_MAX) break; const v=_demCache.get(k); if(v==='loading') continue; _demCache.delete(k); } }
+  /* (#R19) Per-tile decoded pixel buffer, extracted ONCE. demElevBilinear used to call a full 256×256
+     getImageData (a ~256 KB copy) for EVERY sample — ~72,000 samples per LOS run ≈ 18 GB of memory
+     traffic, which is exactly the "Line of sightを使うとパソコンでもブラウザがフリーズ" freeze. */
+  function _demPix(cv){ if(!cv||cv==='loading') return null;
+    if(!cv.__pix){ try{ cv.__pix=cv.getContext('2d',{willReadFrequently:true}).getImageData(0,0,256,256).data; }catch(e){ return null; } }
+    return cv.__pix; }
+  function _ll2tile(lng,lat,z){ const n=Math.pow(2,z); const x=(lng+180)/360*n; const lr=lat*Math.PI/180; const y=(1-Math.log(Math.tan(lr)+1/Math.cos(lr))/Math.PI)/2*n; return {x,y,n}; }
+  /* Pick a DEM tile-zoom matched to the map zoom. Zoomed out → low z (a handful of tiles cover the
+     whole view, so the readout is instant everywhere). Zoomed in → high z (sharper elevation). */
+  function demZoomForMap(){ let mz=4; try{ if(map) mz=map.getZoom(); }catch(_){} return Math.max(3,Math.min(12,Math.round(mz)+1)); }
+  function demElevAt(lng,lat,onReady,zArg){
+    const z=(zArg!=null?zArg:demZoomForMap()); const tl=_ll2tile(lng,lat,z); const xi=Math.floor(tl.x), yi=Math.floor(tl.y);
+    if(xi<0||yi<0||xi>=tl.n||yi>=tl.n||lat>85||lat<-85) return null;
+    const key=z+'/'+xi+'/'+yi; let c=_demCache.get(key);
+    if(c===undefined){
+      _demCacheTrim();
+      _demCache.set(key,'loading');
+      const img=new Image(); img.crossOrigin='anonymous';
+      img.onload=()=>{ try{ const cv=document.createElement('canvas'); cv.width=256; cv.height=256; cv.getContext('2d',{willReadFrequently:true}).drawImage(img,0,0); _demCache.set(key,cv); if(onReady) onReady(); }catch(e){ _demCache.set(key,null); } };
+      img.onerror=()=>_demCache.set(key,null);
+      img.src=`https://s3.amazonaws.com/elevation-tiles-prod/terrarium/${z}/${xi}/${yi}.png`;
+      return null;
+    }
+    if(c==='loading'||c===null) return null;
+    /* (#R19) read from the per-tile decoded buffer — no per-sample getImageData */
+    const d=_demPix(c); if(!d) return null;
+    const px=Math.min(255,Math.max(0,Math.floor((tl.x-xi)*256))), py=Math.min(255,Math.max(0,Math.floor((tl.y-yi)*256)));
+    const i=(py*256+px)*4; return (d[i]*256+d[i+1]+d[i+2]/256)-32768;
+  }
+  /* === Shared async DEM sampler (#R12) — used by the elevation profile and line-of-sight viewshed.
+     Warms every terrarium tile covering a set of points, then samples them LOCALLY. The terrarium
+     DEM carries ocean bathymetry (negative = below sea level), so profiles dip under water and the
+     viewshed reads real terrain — replacing the old per-point Open-Meteo fetch that fired hundreds
+     of requests at once and silently failed (the root cause of "Line of Sight doesn't work"). */
+  function _demZoomForSpan(km){ return Math.max(5, Math.min(13, Math.round(Math.log2(481000/Math.max(1,km))))); }
+  /* (#R18) onProgress(frac 0..1) lets callers (Line of Sight / elevation profile) show a real % + bar
+     while the covering DEM tiles load — the slow part of a viewshed ("計算の進捗をパーセントで表示"). */
+  function warmDEMTiles(points, z, timeoutMs, onProgress){
+    const keys=new Set();
+    points.forEach(p=>{ if(!p) return; const tl=_ll2tile(p[0],p[1],z); const xi=Math.floor(tl.x), yi=Math.floor(tl.y); if(xi>=0&&yi>=0&&xi<tl.n&&yi<tl.n){ keys.add(z+'/'+xi+'/'+yi); demElevAt(p[0],p[1],null,z); } });
+    const total=keys.size||1;
+    return new Promise(res=>{ const t0=Date.now(); (function poll(){ let pending=0; keys.forEach(k=>{ const c=_demCache.get(k); if(c===undefined||c==='loading') pending++; }); if(onProgress){ try{ onProgress((total-pending)/total); }catch(_){} } if(pending===0||Date.now()-t0>(timeoutMs||9000)) res(); else setTimeout(poll,90); })(); });
+  }
+  /* (#R18) Bilinear DEM sample for the viewshed — smooths the stair-stepping of nearest-pixel sampling so
+     ridge lines (which decide what's blocked) are physically truer. Reads the 4 surrounding texels and
+     interpolates; falls back to nearest at tile edges. Tiles must already be warm (LOS warms them first). */
+  function demElevBilinear(lng,lat,z){
+    const tl=_ll2tile(lng,lat,z); const xi=Math.floor(tl.x), yi=Math.floor(tl.y);
+    if(xi<0||yi<0||xi>=tl.n||yi>=tl.n||lat>85||lat<-85) return null;
+    const cv=_demCache.get(z+'/'+xi+'/'+yi); if(!cv||cv==='loading') return null;
+    const d=_demPix(cv); if(!d) return null;   /* (#R19) decoded once per tile, not per sample */
+    const fx=(tl.x-xi)*256-0.5, fy=(tl.y-yi)*256-0.5;
+    const x0=Math.max(0,Math.min(255,Math.floor(fx))), y0=Math.max(0,Math.min(255,Math.floor(fy)));
+    const x1=Math.min(255,x0+1), y1=Math.min(255,y0+1); const tx=Math.max(0,Math.min(1,fx-x0)), ty=Math.max(0,Math.min(1,fy-y0));
+    const el=(px,py)=>{ const i=(py*256+px)*4; return (d[i]*256+d[i+1]+d[i+2]/256)-32768; };
+    const a=el(x0,y0), b=el(x1,y0), c=el(x0,y1), e=el(x1,y1);
+    return (a*(1-tx)+b*tx)*(1-ty)+(c*(1-tx)+e*tx)*ty;
+  }
+  /* Elevation/depth respects the measurement-units setting (#R13c): imperial → feet, both → "m (ft)". */
+  function fmtElevVal(e){ const m=Math.round(e), ft=Math.round(e*3.28084); const um=(typeof HOST.unitMode!=='undefined')?HOST.unitMode:'both'; return um==='imperial'?(ft.toLocaleString()+' ft'):um==='metric'?(m.toLocaleString()+' m'):(m.toLocaleString()+' m ('+ft.toLocaleString()+' ft)'); }
+  /* Live weather-layer value at the cursor (#12): Köppen is instant (pixel sample); SST / air-temp
+     are fetched seamlessly from Open-Meteo (debounced + cached per ~0.1°). */
+  let _wxTimer=null;
+const _wxCache=new Map();
+  function activeWxLayer(){ const on=id=>{ const cb=document.getElementById('dl-'+id); return cb&&cb.checked; }; return on('sst')?'sst':on('temp')?'temp':on('climate')?'climate':null; }
+  function updateLayerReadout(lng,lat){
+    const lyr=activeWxLayer();
+    if(!lyr){ /* no weather layer → show the active numeric choropleth's value at the cursor (#R13c) */
+      let cv=null; try{ cv=window.choroValueAt&&window.choroValueAt(lng,lat); }catch(_){}
+      HOST.lastLayerVal = cv||''; return; }
+    if(lyr==='climate'){ let code=null; try{ code=window.sampleKoppenAt&&window.sampleKoppenAt(lng,lat); }catch(_){}
+      /* no leading emoji on the layer value (#34) */
+      HOST.lastLayerVal = code ? (code+(window.KNAME&&window.KNAME[code]?' · '+(window.KNAME[code][HOST.lang]||window.KNAME[code].en):'')) : ''; return; }
+    /* (#R27) Cache on a COARSER 0.25° grid (was 0.1°). SST / air-temp barely change over ~28 km, so a
+       coarser grid means the cursor lands on an ALREADY-cached cell far more often → the value is shown
+       instantly (no fetch) across a whole local area, and far fewer network calls fire. This is the main
+       "数値が変わるのが遅い" lever — the per-cell fetch was the only real latency. */
+    const q=(v)=>(Math.round(v*4)/4);                        /* snap to 0.25° */
+    const qla=q(lat), qlo=q(lng), key=lyr+':'+qla.toFixed(2)+','+qlo.toFixed(2);
+    if(_wxCache.has(key)){ HOST.lastLayerVal=_wxCache.get(key); return; }
+    /* (#R25/#R27) Show the nearest already-cached neighbor INSTANTLY so the readout tracks the cursor with
+       no blank/stale gap; the exact fetch refines it below. Tolerance widened (0.6°→1.5°) so the readout
+       stays populated while panning into a new region. */
+    try{ let best=null,bd=1e9;
+      for(const k of _wxCache.keys()){ if(k.slice(0,key.indexOf(':'))!==lyr) continue; const m=k.split(':')[1].split(','); const d=Math.abs(+m[0]-qla)+Math.abs(+m[1]-qlo); if(d<bd){ bd=d; best=k; } }
+      if(best&&bd<=1.5){ HOST.lastLayerVal=_wxCache.get(best); } }catch(_){}
+    clearTimeout(_wxTimer);
+    _wxTimer=setTimeout(async()=>{
+      try{
+        let url,pick;   /* fetch the CELL CENTER so the cached value matches the key */
+        if(lyr==='sst'){ url=`https://marine-api.open-meteo.com/v1/marine?latitude=${qla.toFixed(3)}&longitude=${qlo.toFixed(3)}&current=sea_surface_temperature`; pick=j=>j&&j.current&&j.current.sea_surface_temperature; }
+        else { url=`https://api.open-meteo.com/v1/forecast?latitude=${qla.toFixed(3)}&longitude=${qlo.toFixed(3)}&current=temperature_2m`; pick=j=>j&&j.current&&j.current.temperature_2m; }
+        const r=await fetch(url); if(!r.ok) return; const j=await r.json(); const v=pick(j);
+        if(typeof v==='number'){ const um=window.imUnitTemp||'both'; const txt = um==='f' ? (v*9/5+32).toFixed(1)+'°F' : um==='c' ? v.toFixed(1)+'°C' : v.toFixed(1)+'°C ('+(v*9/5+32).toFixed(1)+'°F)'; _wxCache.set(key,txt); HOST.lastLayerVal=txt; renderCoordReadout(lng,lat); }   /* unit-aware (#R13c); no leading emoji (#34) */
+      }catch(_){}
+    },30);
+  }
+  /* (#R25) Coalesce the per-move readout to ONE animation frame with the LATEST cursor position, so fast
+     mouse movement can't build a backlog of heavy updateCoord calls (queryRenderedFeatures + DEM + DOM)
+     that made the value/classification visibly lag behind the cursor ("カーソルを動かしているのに遅い"). */
+  let _ucRAF=0,_ucLng=null,_ucLat=null;
+  function updateCoord(lng,lat){ if(HOST.isMobile()) return; _ucLng=lng; _ucLat=lat; if(_ucRAF) return;
+    _ucRAF=requestAnimationFrame(()=>{ _ucRAF=0; try{ _updateCoordNow(_ucLng,_ucLat); }catch(_){} }); }
+  function _updateCoordNow(lng,lat){
+    if(HOST.isMobile()) return;
+    try{ updateLayerReadout(lng,lat); }catch(_){}
+    /* Instant: read elevation/depth straight from a cached DEM tile (no network). */
+    const dem=demElevAt(lng,lat,()=>{ const d2=demElevAt(lng,lat); if(d2!=null){ HOST.lastElev=HOST.elevText(d2); renderCoordReadout(lng,lat); } });
+    if(dem!=null){ HOST.lastElev=HOST.elevText(dem); renderCoordReadout(lng,lat); return; }
+    /* Tile still loading → show coords now, fall back to network elevation briefly. */
+    const ckey=lat.toFixed(2)+','+lng.toFixed(2);
+    HOST.lastElev=_elevCache.has(ckey)?_elevCache.get(ckey):'';
+    renderCoordReadout(lng,lat);
+    clearTimeout(HOST.elevTimer);
+    if(!_elevCache.has(ckey)) HOST.elevTimer=setTimeout(()=>{ fetchElev(lng,lat); },80);
+  }
+  /* GEBCO 2020 bathymetry (real ocean depth) via CORS proxy — Open-Meteo returns 0 over water. */
+  const _bathyCache=new Map();
+  async function fetchBathymetry(lat,lng){
+    const key=lat.toFixed(2)+','+lng.toFixed(2);
+    if(_bathyCache.has(key)) return _bathyCache.get(key);
+    const u=`https://api.opentopodata.org/v1/gebco2020?locations=${lat.toFixed(4)},${lng.toFixed(4)}`;
+    const proxies=[ x=>`https://api.allorigins.win/raw?url=${encodeURIComponent(x)}`, x=>`https://corsproxy.io/?url=${encodeURIComponent(x)}`, x=>`https://api.codetabs.com/v1/proxy/?quest=${encodeURIComponent(x)}` ];
+    for(const mk of proxies){
+      try{ const r=await fetch(mk(u)); if(!r.ok) continue; const j=await r.json(); const v=j&&j.results&&j.results[0]&&j.results[0].elevation; if(typeof v==='number'){ _bathyCache.set(key,v); return v; } }catch(_){}
+    }
+    return null;
+  }
+  async function fetchElev(lng,lat){
+    const rLat=lat, rLng=lng, seq=++HOST._elevSeq;
+    const ckey=rLat.toFixed(2)+','+rLng.toFixed(2);
+    const set=(txt)=>{ _elevCache.set(ckey,txt); if(seq===HOST._elevSeq){ HOST.lastElev=txt; renderCoordReadout(rLng,rLat); } };
+    try{
+      const r=await fetch(`https://api.open-meteo.com/v1/elevation?latitude=${rLat.toFixed(4)}&longitude=${rLng.toFixed(4)}`);
+      let e=null; if(r.ok){ const j=await r.json(); e=j&&j.elevation&&j.elevation[0]; }
+      if(typeof e==='number' && e>0.5){ set(HOST.elevText(e)); return; }
+      /* At/below sea level → fetch true depth from GEBCO bathymetry. */
+      const d=await fetchBathymetry(rLat,rLng);
+      if(typeof d==='number'){ set(HOST.elevText(d)); }
+      else if(typeof e==='number'){ set(HOST.elevText(e)); }
+    }catch(_){}
+  }
+  function updateCompass(){ const s=document.querySelector('.compass-svg'); if(s&&map)s.style.transform=`rotate(${-map.getBearing()}deg)`; }
+  return { _demZoomForSpan, demElevAt, demElevBilinear, demZoomForMap, fetchBathymetry, fmtElevVal, fmtLL, handleMapClick, refreshGrid, renderCoordReadout, setGrid, showMeasureTip, updateCompass, updateCoord, updateLayerReadout, warmDEMTiles };
+};

--- a/js/news-context.js
+++ b/js/news-context.js
@@ -1,0 +1,193 @@
+/* ============================================================================
+ *  IntMap · News article → place/publisher resolution  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.newsContext=function(map,HOST){
+  function matchPublisher(publisher){ if(!publisher) return null;
+    for(const m of HOST._pubMatchers){ if(m.cjk?publisher.includes(m.label):m.re.test(publisher)) return m; }
+    /* (#R32) Non-AI publisher-location BOOST ("AIを用いない発信地解析を強化 / 位置不明のピンが多い"): a huge
+       share of Google-News sources are LOCAL outlets whose name embeds their city/region/country
+       ("Manila Bulletin", "Kashmir Observer", "Texas Tribune", "Nairobi News"…). When the curated dict
+       misses, scan the publisher string against the place gazetteer and use the most specific match, so far
+       fewer publisher pins land "unknown". Skip demonyms/orgs and very short terms to avoid false hits. */
+    try{ if(typeof HOST.geoDB!=='undefined' && HOST.geoDB){ let best=null,bestLen=0,bestLocal=-1;
+      for(const g of HOST.geoDB){ if(g.demonym||g.org||!g._terms) continue;
+        for(const t of g._terms){ const term=t.term; if(!term||term.length<4) continue;
+          const hit = t.jp ? publisher.includes(term) : (t.matchRe&&t.matchRe.test(publisher));
+          if(hit){ const loc=(typeof TYPE_LOCAL!=='undefined'?(TYPE_LOCAL[g.type]||0):0);
+            if(term.length>bestLen || (term.length===bestLen && loc>bestLocal)){ best=g; bestLen=term.length; bestLocal=loc; } } } }
+      if(best) return { loc:best.loc, label:(best.name&&(best.name[HOST.lang]||best.name.en))||'', cjk:false }; } }catch(_){}
+    return null; }
+  /* Precompile per-term matchers once (runs ≈290 entries × N news items on every refresh):
+       jp      — CJK terms match by substring; Latin terms match on word boundaries
+       matchRe — word-boundary matcher for Latin terms
+       ctxRe   — "is this place governed by a locational preposition / particle?"
+                 EN: in/at/to/from/near/into <place>   ·   JP: <place>で/へ/に/を/から */
+  function isCJKTerm(term){ return /[　-鿿]/.test(term); }
+  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
+  const {_DERU_GZ,_DERU_DEM,_ES_GZ,_ES_DEM}=window.IntMapTables;
+  /* Rebuild the flat geoDB + per-term matchers from geoRaw. Called after the
+     Supabase geo_pins load (and on realtime updates). */
+  function rebuildGeoIndex(){
+    /* Merge the always-present built-in gazetteer (#11) with the Supabase geo_pins so news placement
+       is strong even before/without server data. */
+    const merged={};
+    [HOST.BUILTIN_GAZETTEER, HOST.geoRaw].forEach(src=>{ for(const type in src){ (merged[type]=merged[type]||[]).push(...src[type]); } });
+    /* (#R25/#28) MASSIVE coverage boost for the non-AI locator: auto-add EVERY country (+ its capital name)
+       from the already-bundled countryStats — ~200 countries with real EN/JP names and a representative
+       point. Curated cities/flashpoints still outrank these (higher TYPE_SCORE + lead-position bonus), so
+       precision is unchanged; this just means almost any country/capital mention now places. */
+    try{ if(typeof HOST.countryStats==='object'&&HOST.countryStats){ for(const code in HOST.countryStats){ const s=HOST.countryStats[code];
+      if(!s||!s.latlng||s.latlng[0]==null||s.latlng[1]==null) continue;
+      const terms=[]; if(s.nameEn) terms.push(s.nameEn); if(s.nameJp&&s.nameJp!==s.nameEn) terms.push(s.nameJp);
+      if(s.capital&&String(s.capital).length>=4) terms.push(s.capital);
+      if(!terms.length) continue;
+      (merged.country=merged.country||[]).push({terms, loc:[s.latlng[1],s.latlng[0]], name:{en:s.nameEn||code, jp:s.nameJp||s.nameEn||code}}); } } }catch(_){}
+    /* (#R27) demonyms join as low-confidence country entries (flagged so scoreGeo ranks them below a real
+       place name) — coverage for "Ukrainian/Israeli/Iranian…" headlines that name no explicit place. */
+    try{ for(const [dem,lng,lat,en,jp] of HOST._DEMONYM_GZ){ (merged.country=merged.country||[]).push({terms:[dem], loc:[lng,lat], name:{en,jp}, demonym:true}); } }catch(_){}
+    /* (#R28) organizations / institutions / armed groups join as flagged org:true entries — docked below an
+       explicit place (see scoreGeo) so they only place a story that names no explicit city/country. */
+    try{ for(const [terms,lng,lat,en,jp] of HOST._ORG_GZ){ (merged.country=merged.country||[]).push({terms:terms.slice(), loc:[lng,lat], name:{en,jp}, org:true}); } }catch(_){}
+    /* (#R39) German + Russian places (full DE exonyms / RU stems) and Russian demonyms. */
+    try{ for(const [type,terms,lng,lat,en,jp] of _DERU_GZ){ (merged[type]=merged[type]||[]).push({terms:terms.slice(), loc:[lng,lat], name:{en,jp}}); } }catch(_){}
+    try{ for(const [dem,lng,lat,en,jp] of _DERU_DEM){ (merged.country=merged.country||[]).push({terms:[dem], loc:[lng,lat], name:{en,jp}, demonym:true}); } }catch(_){}
+    /* (#R40) Spanish exonyms + demonyms (same shape) — gives the non-AI locator full Spanish coverage. */
+    try{ for(const [type,terms,lng,lat,en,jp] of _ES_GZ){ (merged[type]=merged[type]||[]).push({terms:terms.slice(), loc:[lng,lat], name:{en,jp}}); } }catch(_){}
+    try{ for(const [dem,lng,lat,en,jp] of _ES_DEM){ (merged.country=merged.country||[]).push({terms:[dem], loc:[lng,lat], name:{en,jp}, demonym:true}); } }catch(_){}
+    HOST.geoDB=Object.entries(merged).flatMap(([type,arr])=>arr.map(g=>({...g,type})));
+    /* (#R161) hand the ADMIN-CURATED Supabase geo_pins to the NewsGeo engine too, so a place an
+       operator added in admin.html is matchable by the primary locator and not only by the legacy
+       fallback. Registered at a lower rank than the built-in gazetteer (curated rows add coverage,
+       they never override a verified place) and de-duplicated inside register(), which matters
+       because this function re-runs on every geo_pins realtime update. */
+    try{ if(window.IntMapNewsGeo&&window.IntMapNewsGeo.register){
+      const extra=[]; for(const type in HOST.geoRaw){ for(const g of (HOST.geoRaw[type]||[])){
+        if(!g||!g.loc||!Array.isArray(g.terms)||!g.terms.length) continue;
+        extra.push({ terms:g.terms, lng:g.loc[0], lat:g.loc[1], type, name_en:(g.name&&g.name.en)||g.terms[0], name_jp:(g.name&&g.name.jp)||'' }); } }
+      if(extra.length) window.IntMapNewsGeo.register(extra);
+    } }catch(_){}
+    /* longer keywords first → "Tel Aviv" wins over "Israel" (stable tiebreaker on equal scores) */
+    HOST.geoDB.sort((a,b)=>Math.max(...b.terms.map(t=>t.length)) - Math.max(...a.terms.map(t=>t.length)));
+    HOST.geoDB.forEach(g=>{
+      g._terms=g.terms.map(term=>{
+        const jp=isCJKTerm(term), cyr=/[Ѐ-ӿ]/.test(term), esc=term.replace(/[.*+?^${}()|[\]\\]/g,'\\$&');
+        /* (#R39) Cyrillic/Russian path: JS `\b` word-boundaries don't fire around Cyrillic (it isn't `\w`),
+           AND Russian inflects heavily — so match the supplied STEM plus up to 4 trailing Cyrillic letters,
+           bounded by a non-Cyrillic-letter on the left (a consuming prefix, not lookbehind, for old-Safari
+           safety). e.g. stem «Москв» → Москва/Москве/Москвы/Москву; «Росси» → России/Россию. */
+        if(cyr){ return { term, jp:false, cyr:true,
+          matchRe: new RegExp('(?:^|[^А-Яа-яЁёІіЇїЄє])'+esc+'[а-яёіїєa-z]{0,4}','i'),
+          ctxRe:   new RegExp('(?:в|во|на|из|под|у|около)\\s+'+esc,'i') }; }
+        return { term, jp,
+          matchRe: jp?null:new RegExp(`\\b${esc}\\b`,'i'),
+          ctxRe:   jp?new RegExp(`${esc}(?:で|へ|に|を|から|では)`)
+                     :new RegExp(`\\b(?:in|at|to|from|near|into)\\s+${esc}\\b`,'i') };
+      });
+    });
+  }
+  /* ===== Scoring model (replaces the old "first geo term wins" loop) =====
+     Every geo entry is scored over the title + description; the highest score is the Subject.
+        title hit          +10   strong signal — the headline names the place
+        description hit     +3    supporting signal from the article snippet
+        type "flashpoint"   +5    conflict zone / chokepoint → high news relevance
+        type "city"         +2    precise locality
+        locational context  +4    "in Gaza" / "ガザで" → the place is the story's setting
+     Ties break toward the more local type (flashpoint > city > country > region). */
+  const TYPE_SCORE={ flashpoint:5, city:2, country:0, region:0 };
+  const TYPE_LOCAL={ flashpoint:4, city:3, country:2, region:1 };
+  function scoreGeo(g,title,desc){
+    let titleHit=false, descHit=false, ctx=false, firstIdx=Infinity;
+    for(const t of g._terms){
+      if(t.jp){ const i=title.indexOf(t.term); if(i>=0){ titleHit=true; if(i<firstIdx) firstIdx=i; if(!ctx&&t.ctxRe.test(title)) ctx=true; } }
+      else { const i=title.search(t.matchRe); if(i>=0){ titleHit=true; if(i<firstIdx) firstIdx=i; if(!ctx&&t.ctxRe.test(title)) ctx=true; } }
+      if(desc&&(t.jp?desc.includes(t.term):t.matchRe.test(desc))){ descHit=true; if(!ctx&&t.ctxRe.test(desc)) ctx=true; }
+    }
+    if(!titleHit&&!descHit) return 0;
+    /* (#R25/#28) Lead-subject bonus: a place named EARLY in the headline is much more likely to be what the
+       story is about (e.g. "Kyiv strikes …" → Kyiv, not a country mentioned at the end). Up to +3. */
+    const tl=title.length||1; const posBonus = titleHit ? Math.max(0, 3-Math.floor((Math.min(firstIdx,tl)/tl)*4)) : 0;
+    /* (#R27) Corroboration bonus: a place named in BOTH the title AND the description is a stronger subject
+       signal (+2). Demonym entries ("Ukrainian"…) are docked 3 so an explicit place name always outranks
+       them — they only win when nothing more specific matched, preserving precision while adding coverage. */
+    const corro = (titleHit&&descHit) ? 2 : 0;
+    /* (#R28) demonyms AND organizations/groups are docked so an explicit place name always outranks them
+       (an "Ukrainian"/"Hamas"/"NATO" mention only places a story that names no explicit city/country). */
+    const demPen = (g.demonym||g.org) ? 3 : 0;
+    return (titleHit?10:0)+(descHit?3:0)+(TYPE_SCORE[g.type]||0)+(ctx?4:0)+posBonus+corro-demPen;
+  }
+  /* (#R107) COUNTRY-LEVEL FALLBACK for the non-AI locator ("more reliable and flawless"): when the gazetteer scored
+     no specific place, anchor a country-level story to the country actually named (its polygon center) instead of a
+     meaningless deterministic scatter point — so far fewer "location unknown" pins, and always a REAL, correct place.
+     Purely ADDITIVE: it only runs when no subject was found, so it can never make an existing result worse. Built once
+     from countryGeo (bbox centers + word-boundary name regexes), memoized; the display name follows the UI language. */
+  let _cfIdx=null;
+  function _cfBuild(){ try{ const cg=window.countryGeo; if(!cg||!cg.features||!cg.features.length) return null;
+    const esc=s=>String(s).replace(/[.*+?^${}()|[\]\\]/g,'\\$&'); const idx=[];
+    for(const f of cg.features){ if(!f.geometry) continue; const p=f.properties||{};
+      let a=180,b=90,c=-180,d=-90; const scan=cs=>{ for(const x of cs){ if(typeof x[0]==='number'){ if(x[0]<a)a=x[0]; if(x[1]<b)b=x[1]; if(x[0]>c)c=x[0]; if(x[1]>d)d=x[1]; } else scan(x); } };
+      try{ scan(f.geometry.coordinates); }catch(_){ continue; } if(!(c>=a&&d>=b)) continue;
+      const names=[p.NAME_EN,p.ADMIN,p.NAME,p.name,p['name:en'],p.NAME_LONG,p.FORMAL_EN].filter(v=>v&&String(v).trim().length>=4);
+      const uniq=[...new Set(names.map(v=>String(v).trim()))]; if(!uniq.length) continue;
+      idx.push({ res:uniq.map(s=>new RegExp('\\b'+esc(s)+'\\b','i')), loc:[(a+c)/2,(b+d)/2], code:(f.id!=null?String(f.id):(p.__code||'')), en:(p.NAME_EN||p.ADMIN||p.NAME||p.name||''), len:Math.max.apply(null,uniq.map(s=>s.length)) }); }
+    return idx.length?idx:null; }catch(_){ return null; } }
+  function _countryFallback(hay){ try{ if(!_cfIdx) _cfIdx=_cfBuild(); if(!_cfIdx) return null;
+    let best=null; for(const c of _cfIdx){ if(c.res.some(re=>re.test(hay))){ if(!best||c.len>best.len) best=c; } }
+    if(!best) return null;
+    let nm=best.en; try{ const s=(typeof HOST.countryStats!=='undefined')&&HOST.countryStats[best.code]; if(s){ nm=(s.name&&(s.name[HOST.lang]||s.name.en))||((HOST.lang==='jp'&&s.nameJp)?s.nameJp:s.nameEn)||s.nameEn||best.en; } }catch(_){}
+    return { loc:best.loc, name:nm }; }catch(_){ return null; } }
+  /* (#R161) NewsGeo kind → the place TYPE the rest of the app already speaks
+     (R123 spreads duplicate pins differently for a country vs a city). */
+  const _NG_KIND={ country:'country', admin1:'region', feature:'region', flashpoint:'flashpoint', city:'city', seat:'city', org:'city' };
+  function analyzeContext(title,publisher,seed,desc){
+    desc=desc||'';
+    const short=HOST.lang==='jp'?(title.length>20?title.slice(0,20)+'…':title):(title.split(' ').slice(0,5).join(' ')+'…');
+    let subjectLoc=null, subjectName=null, subjectType=null, subjectConf=0;
+    /* ---- (#R161) PRIMARY: the deterministic NewsGeo engine (js/newsgeo.js).
+       It does what a plain gazetteer scan cannot — resolves same-name places from
+       country/region cues, suppresses dateline ("Blinken in Washington … Gaza"),
+       swallows traps ("Paris Hilton", "New York Times"), and boosts a city whose
+       own country is also named. Falls through to the legacy scorer below when it
+       declines to answer or the file did not load, so behaviour never regresses. */
+    try{
+      const NG=window.IntMapNewsGeo;
+      if(NG&&NG.locate){
+        const r=NG.locate(title,{desc,publisher,lang:HOST.lang});
+        if(r&&isFinite(r.lng)&&isFinite(r.lat)){
+          subjectLoc=[r.lng,r.lat];
+          subjectName=(HOST.lang==='jp'?(r.name.jp||r.name.en):(r.name.en||r.name.jp))||null;
+          subjectType=_NG_KIND[r.kind]||'city'; subjectConf=r.confidence||0;
+        }
+      }
+    }catch(_){}
+    /* ---- FALLBACK: the in-page gazetteer scorer (also the only path for the
+       admin-curated geo_pins types the engine has no opinion about). ---- */
+    if(!subjectLoc){
+      let best=null, bestScore=0;
+      for(const g of HOST.geoDB){
+        const s=scoreGeo(g,title,desc);
+        if(s<=0) continue;
+        if(s>bestScore || (s===bestScore && (!best||(TYPE_LOCAL[g.type]||0)>(TYPE_LOCAL[best.type]||0)))){ best=g; bestScore=s; }
+      }
+      /* name{} only carries en/jp — for de/ru/es fall back to English instead of
+         `undefined`, which used to surface as a blank pin label. */
+      if(best){ subjectLoc=best.loc; subjectName=best.name[HOST.lang]||best.name.en||best.name.jp||null; subjectType=best.type; }
+    }
+    /* (#R107) no gazetteer hit → try the country actually named (real location beats a random scatter). */
+    if(!subjectLoc){ const cf=_countryFallback(title+' '+desc); if(cf){ subjectLoc=cf.loc; subjectName=cf.name; subjectType='country'; } }
+    /* ---- Publisher HQ (expanded gazetteer, longest-key-first, word-boundary safe) ---- */
+    const pm=matchPublisher(publisher);
+    const pubLoc=pm?pm.loc:null, pubName=pm?((HOST.lang==='jp'?'発信: ':HOST.lang==='de'?'Quelle: ':HOST.lang==='ru'?'Источник: ':HOST.lang==='es'?'Fuente: ':'Source: ')+pm.label):null;
+    /* Remember title/publisher so the toggle/AI passes can re-seed fallbacks later */
+    const res={ subjectLoc, subjectName, subjectType, subjectConf, pubLoc, pubName, short, _title:title, _pub:publisher };
+    HOST.applyPinMode(res);
+    return res;
+  }
+  return { analyzeContext, rebuildGeoIndex };
+};

--- a/js/news-feed.js
+++ b/js/news-feed.js
@@ -1,0 +1,230 @@
+/* ============================================================================
+ *  IntMap · News feed: sources, fetch, cache and title translation  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.newsFeed=function(map,HOST){
+  function startNews(){
+    const feed=document.getElementById('live-news-feed'); HOST.clearMarkers(); feed.innerHTML=''; HOST.renderedCount=0;
+    if(HOST.globalData.length===0){ feed.innerHTML=`<div class="empty-msg">${HOST.t('loading')}</div>`; return; }
+    HOST.newsFiltered=HOST.computeFilteredNews();
+    if(HOST.newsFiltered.length===0){ feed.innerHTML=`<div class="empty-msg">${HOST.t('noMatch')}</div>`; return; }
+    /* Pin every filtered news item on the map IMMEDIATELY, even items not yet rendered in sidebar.
+       This fixes "few pins on map despite many in sidebar". */
+    HOST.newsFeatures=[];
+    HOST.newsFiltered.forEach(item=>{
+      if(item.analysis && item.analysis.loc){
+        const fid='n_'+Math.random().toString(36).slice(2,10);
+        const mappedStr = item.analysis.mapped===true?'true':(item.analysis.mapped==='publisher'?'publisher':'none');
+        HOST.newsFeatures.push({type:'Feature',id:fid,geometry:{type:'Point',coordinates:item.analysis.loc},properties:{
+          fid, mapped:mappedStr, ptype:item.analysis.ptype||'', title:item.title, name:item.analysis.name||'',
+          short:item.analysis.short||'', publisher:item.publisher, link:item.link, pubDate:item.pubDate
+        }});
+      }
+    });
+    HOST._spreadDupNewsPins(HOST.newsFeatures);   /* (#R122) fan out pins sharing an anchor so each is individually clickable */
+    if(map&&map.isStyleLoaded()) HOST.setupIntelLayers();
+    /* (#R79b) don't paint pins for a hidden News window (they'd appear with no window controlling them) */
+    if(map&&map.getSource('news-points')){ map.getSource('news-points').setData({type:'FeatureCollection',features:HOST._wsNewsHidden()?[]:HOST.newsFeatures}); try{HOST.scheduleNewsDeclutter();}catch(_){} }
+    HOST.appendNewsBatch(); HOST.updateOcclusion();
+    maybeAutoEnrich();
+  }
+  function maybeAutoEnrich(){
+    /* (#R29) News location analysis now runs ENTIRELY server-side (refresh-news pre-AI-locates every
+       en/jp article into current_news; the dictionary is the server's fallback). The browser never
+       calls the AI for news geocoding anymore, so there is no client auto-enrich pass to run here.
+       Kept as a no-op hook so existing callers (startNews) stay intact.
+       (#R15) Titles are still translated ONLY on the explicit "Translate titles" button. */
+  }
+  /* ===== AI title translation (multi-language news mode) =====
+     Foreign-language headlines (non-English in EN UI / non-Japanese in JP UI) are translated
+     into the UI language by the AI, with the original language noted on the card. */
+  const LANG_JP={German:'ドイツ語',French:'フランス語',Spanish:'スペイン語',Italian:'イタリア語',Portuguese:'ポルトガル語',Russian:'ロシア語',Arabic:'アラビア語',Chinese:'中国語',Korean:'韓国語',Japanese:'日本語',English:'英語',Dutch:'オランダ語',Turkish:'トルコ語',Hindi:'ヒンディー語',Persian:'ペルシャ語',Hebrew:'ヘブライ語',Ukrainian:'ウクライナ語',Polish:'ポーランド語',Swedish:'スウェーデン語',Greek:'ギリシャ語',Indonesian:'インドネシア語',Thai:'タイ語',Vietnamese:'ベトナム語'};
+  function localizeLangName(en){ if(!en) return ''; return HOST.lang==='jp'?(LANG_JP[en]||en):en; }
+  /* Update only the title cells of already-rendered cards (keeps scroll position). */
+  function rerenderNewsFeedTitles(){
+    (HOST.newsFiltered||[]).forEach(item=>{ const el=item._cardEl; if(el&&el.isConnected){ const tt=el.querySelector('.news-title'); if(tt) tt.innerHTML=HOST.newsTitleHTML(item); } });
+  }
+  let _translateBusy=false;
+  async function aiTranslateTitles(){
+    if(_translateBusy) return;
+    if(!HOST.aiGate()) return;
+    const target=HOST.lang==='jp'?'Japanese':HOST.lang==='de'?'German':HOST.lang==='ru'?'Russian':HOST.lang==='es'?'Spanish':'English';
+    const todo=HOST.computeFilteredNews().filter(it=>it.analysis && !it.analysis._titleTried).slice(0,120);
+    /* (#R9/#20) Spinner + progress + result toast — mirrors the AI-locate "detecting" UI so it's
+       obvious the translation is running and when it finished. */
+    const btn=document.getElementById('ai-translate-btn');
+    if(!todo.length){ HOST.aiToast(HOST.t('aiTransNone')); return; }
+    _translateBusy=true;
+    HOST.aiSetBtnBusy(btn,true,HOST.t('aiTransBusy'));
+    const sys=`You translate news headlines. The UI language is ${target}. For EACH numbered headline: if it is ALREADY written in ${target}, skip it entirely. Otherwise translate it into natural ${target}. Reply with ONLY a JSON array containing one object for each headline that NEEDED translation: {"i":<index number>,"lang":"<original language name in English, e.g. German>","t":"<the ${target} translation>"}. No commentary, no code fences.`;
+    const BATCH=15; let done=0, hit=0;
+    try{
+      for(let i=0;i<todo.length;i+=BATCH){
+        const chunk=todo.slice(i,i+BATCH);
+        const list=chunk.map((it,k)=>`${k}. ${it.title}`).join('\n');
+        let arr=null;
+        try{ arr=await HOST.askAIJSON('Headlines:\n'+list, sys); }catch(e){ break; }
+        if(Array.isArray(arr)) arr.forEach(o=>{
+          if(!o||typeof o.i!=='number'||!o.t) return;
+          const it=chunk[o.i]; if(!it||!it.analysis) return;
+          it.analysis.titleTranslated=String(o.t);
+          it.analysis.titleOrigLang=o.lang||'';
+          it.analysis.titleOrigLangLabel=localizeLangName(o.lang||'');
+          hit++;
+        });
+        chunk.forEach(it=>{ if(it.analysis) it.analysis._titleTried=true; });
+        done+=chunk.length;
+        HOST.aiSetBtnBusy(btn,true,HOST.t('aiTransBusy')+' '+done+'/'+todo.length);
+        if(HOST.mode==='news'||HOST.mode==='saved') rerenderNewsFeedTitles();
+      }
+    } finally { _translateBusy=false; HOST.aiSetBtnBusy(btn,false); }
+    HOST.aiToast(hit? HOST.t('aiTransDone').replace('{n}',hit) : HOST.t('aiTransNone'));
+  }
+  /* ===== Shared helper: strip HTML to plain text (used by the news ingest) ===== */
+  function stripHTML(s){ const d=document.createElement('div'); d.innerHTML=s||''; return d.textContent||d.innerText||''; }
+  function dateRangeQualifier(d){
+    /* ±3 day window for that date */
+    const start=new Date(d.getTime()-3*864e5), end=new Date(d.getTime()+3*864e5);
+    return ` after:${HOST.ymdISO(start)} before:${HOST.ymdISO(end)}`;
+  }
+  /* (#R167) moved verbatim to js/tables.js — see Architecture.md §3.1. */
+  const {NEWS_EDITIONS_MULTI,NEWS_COUNTRY_EDITIONS}=window.IntMapTables;
+  function feedUrls(){
+    /* (#R37) per-language Google News locale so DE/RU get German/Russian feeds (not the JP feed via the old else). */
+    const p=({en:'hl=en-US&gl=US&ceid=US:en', jp:'hl=ja&gl=JP&ceid=JP:ja', de:'hl=de&gl=DE&ceid=DE:de', ru:'hl=ru&gl=RU&ceid=RU:ru', es:'hl=es&gl=ES&ceid=ES:es'})[HOST.lang]||'hl=en-US&gl=US&ceid=US:en';   /* (#R40) +Spanish news edition */
+    if(HOST.newsDate){
+      /* Google News search supports after:/before: operators. Headlines endpoints don't,
+         so a date-filtered query goes through search. */
+      const q=(HOST.activeSearchQuery||'world')+dateRangeQualifier(HOST.newsDate);
+      return [`https://news.google.com/rss/search?q=${encodeURIComponent(q)}&${p}`];
+    }
+    if(HOST.activeSearchQuery) return[`https://news.google.com/rss/search?q=${encodeURIComponent(HOST.activeSearchQuery)}&${p}`];
+    let base;
+    if(HOST.newsLangMode==='multi'){
+      /* (#R9 / #29) In multi-language mode show ONLY the languages ticked in Settings. The UI-language
+         WORLD/BUSINESS base feeds are added only when the UI language is among the selections — so
+         selecting e.g. just Russian no longer also leaks the English base feed. */
+      base=[];
+      const sel=(Array.isArray(HOST.newsLangs)&&HOST.newsLangs.length)?HOST.newsLangs:[HOST.lang];
+      if(sel.includes(HOST.lang)) base.push(`https://news.google.com/rss/headlines/section/topic/WORLD?${p}`,`https://news.google.com/rss/headlines/section/topic/BUSINESS?${p}`);
+      NEWS_EDITIONS_MULTI.filter(ed=>ed.lang!==HOST.lang && sel.includes(ed.lang)).forEach(ed=>base.push(`https://news.google.com/rss/headlines/section/topic/WORLD?${ed.q}`));
+      if(!base.length) base.push(`https://news.google.com/rss/headlines/section/topic/WORLD?${p}`);  /* never fetch nothing */
+    } else {
+      base=[`https://news.google.com/rss/headlines/section/topic/WORLD?${p}`,`https://news.google.com/rss/headlines/section/topic/BUSINESS?${p}`];
+    }
+    /* National media editions chosen in Settings (#29) — multiple allowed. */
+    try{ (window.imNewsCountries||[]).forEach(code=>{ const ed=NEWS_COUNTRY_EDITIONS[code]; if(ed && !base.some(u=>u.includes(ed))) base.push(`https://news.google.com/rss/headlines/section/topic/WORLD?${ed}`); }); }catch(_){}
+    /* Pro "RU·CN local primary-source intel" overlay — pulls the Russian + Chinese editions. */
+    if(window.proIntelOn && window.imIsPro && window.imIsPro()){
+      ['hl=ru&gl=RU&ceid=RU:ru','hl=zh-CN&gl=CN&ceid=CN:zh-Hans'].forEach(ed=>{ if(!base.some(u=>u.includes(ed))) base.push(`https://news.google.com/rss/headlines/section/topic/WORLD?${ed}`); });
+    }
+    return base;
+  }
+  /* News cache → instant render on load/return, refreshed in the background. */
+  function loadNewsCache(){
+    try{ const c=JSON.parse(localStorage.getItem('intmap_news_cache')||'null');
+      if(c && c.lang===HOST.lang && !HOST.activeSearchQuery && !HOST.newsDate && Array.isArray(c.data) && c.data.length && (Date.now()-c.ts < 6*3600e3)) return c.data; }catch(_){}
+    return null;
+  }
+  function saveNewsCache(){
+    try{ if(!HOST.activeSearchQuery && !HOST.newsDate) localStorage.setItem('intmap_news_cache', JSON.stringify({ts:Date.now(), lang:HOST.lang, data:HOST.globalData.slice(0,120)})); }catch(_){}
+  }
+  function buildItems(byLink){
+    let uniq=[...byLink.values()].sort((a,b)=>HOST.parseDate(b.pubDate)-HOST.parseDate(a.pubDate));
+    /* (#R107) TIME-TRAVEL: when a past instant is set, keep ONLY items actually dated near it. Google News ignores
+       after:/before: for dates outside its recent window and returns TODAY's headlines, which then wrongly showed as
+       "past" news ("時間を過去に設定しても最新ニュースが表示される"). Filtering by pubDate drops that leakage, and
+       undated items too — so the feed shows genuine period news around that date, or NOTHING (never latest-as-past). */
+    try{ if(typeof HOST.newsDate!=='undefined' && HOST.newsDate){ const t0=HOST.newsDate.getTime(), win=8*864e5;   /* ±8 days (the fetch query uses ±3; allow timezone slack) */
+      uniq=uniq.filter(it=>{ const pd=HOST.parseDate(it.pubDate); return pd && isFinite(pd) && Math.abs(pd-t0)<=win; }); } }catch(_){}
+    return uniq.slice(0,150).map(it=>{ const sp=it.title.split(' - '); const publisher=sp.length>1?sp.pop():(({en:'News',jp:'報道',de:'Nachrichten',ru:'Новости'})[HOST.lang]||'News'); const title=sp.join(' - '); const desc=it.desc||''; return { title, publisher, link:it.link, pubDate:it.pubDate, desc, analysis:HOST.analyzeContext(title,publisher,it.link,desc) }; });
+  }
+  /* ===== Server-baked news (FAST PATH) =====
+     The `refresh-news` Edge Function pre-fetches + pre-analyses the default feeds every
+     ~20 min into `current_news`, so the browser just runs ONE SELECT (a few ms) instead of
+     proxy-fetching 150 articles and scoring them against the whole gazetteer at startup.
+     A server row already carries subject/publisher coords, so we skip analyzeContext entirely.
+     Used only for the default feed in single-language mode; search / time-travel / multi-language
+     keep the live-RSS path below (the server only bakes the WORLD+BUSINESS UI-language editions). */
+  /* (#R124) detect whether a subject NAME is a whole COUNTRY (vs a city / region). The default news feed comes from
+     the server, which carries no subject_type, so a "USA"-classified cluster had an EMPTY ptype and relied on a
+     fragile bbox-centre heuristic (Alaska skews the US bbox north → never detected as country-level → pins stayed
+     clustered instead of spreading across the country). Deriving the type from the name makes the R123 region-aware
+     spread actually fire for real pins. */
+  let _ctryNameSet=null;
+  function _isCountrySubject(nm){ if(!nm) return false;
+    if(!_ctryNameSet){ _ctryNameSet=new Set();
+      try{ if(typeof HOST.countryStats==='object'&&HOST.countryStats){ for(const cd in HOST.countryStats){ const s=HOST.countryStats[cd]; if(!s) continue; [s.nameEn,s.nameJp].forEach(n=>{ if(n) _ctryNameSet.add(String(n).toLowerCase().trim().replace(/^the\s+/,'')); }); } } }catch(_){}
+      ['usa','u.s.','u.s.a.','us','america','united states','united states of america','uk','u.k.','britain','great britain','south korea','north korea','russia','uae','drc','dr congo','czechia','ivory coast','burma','swaziland','turkey','türkiye','holland'].forEach(a=>_ctryNameSet.add(a)); }
+    const k=String(nm).toLowerCase().trim().replace(/^the\s+/,'').replace(/\s+\(.*\)$/,'');
+    return _ctryNameSet.has(k); }
+  function serverRowToItem(r){
+    const subjectLoc=(r.subject_lng!=null&&r.subject_lat!=null)?[r.subject_lng,r.subject_lat]:null;
+    const pubLoc=(r.pub_lng!=null&&r.pub_lat!=null)?[r.pub_lng,r.pub_lat]:null;
+    const subjectName=HOST.lang==='jp'?(r.subject_name_jp||r.subject_name_en):(r.subject_name_en||r.subject_name_jp);
+    const pubName=r.pub_label?((HOST.lang==='jp'?'発信: ':HOST.lang==='de'?'Quelle: ':HOST.lang==='ru'?'Источник: ':HOST.lang==='es'?'Fuente: ':'Source: ')+r.pub_label):null;
+    const short=HOST.lang==='jp'?(r.short_jp||r.short_en||''):(r.short_en||r.short_jp||'');
+    const subjectType=r.subject_type||((_isCountrySubject(r.subject_name_en)||_isCountrySubject(subjectName))?'country':'');   /* (#R124) derive country-type from the name when the server omits it */
+    const analysis={ subjectLoc, subjectName, subjectType, pubLoc, pubName, short, _title:r.title, _pub:r.publisher||'' };
+    HOST.applyPinMode(analysis);   /* sets loc/name/mapped for the current Subject/Publisher toggle */
+    return { title:r.title, publisher:r.publisher||'', link:r.link, pubDate:r.pub_date||'', desc:r.description||'', analysis };
+  }
+  async function loadNewsFromSupabase(){
+    if(!HOST.DB || HOST.activeSearchQuery || HOST.newsDate || HOST.newsLangMode==='multi') return false;
+    try{
+      const { data, error } = await HOST.DB.from('current_news')
+        .select('title,publisher,link,pub_date,description,subject_lng,subject_lat,subject_name_en,subject_name_jp,pub_lng,pub_lat,pub_label,short_en,short_jp')
+        .eq('lang',HOST.lang).order('pub_date',{ascending:false}).limit(150);
+      if(error) throw error;
+      if(!data||!data.length) return false;          /* not seeded yet → fall through to live RSS */
+      HOST.globalData=data.map(serverRowToItem);
+      saveNewsCache();
+      if(HOST.mode==='news'||HOST.mode==='saved') startNews();
+      return true;
+    }catch(e){ console.warn('[IntMap] current_news unavailable, using live RSS:', e&&e.message); return false; }
+  }
+  async function fetchData(){
+    const feed=document.getElementById('live-news-feed');
+    /* 1) Instant: show cached headlines immediately while fresh ones load. */
+    if(HOST.globalData.length===0){ const cached=loadNewsCache(); if(cached&&cached.length){ HOST.globalData=cached; if(HOST.mode==='news'||HOST.mode==='saved') startNews(); } }
+    if((HOST.mode==='news'||HOST.mode==='saved')&&feed&&HOST.globalData.length===0) feed.innerHTML=`<div class="empty-msg">${HOST.t('loading')}</div>`;
+    /* 1b) FAST PATH: pre-analyzed news from Supabase. If it returns rows we're done — no client scoring.
+       (#R40) TEMPORARILY DISABLED via USE_SERVER_NEWS — always fall through to the client non-AI locator. */
+    if(HOST.USE_SERVER_NEWS && await loadNewsFromSupabase()) return;
+    /* 2) FALLBACK: live RSS via CORS proxies + client-side analysis (function not deployed, or search/time-travel/multi-lang). */
+    const parser=new DOMParser(); const byLink=new Map(); let any=false;
+    const ingest=(txt)=>{
+      if(!txt) return;
+      const xml=parser.parseFromString(txt,'text/xml');
+      xml.querySelectorAll('item, entry').forEach(it=>{
+        const le=it.querySelector('link'); const link=(le&&(le.textContent||le.getAttribute('href')))||'';
+        if(!link||byLink.has(link))return;
+        /* RSS <description>, else Atom <summary>/<content>; HTML stripped to plain text for analysis. */
+        const descNode=it.querySelector('description')||it.querySelector('summary')||it.querySelector('content');
+        /* Google News packs each related article as <a>headline</a><font>publisher</font>.
+           Drop the <font> publisher names first — otherwise "The Washington Post" etc. leak
+           false city matches ("Washington") into the scorer. The <a> headline text is kept. */
+        const descHtml=(descNode?.textContent||'').replace(/<font\b[^>]*>[\s\S]*?<\/font>/gi,' ');
+        byLink.set(link,{
+          title:it.querySelector('title')?.textContent||'',
+          link,
+          pubDate:it.querySelector('pubDate, published, updated')?.textContent||'',
+          desc:stripHTML(descHtml)
+        });
+      });
+      if(byLink.size){ HOST.globalData=buildItems(byLink); any=true; if(HOST.mode==='news'||HOST.mode==='saved') startNews(); }
+    };
+    try{
+      await Promise.all(feedUrls().map(async u=>{ try{ ingest(await HOST.fetchViaProxy(u)); }catch(_){} }));
+      if(!any && HOST.globalData.length===0) throw new Error('no items');
+      if(any) saveNewsCache();
+    }catch(e){ if(HOST.globalData.length===0&&feed&&(HOST.mode==='news'||HOST.mode==='saved')) feed.innerHTML=`<div class="empty-msg" style="color:var(--threat-unmapped);">${HOST.t('networkError')}</div>`; console.warn('fetchData failed:',e); }
+  }
+  return { aiTranslateTitles, fetchData, loadNewsFromSupabase, startNews };
+};

--- a/js/place-labels.js
+++ b/js/place-labels.js
@@ -1,0 +1,275 @@
+/* ============================================================================
+ *  IntMap · Place / sea labels and label localisation  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.placeLabels=function(map,HOST){
+  /* Localize the geopolitical / strategic layer checkboxes in the Layers menu (their text was
+     hard-coded English; pull the right language out of geoLayersDB instead). */
+  /* Fallback names for geo-layer checkboxes whose layer was pulled out of geoLayersDB (e.g. Rimland,
+     now a country-fill) so they still localize EN/JP (#3). */
+  const GEO_LABEL_FALLBACK={ rimland:{name:{en:'Rimland',jp:'リムランド'}}, fsu:{name:{en:'Former Soviet Union',jp:'旧ソ連諸国'}} };
+  function localizeGeoLabels(){
+    document.querySelectorAll('.geo-layer-cb').forEach(cb=>{
+      const key=cb.getAttribute('data-layer'), data=(typeof HOST.geoLayersDB!=='undefined'&&HOST.geoLayersDB[key])||GEO_LABEL_FALLBACK[key]; if(!data||!data.name) return;
+      const label=cb.closest('.layer-option'); if(!label) return;
+      let span=label.querySelector('.geo-label');
+      if(!span){ /* migrate the bare trailing text node into a span we can re-localize */
+        Array.from(label.childNodes).forEach(n=>{ if(n.nodeType===3 && n.textContent.trim()) n.remove(); });
+        span=document.createElement('span'); span.className='geo-label';
+        /* (#R15e) Insert the label BEFORE the favorite star — appending it to the end put it AFTER the
+           star (which has margin-left:auto), shoving the text to the right with a big gap ("ぐちゃっと"). */
+        const star=label.querySelector('.lyr-star');
+        if(star) label.insertBefore(span,star); else label.appendChild(span);
+      }
+      span.textContent=' '+(data.name[HOST.lang]||data.name.en||key);
+    });
+  }
+  let _placeLabelsAdded=false;
+  /* (#R27) IDEMPOTENT now. The old `_placeLabelsAdded` early-return made this a one-shot: if the very
+     first call added the layers a hair before the OFM source/style was truly ready, they were never
+     re-added — which is exactly why labels were missing on first load but appeared after toggling
+     names off/on ("デフォルト選択なのに地名ラベルが出ない、再チェックで出る"). The per-source / per-layer
+     `if(!getLayer)` guards already make repeated calls safe, so we just re-attempt every time. */
+  function ensurePlaceLabels(){
+    if(!map||!map.isStyleLoaded()) return;
+    try{
+      /* Use the TileJSON URL (not a hardcoded tile path) — OpenFreeMap serves versioned tiles, so
+         the bare /planet/{z}/{x}/{y}.pbf path 404s at real zooms and labels never appear. */
+      if(!map.getSource('ofm')) map.addSource('ofm',{type:'vector',url:'https://tiles.openfreemap.org/planet',attribution:'© OpenFreeMap © OpenMapTiles © OSM'});
+      const FONT=['Noto Sans Regular'];
+      const before = map.getLayer('grid-lines') ? 'grid-lines' : undefined;
+      if(!map.getLayer('ofm-country')) map.addLayer({id:'ofm-country',type:'symbol',source:'ofm','source-layer':'place',maxzoom:7,filter:['==',['get','class'],'country'],layout:{visibility:'none','text-field':['get','name'],'text-font':FONT,'text-size':['interpolate',['linear'],['zoom'],1,10,4,15],'text-letter-spacing':0.08,'text-max-width':8,'text-padding':6},paint:{'text-color':'#e8eefc','text-halo-color':'rgba(0,0,0,0.75)','text-halo-width':1.4}}, before);
+      if(!map.getLayer('ofm-city')) map.addLayer({id:'ofm-city',type:'symbol',source:'ofm','source-layer':'place',minzoom:3,filter:['all',['in',['get','class'],['literal',['city','town']]]],layout:{visibility:'none','text-field':['get','name'],'text-font':FONT,'text-size':['interpolate',['linear'],['zoom'],4,11,10,15],'text-max-width':7,'text-variable-anchor':['top','bottom','left','right'],'text-radial-offset':0.4,'text-justify':'auto','icon-optional':true},paint:{'text-color':'#ffffff','text-halo-color':'rgba(0,0,0,0.8)','text-halo-width':1.3}});
+      if(!map.getLayer('ofm-other')) map.addLayer({id:'ofm-other',type:'symbol',source:'ofm','source-layer':'place',minzoom:7,filter:['all',['in',['get','class'],['literal',['village','suburb','hamlet','neighborhood']]]],layout:{visibility:'none','text-field':['get','name'],'text-font':FONT,'text-size':['interpolate',['linear'],['zoom'],8,10,13,13],'text-max-width':7},paint:{'text-color':'#d8dde6','text-halo-color':'rgba(0,0,0,0.75)','text-halo-width':1.1}});
+      /* (#R40) "河川や湖、その他地形のラベルが欲しい" — rivers/lakes/seas (water_name) + mountain peaks (mountain_peak),
+         from the same OFM vector source. Italic blue for water (cartographic convention), a ▲ for peaks with
+         elevation. They follow the Place-names toggle + the active label language (handled in applyLabelLang). */
+      const FONTI=['Noto Sans Italic'];
+      /* (#R41) ROOT CAUSE of "水域のラベルが地図からずれている": river names were read from `water_name` (which is
+         POINT label geometry) but drawn with symbol-placement:line — line placement on a point lands the label
+         off the actual river. River/canal names live in the `waterway` LINE layer; placing them there makes them
+         follow the real river line on the basemap (aligned). */
+      if(!map.getLayer('ofm-river')) map.addLayer({id:'ofm-river',type:'symbol',source:'ofm','source-layer':'waterway',minzoom:6,filter:['in',['get','class'],['literal',['river','canal']]],layout:{visibility:'none','symbol-placement':'line','text-field':['get','name'],'text-font':FONTI,'text-size':['interpolate',['linear'],['zoom'],6,10,12,13],'text-max-angle':38,'text-letter-spacing':0.02,'symbol-spacing':350},paint:{'text-color':'#7fc4ff','text-halo-color':'rgba(0,0,0,0.7)','text-halo-width':1.1}});
+      /* (#R62) sea/ocean/bay labels moved OFF the vector tiles: water_name label points are stored PER TILE, so the
+         visible label jumped to a different point at every zoom level ("ズームに応じて位置がどんどんずれてしまう").
+         OFM now only supplies LAKE names (compact bodies → no visible drift); seas/oceans/gulfs come from the fixed
+         gazetteer below (one stable coordinate each, 5 languages, clickable). */
+      /* (#R63) lakes: major lakes now come from the FIXED gazetteer too (their per-tile label points also drifted);
+         OFM keeps only the long tail of small lakes from z5.5 where any drift is sub-glyph. Constant text size —
+         the size interpolation amplified the perceived slide while zooming. */
+      /* (#R64) WATER labels: the vector tiles store a DIFFERENT label geometry for the same lake at every zoom
+         (per-tile LineString label lines), so a tile-driven layer re-anchors on zoom → the visible "slide".
+         Water labels therefore render from a client-side STABLE source ('stab-water-src') that a harvester fills
+         at runtime: every water name keeps the FIRST coordinate it was seen at, worldwide, nothing hardcoded.
+         (#R67) PEAKS ARE THE OPPOSITE CASE and go back to DIRECT tile rendering: summits are exact POINT nodes
+         whose tile-quantization error is always sub-pixel AT THE ZOOM THAT TILE IS VIEWED AT (error and pixel
+         size shrink together), so the raw tile layer is inherently drift-free — while pinning them (R64/R66)
+         BAKED IN one zoom's coarse coordinate and then hopped on refinement, which was itself the reported
+         "山岳名がズームに応じて位置ずれする". Do not re-pin point features. */
+      try{ if(!map.getSource('stab-water-src')) map.addSource('stab-water-src',{type:'geojson',data:{type:'FeatureCollection',features:[]}}); }catch(_){}
+      /* (#R69) both water layers additionally gate each pin on its first-seen tile zoom (`mz`, see _harvestOne)
+         so zoomed-in harvests don't flood lower zooms ("水域ラベルが…過剰な数見えすぎ"). */
+      if(!map.getLayer('ofm-water')) map.addLayer({id:'ofm-water',type:'symbol',source:'stab-water-src',minzoom:5.5,filter:['all',['!',['in',['get','class'],['literal',['ocean','sea','bay','strait','gulf','lagoon']]]],['<=',['coalesce',['get','mz'],0],['+',['zoom'],0.2]]],layout:{visibility:'none','text-field':['get','name'],'text-font':FONTI,'text-size':13,'text-max-width':8},paint:{'text-color':'#8fd0ff','text-halo-color':'rgba(0,0,0,0.7)','text-halo-width':1.1}});
+      /* (#R65) seas/bays/straits/gulfs from the SAME pinned dynamic source (visible from low zoom) — every
+         named water body worldwide gets a stable label, not just the curated majors. */
+      if(!map.getLayer('ofm-water2')) map.addLayer({id:'ofm-water2',type:'symbol',source:'stab-water-src',minzoom:2,filter:['all',['in',['get','class'],['literal',['ocean','sea','bay','strait','gulf','lagoon']]],['<=',['coalesce',['get','mz'],0],['+',['zoom'],0.2]]],layout:{visibility:'none','text-field':['get','name'],'text-font':FONTI,'text-letter-spacing':0.06,'text-max-width':8,'text-size':13.5},paint:{'text-color':'#8fd0ff','text-halo-color':'rgba(0,0,0,0.7)','text-halo-width':1.1,'text-opacity':0.95}});
+      try{ if(!map.getSource('geo-sea-src')){
+        const S=window.SEA_LABELS||[];
+        map.addSource('geo-sea-src',{type:'geojson',data:{type:'FeatureCollection',features:S.map((r,i)=>({type:'Feature',id:i,geometry:{type:'Point',coordinates:[r[0],r[1]]},properties:{z:r[2],big:r[2]<=1?1:0,en:r[3],jp:r[4],de:r[5],ru:r[6],es:r[7]}}))}});
+      }
+      /* (#R73) ROOT CAUSE of "主要な海や湖の名前が表示されない" (and the earlier 東シナ海 report): this layer's
+         text-size was `case(big, interpolate(zoom), interpolate(zoom))` — a zoom interpolation NESTED inside
+         `case`, which the style spec forbids (zoom must be the OUTERMOST expression). MapLibre rejected the
+         whole addLayer SILENTLY (async error event, swallowed try) → the gazetteer sea/lake layer NEVER existed,
+         and because the harvester dedupes any name already in the gazetteer, the majors were labelled NOWHERE.
+         Rewritten with zoom outermost and the big/small distinction inside each stop output (valid form). */
+      if(!map.getLayer('geo-sea')) map.addLayer({id:'geo-sea',type:'symbol',source:'geo-sea-src',minzoom:0,filter:['<=',['get','z'],['+',['zoom'],0.001]],layout:{visibility:'none','symbol-sort-key':['get','z'],'text-field':['get','en'],'text-font':FONTI,'text-letter-spacing':0.08,'text-max-width':8,
+        'text-size':['interpolate',['linear'],['zoom'],1,['case',['==',['get','big'],1],11,10],2,['case',['==',['get','big'],1],12.7,10],4,['case',['==',['get','big'],1],16,12],5,['case',['==',['get','big'],1],16.8,13],8,['case',['==',['get','big'],1],19,15.3],9,['case',['==',['get','big'],1],19.3,16]]},
+        paint:{'text-color':'#8fd0ff','text-halo-color':'rgba(0,0,0,0.7)','text-halo-width':1.1,'text-opacity':0.95}}); }catch(_){}
+      /* (#R63) peaks: CONSTANT text size — size interpolation read as sliding. (#R67) rendered DIRECTLY from the
+         mountain_peak tiles (point nodes are sub-pixel accurate at every zoom's own tiles).
+         (#R68) MEASURED root cause of the still-reported drift: the anchors were glued (≤2.4 m across z10→z13.5,
+         verified via queryRenderedFeatures), but text-anchor:'top' centered the whole "▲ Name" string under the
+         point — the ▲ marker sat half-a-string-width LEFT of the summit, a constant SCREEN offset that spans
+         kilometres of terrain at low zoom and metres at high zoom → the ▲ visibly pointed at different terrain
+         at every zoom. The string is now LEFT-anchored: the ▲ glyph itself sits ON the summit at every zoom. */
+      if(!map.getLayer('ofm-peak')) map.addLayer({id:'ofm-peak',type:'symbol',source:'ofm','source-layer':'mountain_peak',minzoom:7,filter:['has','name'],layout:{visibility:'none','text-field':['concat','▲ ',['get','name']],'text-font':FONT,'text-size':12.5,'text-max-width':30,'text-anchor':'left','text-justify':'left','text-offset':[-0.32,0]},paint:{'text-color':'#e7dcc8','text-halo-color':'rgba(0,0,0,0.8)','text-halo-width':1.2}});
+      _placeLabelsAdded=true;
+      /* register the harvester ONCE — ensurePlaceLabels is intentionally re-run all the time (R27 idempotency),
+         so an unguarded map.on here would pile up listeners. */
+      if(!ensurePlaceLabels._harvestHooked){ ensurePlaceLabels._harvestHooked=true; map.on('idle',()=>{ try{ harvestStableLabels(); }catch(_){}
+        /* (#R72) SELF-HEAL: a basemap/style swap can wipe individual label layers; if the water/sea layers are
+           gone while the toggle is on, re-add + re-apply. This was the reported "東シナ海が全体を写していても
+           出ない" — the fixed sea-label layer had been silently dropped and nothing ever put it back. */
+        try{ if(typeof HOST.geoLabelsOn!=='undefined'&&HOST.geoLabelsOn&&(!map.getLayer('geo-sea')||!map.getLayer('ofm-water')||!map.getLayer('ofm-water2'))){ ensurePlaceLabels(); if(typeof applyLabelLang==='function') applyLabelLang(); } }catch(_){} }); }
+    }catch(e){ console.warn('ensurePlaceLabels',e); }
+  }
+  let _stabSeaNames=null, _stabDirty={water:false};
+  function _seaNameSet(){ if(_stabSeaNames) return _stabSeaNames; _stabSeaNames=new Set();
+    try{ (window.SEA_LABELS||[]).forEach(r=>{ for(let i=3;i<=7;i++){ if(r[i]) _stabSeaNames.add(String(r[i]).toLowerCase()); } }); }catch(_){}
+    return _stabSeaNames; }
+  function _harvestOne(kind,sourceLayer,filter,cellDeg){
+    const idx=HOST._stabIdx[kind]; let feats=[];
+    try{ const opts={sourceLayer}; if(filter) opts.filter=filter; feats=map.querySourceFeatures('ofm',opts)||[]; }catch(_){ return; }
+    const seaSet=(kind==='water')?_seaNameSet():null;
+    /* (#R69) DENSITY ("水域ラベルがそれほどズームしていない状態でも過剰な数見えすぎ"): a pin harvested while
+       zoomed in used to stay visible at EVERY lower zoom (the geojson source has no per-feature importance).
+       Each pin now records the lowest tile zoom it was actually SEEN at (`mz`) — exactly the importance grading
+       OpenMapTiles itself applies per zoom — and the label layers filter on it, so zooming out only keeps the
+       water bodies the low-zoom tiles themselves consider worth labelling. mz only ever moves DOWN (a pin never
+       disappears while zooming in) and the pinned POSITION never changes. */
+    let zNow=6; try{ zNow=Math.max(0,Math.floor(map.getZoom())); }catch(_){}
+    for(const f of feats){ try{
+      const p=f.properties||{}; const nm2=p.name||p['name:en']||p.name_en; if(!nm2) continue;
+      if(seaSet){ let dup=false; [p.name,p['name:en'],p.name_en,p['name:ja'],p['name:de'],p['name:ru'],p['name:es']].forEach(v=>{ if(v&&seaSet.has(String(v).toLowerCase())) dup=true; }); if(dup) continue; }   /* the curated multilingual gazetteer already labels it */
+      /* OFM stores lake/water labels as per-tile LineStrings (label placement lines) — exactly why they drifted.
+         Pin the midpoint of the line (or the point) as the one stable anchor. */
+      const g=f.geometry; if(!g) continue; let co=null;
+      if(g.type==='Point') co=g.coordinates;
+      else if(g.type==='LineString'&&g.coordinates.length) co=g.coordinates[Math.floor(g.coordinates.length/2)];
+      else if(g.type==='MultiLineString'&&g.coordinates.length&&g.coordinates[0].length){ const ln=g.coordinates[0]; co=ln[Math.floor(ln.length/2)]; }
+      if(!co) continue;
+      /* (#R65) dedupe radius scales with the feature's physical size class — one "Caspian Sea" pin, not one
+         per tile pyramid level; small bays still allow same-name twins far apart. */
+      const cls=String(p.class||'');
+      const cell=(typeof cellDeg==='number')?cellDeg:(cls==='ocean'?30:cls==='sea'?12:(cls==='bay'||cls==='strait'||cls==='gulf'||cls==='lagoon')?2.5:4);
+      const base=String(nm2).toLowerCase();
+      /* same name may exist in several places (e.g. many "Long Lake") — key by name + coarse cell, and treat a
+         nearby existing pin as THE anchor. FIRST SEEN WINS, FOREVER: a water label floats on the water body, so
+         a few hundred metres of low-zoom quantization is invisible — total positional stability is what matters
+         (#R67: the R66 "refinement" idea is deliberately gone; updating pins was itself visible movement). */
+      /* (#R69) per-class floor keeps rare huge bodies visible early while bays/lagoons wait for closer zooms.
+         (#R72) straits/lagoons raised 5.5→8.5 and bays →7.2: OpenMapTiles ships small 瀬戸/straits in mid-zoom
+         tiles, so they were labelled at region-wide views ("近畿全体を写しているときに〇〇瀬戸が出てくる") —
+         a strait label only makes sense once the strait itself is a meaningful share of the screen. */
+      const clsMin=(cls==='ocean')?0:(cls==='sea')?3:(cls==='gulf')?4.5:(cls==='strait'||cls==='lagoon')?8.5:(cls==='bay')?7.2:6.5;
+      const mzNew=Math.max(clsMin,zNow);
+      let hit=null; for(let dx=-1;dx<=1&&!hit;dx++) for(let dy=-1;dy<=1&&!hit;dy++){ const k=base+'|'+cell+'|'+(Math.round(co[0]/cell)+dx)+'|'+(Math.round(co[1]/cell)+dy); if(idx.has(k)) hit=k; }
+      if(hit){ const ex=idx.get(hit); const exz=(ex&&ex.properties&&typeof ex.properties.mz==='number')?ex.properties.mz:99;
+        if(mzNew<exz-0.01){ ex.properties.mz=mzNew; _stabDirty[kind]=true; }   /* seen in a lower-zoom tile → may appear earlier; position untouched */
+        continue; }
+      const key=base+'|'+cell+'|'+Math.round(co[0]/cell)+'|'+Math.round(co[1]/cell);
+      if(idx.size>9000) return;
+      p.mz=mzNew;
+      idx.set(key,{type:'Feature',id:idx.size,geometry:{type:'Point',coordinates:[co[0],co[1]]},properties:p});
+      _stabDirty[kind]=true;
+    }catch(_){} } }
+  function harvestStableLabels(){
+    let vis=false; try{ vis=map.getLayer('ofm-water')&&map.getLayoutProperty('ofm-water','visibility')==='visible'; }catch(_){}
+    if(!vis) return;
+    /* (#R65) ALL water_name classes — seas, bays, straits, gulfs, lagoons AND lakes — are pinned dynamically.
+       The curated gazetteer is only a multilingual override for the majors; every other water body on the
+       planet gets its label from live tile data (no fixed list, no coverage ceiling). */
+    _harvestOne('water','water_name',null,null);
+    ['water'].forEach(kind=>{ if(!_stabDirty[kind]) return; _stabDirty[kind]=false;
+      try{ const s=map.getSource('stab-'+kind+'-src'); if(s) s.setData({type:'FeatureCollection',features:Array.from(HOST._stabIdx[kind].values())}); }catch(_){} });
+  }
+  function applyLabelLang(){
+    if(!map) return;
+    const mode=window.imLabelLang||'ui';
+    let nameExpr;
+    if(mode==='en') nameExpr=['coalesce',['get','name:en'],['get','name:latin'],['get','name_int'],['get','name']];
+    else if(mode==='local') nameExpr=['get','name'];
+    else if(HOST.lang==='jp') nameExpr=['coalesce',['get','name:ja'],['get','name']];
+    else if(HOST.lang==='de') nameExpr=['coalesce',['get','name:de'],['get','name:en'],['get','name:latin'],['get','name']];   /* (#R32) German place labels */
+    else if(HOST.lang==='ru') nameExpr=['coalesce',['get','name:ru'],['get','name:en'],['get','name:latin'],['get','name']];   /* (#R40) Russian place labels — RU previously fell into the English branch (item: 地名ラベルが英語のまま) */
+    else if(HOST.lang==='es') nameExpr=['coalesce',['get','name:es'],['get','name:en'],['get','name:latin'],['get','name']];   /* (#R40) Spanish place labels */
+    else nameExpr=['coalesce',['get','name:en'],['get','name:latin'],['get','name']];
+    const sat=(HOST.mapType==='sat');
+    /* Show vector labels in satellite mode (always — replaces ugly Esri) and on the map for jp/local. */
+    const show = HOST.namesOn && (sat || HOST.mapLabelsViaVector());
+    const isDark = !( (window.imMapColor==='light') || (window.imMapColor!=='dark' && ((HOST.userTheme==='light')||(HOST.userTheme==='auto'&&window.matchMedia('(prefers-color-scheme: light)').matches))) );
+    /* (#R40) localize + show/hide the water (river/lake/sea) and mountain-peak labels with the same toggle.
+       They keep their own (blue / stone) colors, so they're only given the language expression + visibility. */
+    /* (#R41) water/terrain labels follow their OWN checkbox (geoLabelsOn), independent of place names. */
+    const showGeo = HOST.geoLabelsOn && (sat || HOST.mapLabelsViaVector());
+    try{ ['ofm-river','ofm-water','ofm-water2'].forEach(id=>{ if(!map.getLayer(id)) return; map.setLayoutProperty(id,'visibility',showGeo?'visible':'none'); map.setLayoutProperty(id,'text-field',nameExpr); });
+      if(map.getLayer('ofm-peak')){ map.setLayoutProperty('ofm-peak','visibility',showGeo?'visible':'none'); map.setLayoutProperty('ofm-peak','text-field',['concat','▲ ',nameExpr]); }
+      /* (#R62) fixed sea labels follow the same toggle; language from the gazetteer's own 5 name fields. */
+      if(map.getLayer('geo-sea')){ const gl=(mode==='en')?'en':(mode==='local')?'en':(({jp:'jp',de:'de',ru:'ru',es:'es'})[HOST.lang]||'en');
+        map.setLayoutProperty('geo-sea','visibility',showGeo?'visible':'none'); map.setLayoutProperty('geo-sea','text-field',['get',gl]); }
+      /* (#R64) populate the pinned lake/peak anchors immediately when the toggle turns on */
+      if(showGeo) setTimeout(()=>{ try{ harvestStableLabels(); }catch(_){} },250); }catch(_){}
+    /* (#R103) ROOT FIX for "過去に戻っても国名が変わらない (変化なし)": while the time machine is on a past year the
+       MODERN country labels must stay hidden (the era names come from imtb-lbl/lbl2). applyLabelLang runs on many
+       events (styledata, cb-names, language change…) and was unconditionally RE-SHOWING ofm-country based on namesOn,
+       overriding _applyBorders → the present-day country names kept reappearing under/over the era labels. Keep
+       ofm-country hidden here whenever travelling. City/other place labels stay (they aren't country names). */
+    const _travelingLbl=!!(window.IntMapTimeBorders&&window.IntMapTimeBorders.active&&window.IntMapTimeBorders.active());
+    ['ofm-country','ofm-city','ofm-other'].forEach(id=>{ if(!map.getLayer(id)) return;
+      const _showThis=(id==='ofm-country'&&_travelingLbl)?false:show;
+      map.setLayoutProperty(id,'visibility',_showThis?'visible':'none');
+      map.setLayoutProperty(id,'text-field',nameExpr);
+      /* dark map / satellite → light text; light map → dark text */
+      const lightText = sat || isDark;
+      map.setPaintProperty(id,'text-color', lightText?(id==='ofm-country'?'#eaf0ff':'#ffffff'):'#1b1b1f');
+      map.setPaintProperty(id,'text-halo-color', lightText?'rgba(0,0,0,0.8)':'rgba(255,255,255,0.9)');
+    });
+  }
+  function geoLabel(s){ return (HOST.lang==='jp' && HOST.GEO_LABEL_JP[s]) ? HOST.GEO_LABEL_JP[s] : s; }
+  function buildGeoFC(data){
+    const feats=[];
+    (data.areas||[]).forEach(a=>{
+      const ring=a.ring.slice(); const f=ring[0], l=ring[ring.length-1];
+      if(f[0]!==l[0]||f[1]!==l[1]) ring.push(f);
+      feats.push({type:'Feature',geometry:{type:'Polygon',coordinates:[ring]},properties:{}});
+      if(a.label){ let sx=0,sy=0; a.ring.forEach(p=>{sx+=p[0];sy+=p[1];}); feats.push({type:'Feature',geometry:{type:'Point',coordinates:[sx/a.ring.length,sy/a.ring.length]},properties:{label:geoLabel(a.label)}}); }
+    });
+    (data.lines||[]).forEach(ln=>{
+      const path=(data.smooth&&window.smoothGeoPath)?window.smoothGeoPath(ln.path,16):ln.path;
+      feats.push({type:'Feature',geometry:{type:'LineString',coordinates:path},properties:{kind:ln.kind||''}});
+      if(ln.label){ const m=ln.path[Math.floor(ln.path.length/2)]; feats.push({type:'Feature',geometry:{type:'Point',coordinates:m},properties:{label:geoLabel(ln.label),kind:ln.kind||''}}); }
+    });
+    (data.points||[]).forEach(pt=>{
+      feats.push({type:'Feature',geometry:{type:'Point',coordinates:pt.at},properties:{label:geoLabel(pt.label),marker:1}});
+    });
+    return {type:'FeatureCollection',features:feats};
+  }
+  function ensureGeoLayers(){
+    if(!map) return;
+    /* Style may not be ready yet (e.g. right after setProjection on load). Retry until it is. */
+    if(!map.isStyleLoaded()){ clearTimeout(ensureGeoLayers._t); ensureGeoLayers._t=setTimeout(ensureGeoLayers,160); return; }
+    for(const[key,data] of Object.entries(HOST.geoLayersDB)){
+      if(map.getSource(key)) continue;
+      try{ map.addSource(key,{type:'geojson',data:buildGeoFC(data)}); }catch(e){ continue; }
+      try{
+        if(data.areas&&data.areas.length){
+          map.addLayer({id:key+'-fill',type:'fill',source:key,filter:['==','$type','Polygon'],layout:{visibility:'none'},paint:{'fill-color':data.color,'fill-opacity':0.22}});
+          /* soft, fuzzy zone edge — no hard outline (zones are conceptual, not borders) */
+          map.addLayer({id:key+'-edge',type:'line',source:key,filter:['==','$type','Polygon'],layout:{visibility:'none','line-cap':'round','line-join':'round'},paint:{'line-color':data.color,'line-width':16,'line-opacity':0.18,'line-blur':8}});
+        }
+        /* (#R8) High-quality pipeline network: two-tone OIL/GAS color, a crisp dark casing and
+           zoom-scaled width = an "infrastructure map" look. Other geo lines (theory corridors) carry
+           kind:'' so the match falls through to their single conceptual color — unchanged. */
+        const _pipe=key==='pipelines';
+        const _lineColor=_pipe?['match',['get','kind'],'oil','#d6451f','gas','#f4a72c',data.color]:data.color;
+        map.addLayer({id:key+'-glow',type:'line',source:key,filter:['==','$type','LineString'],layout:{visibility:'none','line-cap':'round','line-join':'round'},paint:{'line-color':_lineColor,'line-width':_pipe?['interpolate',['linear'],['zoom'],1,7,5,14]:10,'line-opacity':_pipe?0.22:0.18,'line-blur':4}});
+        if(_pipe) map.addLayer({id:key+'-casing',type:'line',source:key,filter:['==','$type','LineString'],layout:{visibility:'none','line-cap':'round','line-join':'round'},paint:{'line-color':'#1f0d05','line-width':['interpolate',['linear'],['zoom'],1,3,4,5.5,8,10],'line-opacity':0.6}});
+        map.addLayer({id:key+'-line',type:'line',source:key,filter:['==','$type','LineString'],layout:{visibility:'none','line-cap':'round','line-join':'round'},paint:{'line-color':_lineColor,'line-width':_pipe?['interpolate',['linear'],['zoom'],1,1.6,4,3.2,8,5.5]:3.5,'line-opacity':0.97}});
+        map.addLayer({id:key+'-pt',type:'circle',source:key,filter:['==','marker',1],layout:{visibility:'none'},paint:{'circle-radius':5,'circle-color':data.color,'circle-stroke-color':'#fff','circle-stroke-width':2,'circle-opacity':0.95}});
+        map.addLayer({id:key+'-label',type:'symbol',source:key,filter:['has','label'],layout:{visibility:'none','text-field':['get','label'],'text-size':12,'text-font':['literal',['Noto Sans Regular']],'text-offset':[0,1.1],'text-anchor':'top','text-allow-overlap':false,'symbol-placement':'point'},paint:{'text-color':data.color,'text-halo-color':'rgba(255,255,255,0.95)','text-halo-width':1.8}});
+      }catch(e){ console.warn('geoLayer add fail',key,e); }
+    }
+    updateGeoLayers();
+  }
+  function updateGeoLayers(){
+    if(!map)return;
+    /* (#R13c) If the style is mid-load, a toggle-OFF would silently no-op and the layer would STAY on
+       ("消したはずのレイヤーが残る"). Re-run once the style settles so the on/off state always lands. */
+    if(!map.isStyleLoaded()){ try{ map.once('idle',()=>{ try{ updateGeoLayers(); }catch(_){} }); }catch(_){} return; }
+    const isDark=document.documentElement.getAttribute('data-theme')==='dark';
+    for(const key of Object.keys(HOST.geoLayersDB)){
+      const cb=document.querySelector(`input[data-layer="${key}"]`);
+      const vis=((cb&&cb.checked)||HOST.forceHoverLayers.has(key))?'visible':'none';
+      ['-fill','-edge','-glow','-casing','-line','-pt','-label'].forEach(s=>{ if(map.getLayer(key+s)) map.setLayoutProperty(key+s,'visibility',vis); });
+      if(map.getLayer(key+'-label')) map.setPaintProperty(key+'-label','text-halo-color',isDark?'rgba(0,0,0,0.85)':'rgba(255,255,255,0.95)');
+    }
+  }
+  return { applyLabelLang, buildGeoFC, ensureGeoLayers, ensurePlaceLabels, localizeGeoLabels, updateGeoLayers };
+};

--- a/js/satellite.js
+++ b/js/satellite.js
@@ -1,0 +1,248 @@
+/* ============================================================================
+ *  IntMap · Satellite imagery controller  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.satellite=function(map,HOST){
+  const saveSatKeys=()=>{ try{ localStorage.setItem('intmap_sat_keys',JSON.stringify(HOST.satKeys)); }catch(_){} };
+  const satProviderById=(id)=>HOST.SAT_PROVIDERS.find(p=>p.id===id);
+  /* BYOK/paid satellite providers require Pro AND a saved key; free providers are always usable. */
+  const satHasKey=(p)=>p.tier==='free' || (HOST.imIsPro() && !!(HOST.satKeys[p.keyName]&&String(HOST.satKeys[p.keyName]).trim()));
+  const satMaxDay=()=>new Date().toISOString().slice(0,10);
+  function satMsg(key,p){ return String(HOST.t(key)||'').replace('{provider}',(p&&(p.name[HOST.lang]||p.name.en||p.short))||''); }
+  function satCaptureLabel(p){ if(!p) return ''; if(!p.dated) return HOST.t('satLatest'); if(p.dateMode==='year') return HOST.satState.year+' '+HOST.t('satMosaicSuffix'); return HOST.satState.day; }
+  function satChipHTML(){ const p=satProviderById(HOST.satState.providerId); if(!p) return ''; return `<span class="cr-sat">📡 ${p.short} · ${satCaptureLabel(p)}</span>`; }
+  function satRefreshReadout(){ try{ HOST.renderCoordReadout(); }catch(_){} }
+  function satToast(msg){
+    let el=document.getElementById('sat-toast');
+    if(!el){ el=document.createElement('div'); el.id='sat-toast'; el.className='sat-toast'; document.body.appendChild(el); }
+    el.textContent=msg; el.classList.add('show');
+    clearTimeout(satToast._t); satToast._t=setTimeout(()=>el.classList.remove('show'),4400);
+  }
+  /* Self-rescheduling style-ready guard (same pattern that fixed the layer race). */
+  function satReady(cb,n){ n=n||0; if(map&&map.isStyleLoaded()){ try{cb();}catch(_){ } return; } if(n>80) return; setTimeout(()=>satReady(cb,n+1),160); }
+  function satBuildTiles(p){
+    const da=p.dateMode==='year'?HOST.satState.year:HOST.satState.day;
+    if(p.tier==='pro'){ const k=HOST.satKeys[p.keyName]; if(!k||!String(k).trim()) return null; return p.tiles(da,String(k).trim()); }
+    return p.tiles(da);
+  }
+  /* Core: load the selected provider into the idle buffer, then cross-fade (double-buffering). */
+  function satApply(animate){
+    if(!map) return;
+    const p=satProviderById(HOST.satState.providerId); if(!p) return;
+    HOST.satErrCount=0;
+    /* Esri = the always-present base layer (layer-sat): no buffer needed → it is our fallback. */
+    if(p.id==='esri'){ satShowBase(animate); return; }
+    const tiles=satBuildTiles(p);
+    if(!tiles){ satToast(HOST.t('satLocked')); satRevertToFallback(); return; }
+    if(map.getLayer('layer-sat')) map.setPaintProperty('layer-sat','raster-opacity',1); /* solid fallback under the buffer */
+    const target=(HOST.satActive===0)?1:0, srcId='sat-src-'+target, lyrId='sat-fx-'+target;
+    try{ if(map.getLayer(lyrId)) map.removeLayer(lyrId); if(map.getSource(srcId)) map.removeSource(srcId); }catch(_){}
+    try{
+      map.addSource(srcId,{type:'raster',tiles:tiles,tileSize:256,maxzoom:p.maxzoom||19,attribution:p.attribution||''});
+      const before=map.getLayer('layer-sat-labels')?'layer-sat-labels':undefined;
+      map.addLayer({id:lyrId,type:'raster',source:srcId,layout:{visibility:'visible'},
+        paint:{'raster-opacity':animate?0:HOST.satState.opacity,'raster-opacity-transition':{duration:animate?450:0}}},before);
+    }catch(e){ console.warn('satApply add failed',e); return; }
+    const prev=HOST.satActive;
+    const finish=()=>{
+      if(map.getLayer(lyrId)) map.setPaintProperty(lyrId,'raster-opacity',HOST.satState.opacity);
+      if(prev!==-1 && prev!==target){
+        const pl='sat-fx-'+prev, ps='sat-src-'+prev;
+        if(map.getLayer(pl)){ map.setPaintProperty(pl,'raster-opacity-transition',{duration:450}); map.setPaintProperty(pl,'raster-opacity',0); }
+        setTimeout(()=>{ if(HOST.satActive!==prev){ try{ if(map.getLayer(pl)) map.removeLayer(pl); if(map.getSource(ps)) map.removeSource(ps); }catch(_){} } },520);
+      }
+      HOST.satActive=target; HOST.satLastGood=HOST.satState.providerId; HOST.satErrCount=0;
+    };
+    if(!animate){ finish(); return; }
+    let done=false;
+    const onData=(e)=>{ if(e&&e.sourceId===srcId&&e.isSourceLoaded){ if(done)return; done=true; map.off('sourcedata',onData); finish(); } };
+    map.on('sourcedata',onData);
+    setTimeout(()=>{ if(!done){ done=true; map.off('sourcedata',onData); finish(); } },1900);
+  }
+  function satShowBase(animate){
+    if(HOST.satActive!==-1){
+      const a=HOST.satActive, pl='sat-fx-'+a, ps='sat-src-'+a;
+      if(map.getLayer(pl)){ map.setPaintProperty(pl,'raster-opacity-transition',{duration:animate?450:0}); map.setPaintProperty(pl,'raster-opacity',0); }
+      setTimeout(()=>{ if(HOST.satState.providerId==='esri'){ try{ if(map.getLayer(pl)) map.removeLayer(pl); if(map.getSource(ps)) map.removeSource(ps); }catch(_){} } },animate?520:0);
+      HOST.satActive=-1;
+    }
+    if(map.getLayer('layer-sat')) map.setPaintProperty('layer-sat','raster-opacity',HOST.satState.opacity);
+    HOST.satLastGood='esri';
+  }
+  function satSetOpacity(v){
+    HOST.satState.opacity=v;
+    const p=satProviderById(HOST.satState.providerId);
+    if(p&&p.id==='esri'){ if(map.getLayer('layer-sat')) map.setPaintProperty('layer-sat','raster-opacity',v); }
+    else if(HOST.satActive!==-1&&map.getLayer('sat-fx-'+HOST.satActive)){ map.setPaintProperty('sat-fx-'+HOST.satActive,'raster-opacity',v); }
+  }
+  function satSelectProvider(id){
+    const p=satProviderById(id); if(!p) return;
+    if(!satHasKey(p)){ satToast(HOST.t('satLocked')); satRenderController(); return; }
+    HOST.satState.providerId=id; HOST.satErrCount=0; HOST.satAutoBackoff=0;
+    satRenderController(); satApply(true); satRefreshReadout();
+  }
+  function satStepDay(delta,auto){
+    if(!auto) HOST.satAutoBackoff=0;
+    const d=new Date(HOST.satState.day+'T00:00:00Z'); if(isNaN(d.getTime())) return;
+    d.setUTCDate(d.getUTCDate()+delta);
+    let s=d.toISOString().slice(0,10); const today=satMaxDay(); if(s>today) s=today;
+    HOST.satState.day=s;
+    const inp=document.getElementById('satc-day'); if(inp) inp.value=s;
+    satApply(true); satRefreshReadout();
+  }
+  function satRevertToFallback(){
+    const fb=(HOST.satLastGood&&HOST.satLastGood!==HOST.satState.providerId)?HOST.satLastGood:'esri';
+    HOST.satState.providerId=fb; HOST.satErrCount=0;
+    satRenderController(); satApply(true); satRefreshReadout();
+  }
+  /* Render-state tracking: tile/auth failures on a sat buffer → notify + fall back. */
+  function satOnError(e){
+    if(!e||!e.sourceId||String(e.sourceId).indexOf('sat-src-')!==0) return;
+    const p=satProviderById(HOST.satState.providerId); if(!p) return;
+    const st=e.error&&e.error.status;
+    if(st===401||st===403){ satToast(satMsg('satErrAuth',p)); HOST.satErrCount=0; satRevertToFallback(); return; }
+    HOST.satErrCount++;
+    /* Dated GIBS day-layers: the latest day may not be processed yet → walk back to the freshest
+       AVAILABLE day before giving up, so "latest" really means latest-that-exists. */
+    if(p.dated && p.dateMode==='day' && HOST.satAutoBackoff<5 && HOST.satErrCount>=2){
+      HOST.satAutoBackoff++; HOST.satErrCount=0; satStepDay(-1,true); return;
+    }
+    if(HOST.satErrCount>=4){ HOST.satErrCount=0; satToast(satMsg('satErrTiles',p)); satRevertToFallback(); }
+  }
+  /* Sat-Controller panel (provider + capture-date + opacity). Rebuilt on change / language. */
+  function satRenderController(){
+    const panel=document.getElementById('sat-controller'); if(!panel) return;
+    const p=satProviderById(HOST.satState.providerId)||HOST.SAT_PROVIDERS[0];
+    let opts='';
+    HOST.SAT_PROVIDERS.forEach(pr=>{
+      const sel=pr.id===HOST.satState.providerId?' selected':'', nm=pr.name[HOST.lang]||pr.name.en;
+      if(pr.tier==='free') opts+=`<option value="${pr.id}"${sel}>${nm}</option>`;
+      else { const has=satHasKey(pr); opts+=`<option value="${pr.id}"${sel}${has?'':' disabled'}>${has?'':'🔒 '}${nm}${has?'':' — '+HOST.t('satLocked')}</option>`; }
+    });
+    let dateCtrl;
+    if(p.dated&&p.dateMode==='day'){
+      dateCtrl=`<div class="satc-row"><label>${HOST.t('satDate')}</label><div class="satc-date"><button class="satc-step" id="satc-prev" title="${HOST.t('satPrevDay')}">◀</button><input type="date" id="satc-day" value="${HOST.satState.day}" max="${satMaxDay()}"><button class="satc-step" id="satc-next" title="${HOST.t('satNextDay')}">▶</button></div></div>`;
+    } else if(p.dated&&p.dateMode==='year'){
+      const yo=p.years.map(y=>`<option value="${y}"${y===HOST.satState.year?' selected':''}>${y}</option>`).join('');
+      dateCtrl=`<div class="satc-row"><label>${HOST.t('satDate')}</label><select id="satc-year">${yo}</select></div>`;
+    } else {
+      dateCtrl=`<div class="satc-row"><label>${HOST.t('satDate')}</label><span class="satc-latest">${HOST.t('satLatest')}</span></div>`;
+    }
+    panel.innerHTML=`<div class="satc-head">📡 <span>${HOST.t('satCtrlTitle')}</span><button id="satc-close" title="${HOST.lang==='jp'?'閉じる':HOST.lang==='de'?'Schließen':HOST.lang==='ru'?'Закрыть':HOST.lang==='es'?'Cerrar':'Close'}" aria-label="Close" style="margin-left:auto;background:transparent;border:none;color:var(--text-muted);width:26px;height:26px;font-size:22px;font-weight:300;line-height:1;cursor:pointer;">×</button></div>`+
+      `<div class="satc-row"><label>${HOST.t('satProvider')}</label><select id="satc-provider">${opts}</select></div>`+
+      dateCtrl+
+      `<div class="satc-row"><label>${HOST.t('opacity')}</label><input type="range" id="satc-op" min="0.2" max="1" step="0.05" value="${HOST.satState.opacity}"></div>`+
+      aiSatChangeBlockHTML(p)+
+      `<div class="satc-attr">${p.attribution||''}</div>`;
+    const sp=panel.querySelector('#satc-provider'); if(sp) sp.onchange=ev=>satSelectProvider(ev.target.value);
+    const dd=panel.querySelector('#satc-day'); if(dd) dd.onchange=ev=>{ HOST.satState.day=ev.target.value||HOST.satState.day; satApply(true); satRefreshReadout(); };
+    const yy=panel.querySelector('#satc-year'); if(yy) yy.onchange=ev=>{ HOST.satState.year=parseInt(ev.target.value,10)||HOST.satState.year; satApply(true); satRefreshReadout(); };
+    const pv=panel.querySelector('#satc-prev'); if(pv) pv.onclick=()=>satStepDay(-1);
+    const nx=panel.querySelector('#satc-next'); if(nx) nx.onclick=()=>satStepDay(1);
+    const op=panel.querySelector('#satc-op'); if(op) op.oninput=ev=>satSetOpacity(parseFloat(ev.target.value));
+    const cb=panel.querySelector('#ai-satchange-btn'); if(cb){ cb.classList.toggle('ai-needs-key',!HOST.aiVisionReady()); cb.title=HOST.aiVisionReady()?'':(HOST.aiReady()?HOST.t('aiNoVision'):HOST.t('aiNoKey')); cb.onclick=aiSatChangeDetect; }
+    const cl=panel.querySelector('#satc-close'); if(cl) cl.onclick=()=>{ HOST.satPanelDismissed=true; panel.style.display='none'; };
+  }
+  /* Settings-modal API-key management (Pro / BYOK providers). */
+  function satRenderKeyInputs(){
+    const wrap=document.getElementById('sat-keys-list'); if(!wrap) return;
+    /* Only Pro users may register their own (paid) satellite imagery providers. */
+    if(!HOST.imIsPro()){
+      wrap.innerHTML=`<div style="font-size:12.5px;color:var(--text-muted);line-height:1.55;padding:4px 0;">${HOST.lang==='jp'?'🔒 独自の衛星画像サービス（API連携）を追加できるのは <b>Pro</b> ユーザーのみです。':HOST.lang==='de'?'🔒 Nur <b>Pro</b>-Nutzer können eigene Satellitenbild-Dienste (API-Integrationen) hinzufügen.':HOST.lang==='ru'?'🔒 Только пользователи <b>Pro</b> могут добавлять собственные сервисы спутниковых снимков (API).':HOST.lang==='es'?'🔒 Solo los usuarios <b>Pro</b> pueden añadir sus propios servicios de imágenes satelitales (API).':'🔒 Only <b>Pro</b> users can add their own satellite imagery services (API integrations).'}<br><button type="button" id="sat-keys-upgrade" style="margin-top:8px;background:linear-gradient(135deg,#ffe08a,#e9b949);color:#7a5a00;border:none;padding:8px 14px;border-radius:8px;font-weight:700;font-size:12px;cursor:pointer;">${HOST.lang==='jp'?'IntMap Pro を見る':HOST.lang==='de'?'IntMap Pro ansehen':HOST.lang==='ru'?'Смотреть IntMap Pro':HOST.lang==='es'?'Ver IntMap Pro':'See IntMap Pro'}</button></div>`;
+      const up=wrap.querySelector('#sat-keys-upgrade'); if(up) up.onclick=()=>{ try{ if(typeof window.openProModal==='function') window.openProModal(); }catch(_){} };
+      return;
+    }
+    wrap.innerHTML=HOST.SAT_PROVIDERS.filter(p=>p.tier==='pro').map(p=>{
+      const v=HOST.satKeys[p.keyName]||'', on=!!String(v).trim();
+      const nm=(p.keyLabel&&(p.keyLabel[HOST.lang]||p.keyLabel.en))||(p.name[HOST.lang]||p.name.en);
+      return `<div class="sat-key-row"><div class="sat-key-top"><span class="sat-key-name">${nm}</span>`+
+        `<span class="sat-key-status ${on?'on':''}">${on?'● '+HOST.t('satKeyConnected'):'○ '+HOST.t('satKeyNone')}</span></div>`+
+        `<input type="text" class="sat-key-input" data-keyname="${p.keyName}" value="${String(v).replace(/"/g,'&quot;')}" placeholder="${String(p.keyPh||'').replace(/"/g,'&quot;')}" autocomplete="off" autocapitalize="off" spellcheck="false"></div>`;
+    }).join('');
+  }
+  function satSaveKeyInputs(){
+    const wrap=document.getElementById('sat-keys-list'); if(!wrap) return;
+    wrap.querySelectorAll('.sat-key-input').forEach(inp=>{ const k=inp.getAttribute('data-keyname'), val=inp.value.trim(); if(val) HOST.satKeys[k]=val; else delete HOST.satKeys[k]; });
+    saveSatKeys();
+    const cur=satProviderById(HOST.satState.providerId);
+    if(cur&&cur.tier==='pro'&&!satHasKey(cur)&&HOST.mapType==='sat') satRevertToFallback();
+    else if(HOST.mapType==='sat') satRenderController();
+  }
+  function satSetup(){
+    if(!map) return;
+    if(!satSetup._wired){ satSetup._wired=true; try{ map.on('error',satOnError); }catch(_){}
+      /* (#R24) auto-dismiss the FLOATING satellite controller when the user starts operating elsewhere
+         ("それ以外の場所を操作し始めたら自動で消える"); it re-opens via the Satellite button (which resets
+         satPanelDismissed). On mobile it lives inside the sheet (not floating), so leave that one alone. */
+      const _satDismiss=()=>{ try{ const p=document.getElementById('sat-controller');
+        if(p && p.style.display==='block' && !(window.matchMedia&&window.matchMedia('(max-width:768px)').matches)){ HOST.satPanelDismissed=true; p.style.display='none'; } }catch(_){} };
+      try{ map.on('dragstart',_satDismiss); map.on('zoomstart',(e)=>{ if(e&&e.originalEvent) _satDismiss(); }); }catch(_){}
+      document.addEventListener('pointerdown',(e)=>{ try{ const p=document.getElementById('sat-controller');
+        if(p && p.style.display==='block' && e.target && !e.target.closest('#sat-controller') && !e.target.closest('#btn-view-sat')) _satDismiss(); }catch(_){} }, true);
+    }
+    if(HOST.mapType==='sat') satReady(()=>{ satRenderController(); satApply(false); });
+  }
+  /* ===== AI FEATURE 4: satellite change detection (vision) =====
+     Capture the map canvas at two dates and ask a vision model to compare them. Requires
+     preserveDrawingBuffer:true on the map (set in the map config) + a vision-capable model. */
+  function aiSatChangeBlockHTML(p){
+    if(!p||!p.dated) return '';
+    const today=satMaxDay(); let inputs;
+    if(p.dateMode==='year'){
+      const yo=v=>(p.years||[]).map(y=>`<option value="${y}"${y===v?' selected':''}>${y}</option>`).join('');
+      inputs=`<select id="aic-date-a">${yo((p.years||[])[0])}</select><span>→</span><select id="aic-date-b">${yo((p.years||[])[(p.years||[]).length-1])}</select>`;
+    } else {
+      const dA=new Date(Date.now()-33*864e5).toISOString().slice(0,10);
+      inputs=`<input type="date" id="aic-date-a" value="${dA}" max="${today}"><span>→</span><input type="date" id="aic-date-b" value="${HOST.satState.day}" max="${today}">`;
+    }
+    return `<div class="aic-sec"><div class="aic-head">🛰 ${HOST.t('aiVisHead')}</div><div class="aic-dates">${inputs}</div><button class="ai-action-btn" id="ai-satchange-btn">✨ ${HOST.t('aiVisBtn')}</button></div>`;
+  }
+  function aiDownscaleDataURL(canvas,maxDim){
+    try{ const w=canvas.width,h=canvas.height,s=Math.min(1,(maxDim||1024)/Math.max(w,h));
+      const c=document.createElement('canvas'); c.width=Math.max(1,Math.round(w*s)); c.height=Math.max(1,Math.round(h*s));
+      c.getContext('2d').drawImage(canvas,0,0,c.width,c.height); return c.toDataURL('image/jpeg',0.85);
+    }catch(e){ return null; }
+  }
+  async function aiCaptureSatAt(p,val){
+    if(p.dateMode==='year') HOST.satState.year=parseInt(val,10)||HOST.satState.year; else HOST.satState.day=val;
+    try{ satApply(false); }catch(_){}
+    await HOST.aiWaitMapIdle(5000);
+    await new Promise(r=>setTimeout(r,500)); /* let the cross-fade buffer cleanup settle */
+    return await aiCaptureCanvas(1024);
+  }
+  /* Read the WebGL canvas INSIDE a render tick so capture works without preserveDrawingBuffer
+     (a WebGL drawing buffer is only guaranteed valid in the same frame it was drawn). */
+  function aiCaptureCanvas(maxDim){
+    return new Promise(res=>{
+      if(!map){ res(null); return; }
+      let done=false; const grab=()=>{ if(done)return; done=true; try{ res(aiDownscaleDataURL(map.getCanvas(),maxDim)); }catch(_){ res(null); } };
+      try{ map.once('render',grab); map.triggerRepaint(); }catch(_){ grab(); }
+      setTimeout(grab,900); /* safety net if no render event fires */
+    });
+  }
+  async function aiSatChangeDetect(){
+    if(!HOST.aiGate()) return;
+    const aEl=document.getElementById('aic-date-a'), bEl=document.getElementById('aic-date-b');
+    const va=aEl&&aEl.value, vb=bEl&&bEl.value;
+    const btn=document.getElementById('ai-satchange-btn'); HOST.aiSetBtnBusy(btn,true,HOST.t('aiVisCapturing'));
+    const cap=await window._imSatCapture(va,vb);
+    HOST.aiSetBtnBusy(btn,false);
+    if(cap.err){ HOST.aiToast(cap.err); return; }
+    const imgA=cap.imgA, imgB=cap.imgB;
+    const rep=HOST.aiReport({ title:HOST.t('aiVisTitle'), sub:HOST.t('aiVisSub').replace('{a}',va).replace('{b}',vb),
+      images:[{src:imgA,caption:HOST.t('aiVisBefore')+' · '+va},{src:imgB,caption:HOST.t('aiVisAfter')+' · '+vb}] });
+    const run=async()=>{
+      rep.setLoading(HOST.t('aiThinking'));
+      try{ const out=await window._imSatAnalyze(va,vb,imgA,imgB); rep.setBody(out||''); }
+      catch(e){ rep.setError((e&&e.message)||HOST.t('aiError'),run); }
+    };
+    run();
+  }
+  return { aiCaptureSatAt, satApply, satBuildTiles, satCaptureLabel, satChipHTML, satHasKey, satProviderById, satReady, satRefreshReadout, satRenderController, satRenderKeyInputs, satRevertToFallback, satSaveKeyInputs, satSelectProvider, satSetOpacity, satSetup, satStepDay, satToast };
+};

--- a/js/search-geocode.js
+++ b/js/search-geocode.js
@@ -1,0 +1,192 @@
+/* ============================================================================
+ *  IntMap · Search box: query pre-processing, geocoding and the result card  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.searchGeocode=function(map,HOST){
+  /* ===== Map-side global place search (Nominatim) + abstract / natural-language pre-processing =====
+   * Handles patterns like:
+   *   - "capital of <country>"
+   *   - "highest mountain in <country>"
+   *   - "largest city in <country>"
+   *   - "<place> nearest to <city>"
+   *   - country names by stat ("country with highest GDP")
+   * For anything we can't pattern-match, we just hand the raw query to Nominatim, which
+   * itself is reasonably forgiving for natural-language queries.
+   */
+  function preprocessNLQuery(q){
+    const ql=q.toLowerCase().trim();
+    /* "capital of <country>" → look up CAPITAL[code] */
+    const mCap=ql.match(/^capital\s+of\s+(.+)$/) || ql.match(/^(.+?)の首都$/);
+    if(mCap){
+      const name=mCap[1].trim();
+      const hit=Object.values(HOST.countryStats||{}).find(s=>{
+        const en=(s.nameEn||'').toLowerCase(), jp=s.nameJp||'';
+        return en===name || en.includes(name) || jp.includes(name);
+      });
+      if(hit && hit.capital) return hit.capital+', '+hit.nameEn;
+    }
+    /* "country with the highest <stat>" */
+    const STAT_KEYS={'gdp':'gdp','economy':'gdp','population':'pop','area':'area','hdi':'hdi','democracy':'dem','military':'milSpend','life expectancy':'lifeExp','internet':'internet'};
+    const mHigh=ql.match(/^(?:country|nation)\s+(?:with\s+)?(?:the\s+)?(?:highest|largest|biggest|most)\s+(.+)$/);
+    if(mHigh){
+      const key=Object.keys(STAT_KEYS).find(k=>mHigh[1].includes(k));
+      if(key){ const sk=STAT_KEYS[key]; const top=Object.values(HOST.countryStats).filter(s=>s[sk]!=null).sort((a,b)=>b[sk]-a[sk])[0]; if(top) return top.nameEn; }
+    }
+    /* Japanese: "X 最大" / "X 最高" → similar fallback */
+    const mJpHigh=ql.match(/^(.+?)(が|の)?(最大|最多|最高)(?:の国)?$/);
+    if(mJpHigh){
+      const w=mJpHigh[1].trim();
+      const map={'人口':'pop','GDP':'gdp','面積':'area','軍事費':'milSpend','HDI':'hdi'};
+      const sk=map[w]; if(sk){ const top=Object.values(HOST.countryStats).filter(s=>s[sk]!=null).sort((a,b)=>b[sk]-a[sk])[0]; if(top) return top.nameEn; }
+    }
+    return q;
+  }
+  /* (#R15) Tiny Levenshtein for tolerant (fuzzy) matching of short queries. */
+  function _lev(a,b){ a=a||'';b=b||''; const m=a.length,n=b.length; if(!m)return n; if(!n)return m;
+    let prev=Array.from({length:n+1},(_,j)=>j), cur=new Array(n+1);
+    for(let i=1;i<=m;i++){ cur[0]=i; for(let j=1;j<=n;j++){ const c=a[i-1]===b[j-1]?0:1; cur[j]=Math.min(prev[j]+1,cur[j-1]+1,prev[j-1]+c); } [prev,cur]=[cur,prev]; }
+    return prev[n]; }
+  /* (#R15 / #34) Local fuzzy place lookup — resolves vague / partial / slightly-misspelled queries
+     against bundled country names, capitals and the built-in gazetteer, so search still works when the
+     external geocoder is slow / rate-limited / too strict for a loose query. Returns scored {name,lng,lat}. */
+  function localFuzzyPlaces(q){
+    const ql=(q||'').toLowerCase().trim(); if(!ql) return [];
+    const out=[];
+    const push=(name,lng,lat,score,kind)=>{ lng=+lng;lat=+lat; if(isNaN(lng)||isNaN(lat))return; out.push({name,lng,lat,score,kind:kind||''}); };   /* (#R46) kind = scale hint (country/capital/city/…) for Atlas zoom */
+    try{ Object.values(HOST.countryStats||{}).forEach(s=>{
+      if(!s.latlng) return; const en=(s.nameEn||'').toLowerCase(), jp=(s.nameJp||''), cap=(s.capital||'').toLowerCase();
+      let sc=0, suffix='';
+      if(en===ql||(jp&&jp===q)) sc=100;
+      else if(en.startsWith(ql)) sc=86;
+      else if(cap===ql){ sc=82; suffix=' · '+s.capital; }
+      else if(en.includes(ql)||(jp&&jp.includes(q))) sc=72;
+      else if(en.split(/\s+/).some(w=>w.startsWith(ql))&&ql.length>=3) sc=66;   /* (#R19) word-prefix: "zeal"→New Zealand */
+      else if(cap.includes(ql)&&ql.length>=3){ sc=58; suffix=' · '+s.capital; }
+      else if(ql.length>=4 && _lev(en,ql)<=2) sc=62;
+      else if(ql.length>=5 && cap && _lev(cap,ql)<=2){ sc=56; suffix=' · '+s.capital; }   /* (#R19) misspelled capital */
+      if(sc>0) push(s.nameEn+suffix, s.latlng[1], s.latlng[0], sc, suffix?'capital':'country');
+    }); }catch(_){}
+    try{ const gz=(typeof HOST.BUILTIN_GAZETTEER!=='undefined')?HOST.BUILTIN_GAZETTEER:null;
+      if(gz) for(const type in gz){ gz[type].forEach(e=>{ const terms=Array.isArray(e.terms)?e.terms.join(' '):String(e.terms||''); const tl=terms.toLowerCase(); const nm=(e.name&&(e.name[HOST.lang]||e.name.en))||terms;
+        const words=tl.split(/[|,\s]+/);
+        let sc=0; if(words.includes(ql)) sc=88; else if(words.some(w=>w.startsWith(ql))&&ql.length>=3) sc=68;   /* (#R19) prefix */
+        else if(tl.includes(ql)&&ql.length>=3) sc=64;
+        else if(ql.length>=4 && words.some(w=>w.length>=4&&_lev(w,ql)<=2)) sc=58;   /* (#R19) per-word typo tolerance */
+        if(sc>0 && e.loc) push(nm, e.loc[0], e.loc[1], sc, type); }); }
+    }catch(_){}
+    const seen=new Set();
+    return out.sort((a,b)=>b.score-a.score).filter(x=>{ const k=x.name+'|'+x.lng.toFixed(1)+'|'+x.lat.toFixed(1); if(seen.has(k))return false; seen.add(k); return true; }).slice(0,7);
+  }
+  async function doGeocode(){
+    const inp=document.getElementById('ms-input'), q=inp.value.trim(), res=document.getElementById('ms-results'); if(!q)return;
+    res.style.display='block';
+    /* (#R15e) Make sure the bundled country data is loading so local country/capital matches are available
+       (the gazetteer is always loaded; countryStats may not be until Stats is opened). Non-blocking. */
+    try{ if(typeof HOST.loadCountryData==='function' && (typeof HOST.countryStats==='undefined' || !HOST.countryStats || !Object.keys(HOST.countryStats).length)) HOST.loadCountryData(); }catch(_){}
+    const pq=preprocessNLQuery(q);
+    const local=localFuzzyPlaces(q);
+    const seen=new Set();
+    const addItem=(label,lng,lat,raw)=>{ if(isNaN(lng)||isNaN(lat))return; const key=label+'|'+lng.toFixed(2)+'|'+lat.toFixed(2); if(seen.has(key))return; seen.add(key);
+      const d=document.createElement('div'); d.className='ms-item'; d.textContent=label; d.onclick=()=>{ gotoPlace(lng,lat,label,raw||null); res.style.display='none'; inp.value=String(label).split(',')[0].split(' · ')[0]; }; res.appendChild(d); };
+    /* (#R15e) Show strong LOCAL matches IMMEDIATELY — was awaiting Nominatim with no timeout, so a slow /
+       unreachable geocoder left the box frozen on "Loading…" forever ("結果が出てこない"). Now local
+       (countries/capitals/gazetteer) appear instantly; the external geocoder is merged in with a hard
+       timeout so it can never hang the search. */
+    res.innerHTML='';
+    local.filter(l=>l.score>=72).forEach(l=>addItem(l.name,l.lng,l.lat,null));
+    if(!res.children.length) res.innerHTML=`<div class="ms-loading">${HOST.t('loading')}</div>`;
+    /* (#R16) The mobile "no results" bug: under file:// / on mobile networks Nominatim is often rate-limited,
+       blocked (null Origin) or just slow, and on a fresh load countryStats isn't loaded yet, so there was
+       NOTHING to show. Now query TWO CORS-friendly geocoders in PARALLEL behind one hard timeout —
+       **Open-Meteo geocoding** (fast, robust, fuzzy, works where Nominatim doesn't) AND Nominatim (richer
+       coverage). Either one alone yields results, so the search practically never comes back empty. */
+    const ctrl=new AbortController(); const to=setTimeout(()=>{ try{ctrl.abort();}catch(_){} },5000);
+    const omP=fetch(`https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(q)}&count=6&language=${HOST.lang==='jp'?'ja':'en'}&format=json`,{signal:ctrl.signal})
+      .then(r=>r.ok?r.json():null).then(j=>{ (j&&j.results||[]).forEach(p=>{ if(p.latitude==null||p.longitude==null)return; const adm=[p.admin1,p.country].filter(Boolean).join(', '); addItem(p.name+(adm?', '+adm:''),+p.longitude,+p.latitude,{display_name:p.name,type:p.feature_code,address:{country:p.country}}); }); }).catch(()=>{});
+    const nomP=fetch(`https://nominatim.openstreetmap.org/search?format=jsonv2&limit=6&accept-language=${HOST.lang==='jp'?'ja':'en'}&q=${encodeURIComponent(pq)}`,{signal:ctrl.signal})
+      .then(r=>r.ok?r.json():[]).then(a=>{ (a||[]).forEach(pl=>addItem(pl.display_name,+pl.lon,+pl.lat,pl)); }).catch(()=>{});
+    /* (#R19) Third parallel geocoder: Photon (komoot) — TYPO-TOLERANT like a search engine
+       ("あいまいな単語を入れても検索できるように"; curl-verified CORS* and that "osakaa" → Osaka). */
+    const phP=fetch(`https://photon.komoot.io/api/?q=${encodeURIComponent(q)}&limit=6&lang=${HOST.lang==='jp'?'en':'en'}`,{signal:ctrl.signal})
+      .then(r=>r.ok?r.json():null).then(j=>{ (j&&j.features||[]).forEach(f=>{ try{ const p=f.properties||{}, g=f.geometry; if(!g||!g.coordinates) return;
+        const label=[p.name,p.city,p.state,p.country].filter(Boolean).filter((v,i,a)=>a.indexOf(v)===i).join(', ');
+        if(label) addItem(label,+g.coordinates[0],+g.coordinates[1],{display_name:label,type:p.osm_value||p.type,address:{country:p.country}}); }catch(_){} }); }).catch(()=>{});
+    await Promise.allSettled([omP,nomP,phP]); clearTimeout(to);
+    const lo=res.querySelector('.ms-loading'); if(lo) lo.remove();
+    if(!res.querySelector('.ms-item')){ res.innerHTML=''; local.forEach(l=>addItem(l.name,l.lng,l.lat,null)); }   /* weak local fallback */
+    if(!res.querySelector('.ms-item')){ res.innerHTML=`<div class="ms-loading">${HOST.t('noMatch')}</div>`; }
+  }
+  let searchCardEl=null, searchCardData=null, searchCardOnMove=null;
+  function closeSearchCard(){
+    if(HOST.searchMarker){ HOST.searchMarker.remove(); HOST.searchMarker=null; }
+    if(searchCardEl){ searchCardEl.remove(); searchCardEl=null; }
+    if(searchCardOnMove && map){ map.off('move',searchCardOnMove); searchCardOnMove=null; }
+    searchCardData=null;
+  }
+  function positionSearchCard(){
+    if(!searchCardEl||!searchCardData||!map) return;
+    const pt=map.project([searchCardData.lng,searchCardData.lat]);
+    searchCardEl.style.left=pt.x+'px';
+    searchCardEl.style.top=pt.y+'px';
+  }
+  async function gotoPlace(lng,lat,displayName,raw){
+    if(!map)return;
+    closeSearchCard();
+    map.flyTo({center:[lng,lat],zoom:9,speed:1.4});
+    /* Build custom HTML pin element */
+    const pinEl=document.createElement('div');
+    pinEl.className='search-pin';
+    pinEl.innerHTML='<div class="sp-body"></div><div class="sp-pulse"></div>';
+    HOST.searchMarker=new maplibregl.Marker({element:pinEl,anchor:'bottom'}).setLngLat([lng,lat]).addTo(map);
+    /* Build the result card */
+    searchCardData={lng,lat,name:displayName,raw};
+    searchCardEl=document.createElement('div');
+    searchCardEl.className='search-result-card';
+    document.getElementById('map-container').appendChild(searchCardEl);
+    /* Try to enrich with admin info via reverse geocode (Nominatim) */
+    let admin='', type='', country='';
+    try{
+      if(raw){ admin=raw.display_name||''; type=raw.type||raw.class||''; country=raw.address&&raw.address.country||''; }
+    }catch(_){}
+    const parts=(displayName||'').split(',');
+    const primary=parts[0]||displayName||'';
+    const restAdmin=parts.slice(1,4).map(s=>s.trim()).filter(Boolean).join(', ');
+    searchCardEl.innerHTML=`<button class="src-card-close" title="${HOST.t('close')}">✕</button>
+      <div class="src-card">
+        <h4>📍 ${IntMapSafe.html(primary)}</h4>
+        <div class="src-sub">${IntMapSafe.html(restAdmin||country||'')}</div>
+        <div class="src-row"><span>${HOST.t('coords')}</span><b>${HOST.fmtLL(lng,lat)}</b></div>
+        ${type?`<div class="src-row"><span>${HOST.lang==='jp'?'種別':HOST.lang==='de'?'Typ':HOST.lang==='ru'?'Тип':HOST.lang==='es'?'Tipo':'Type'}</span><b>${IntMapSafe.html(type)}</b></div>`:''}
+        <div class="src-row"><span>${HOST.t('elev')}</span><b id="src-elev">${HOST.lang==='jp'?'取得中...':HOST.lang==='de'?'Lädt…':HOST.lang==='ru'?'Загрузка…':HOST.lang==='es'?'Cargando…':'Loading...'}</b></div>
+        <div class="src-actions">
+          <button class="primary" id="src-copy">📋 ${HOST.t('ctxCopy')}</button>
+          <button id="src-pin">📍 ${HOST.t('ctxDropPin')}</button>
+        </div>
+      </div>`;
+    searchCardEl.querySelector('.src-card-close').onclick=closeSearchCard;
+    searchCardEl.querySelector('#src-copy').onclick=()=>{ try{ navigator.clipboard.writeText(`${lat.toFixed(5)}, ${lng.toFixed(5)}`); }catch(_){} };
+    searchCardEl.querySelector('#src-pin').onclick=()=>{ const id=HOST.addPin(lng,lat); HOST.openPinPopup(id); };
+    /* (#R36) rAF-coalesce the per-move reposition (mobile pan/zoom smoothness #13): `move` can fire several
+       times per frame during inertia, and positionSearchCard does layout (getBoundingClientRect + style writes);
+       collapse it to at most once per frame so it never piles up work mid-gesture. */
+    let _scRAF=0; searchCardOnMove=()=>{ if(_scRAF) return; _scRAF=requestAnimationFrame(()=>{ _scRAF=0; try{ positionSearchCard(); }catch(_){} }); }; map.on('move',searchCardOnMove);
+    positionSearchCard();
+    /* Async elevation / depth */
+    try{
+      const r=await fetch(`https://api.open-meteo.com/v1/elevation?latitude=${lat.toFixed(4)}&longitude=${lng.toFixed(4)}`);
+      let e=null; if(r.ok){ const j=await r.json(); e=j&&j.elevation&&j.elevation[0]; }
+      const el=searchCardEl&&searchCardEl.querySelector('#src-elev');
+      if(el){
+        if(typeof e==='number' && e>0.5){ el.textContent=HOST.fmtElevVal(e); }
+        else { const d=await HOST.fetchBathymetry(lat,lng); if(typeof d==='number'){ el.textContent = d<0 ? (HOST.fmtElevVal(Math.abs(d))+' '+(HOST.lang==='jp'?'(水深)':HOST.lang==='de'?'(Tiefe)':HOST.lang==='ru'?'(глубина)':HOST.lang==='es'?'(profundidad)':'(depth)')) : HOST.fmtElevVal(d); } else if(typeof e==='number'){ el.textContent=HOST.fmtElevVal(e); } else el.textContent='—'; }
+      }
+    }catch(_){}
+  }
+  return { doGeocode, localFuzzyPlaces };
+};

--- a/js/window-manager.js
+++ b/js/window-manager.js
@@ -1,0 +1,93 @@
+/* ============================================================================
+ *  IntMap · Floating-panel drag / resize / z-order  (#R169)
+ * ----------------------------------------------------------------------------
+ *  Moved VERBATIM out of the index.html DOMContentLoaded closure (Architecture.md §3.1).
+ *  Every statement here is a DECLARATION — the factory runs no app code, so it can be
+ *  instantiated with the other #R168/#R169 factories right after `map` exists.
+ *  The only edit to the moved text is that free references to closure variables became
+ *  HOST.<member> reads/writes.
+ * ==========================================================================*/
+window.IntMapModules=window.IntMapModules||{};
+window.IntMapModules.windowManager=function(map,HOST){
+  /* (#R14) Draggable panels now support TOUCH too (mobile users reported the tool panel "couldn't be
+     moved" — only onmousedown was wired) and CLAMP to the offset-parent so a panel can never be dragged
+     off-screen and become unreachable (the other half of the mobile measure complaint, #7). */
+  function makeDraggable(panel,handle){
+    /* (#R27) ROOT CAUSE of "ポップアップや凡例の×を押しても反応しない" on mobile: the drag handle is the
+       panel HEADER, which CONTAINS the close ×. The touchstart below calls preventDefault() — and on
+       touch devices preventDefault on touchstart CANCELS the synthesized click, so the ×'s onclick never
+       fired. (On desktop, mousedown-preventDefault does NOT cancel click, which is why it worked there.)
+       Fix: if the gesture STARTS on a button / control, don't start a drag and don't preventDefault —
+       let the tap become a normal click. Dragging from the empty header area still works. */
+    const NODRAG='button, input, select, textarea, a, label, [role="button"], .layer-popup-x, .legend-min, .tp-close, .kip-x, .country-popup-close, .pin-popup-close, .src-card-close, .satc-close, .wgt-x, .wgt-cfg';
+    const onCtl=(e)=>{ try{ return !!(e.target&&e.target.closest&&e.target.closest(NODRAG)); }catch(_){ return false; } };
+    const clampTo=(l,t)=>{ const op=panel.offsetParent||document.documentElement; const ow=op.clientWidth||window.innerWidth, oh=op.clientHeight||window.innerHeight; const pw=panel.offsetWidth||0, ph=panel.offsetHeight||0; return [Math.max(6,Math.min(ow-Math.min(pw,ow)-6,l)), Math.max(6,Math.min(oh-Math.min(ph,oh)-6,t))]; };
+    /* (#R16) Write position with INLINE !important. On mobile the .tool-panel rule pins
+       `left:12px!important; top:auto!important`, which silently beat the drag's plain inline styles —
+       so panels "couldn't be moved" / "only moved left-right". Inline-!important beats stylesheet-
+       !important, so the drag now fully controls BOTH axes on phones. data-dragged lets any
+       :not([data-dragged]) auto-placement leave it alone. */
+    const move=(cx,cy)=>{ if(!HOST.panelDrag)return; const c=clampTo(HOST.panelDrag.l+cx-HOST.panelDrag.x, HOST.panelDrag.t+cy-HOST.panelDrag.y);
+      panel.style.setProperty('left',c[0]+'px','important'); panel.style.setProperty('top',c[1]+'px','important');
+      panel.style.setProperty('right','auto','important'); panel.style.setProperty('bottom','auto','important');
+      panel.setAttribute('data-dragged','1'); };
+    /* (#R79b) when this panel is wrapped inside a workspace window, the WINDOW owns drag/resize — the panel's
+       own handlers would fight it (the Atlas input field "moved freely" while resizing). Bail out cleanly. */
+    /* (#R79b/#R153) Disable a panel's OWN drag ONLY when it IS a workspace window's content — i.e. a DIRECT child of
+       .ws-body (the moved source elements: Atlas panel, News/Countries feed, #map-container). In workspace mode the whole
+       #map-container is relocated INTO the map window, so every in-map popup (tool-panel, legends, etc.) became a DEEP
+       descendant of a .ws-win and the old `closest('.ws-win')` test wrongly killed their drag ("ワークスペースモード内の
+       地図内のポップアップは自由に動かせない"). A direct-child-of-.ws-body test protects the window content while letting
+       genuinely-floating in-map popups drag again (their offset-parent-relative math already clamps them inside the map). */
+    const _inWsWin=()=>{ try{ return !!(panel.parentElement&&panel.parentElement.classList&&panel.parentElement.classList.contains('ws-body')); }catch(_){ return false; } };
+    handle.onmousedown=(e)=>{ if(onCtl(e)||panel.dataset.resizing||_inWsWin()) return; HOST.panelDrag={x:e.clientX,y:e.clientY,l:panel.offsetLeft,t:panel.offsetTop}; e.preventDefault(); document.onmousemove=(ev)=>move(ev.clientX,ev.clientY); document.onmouseup=()=>{ HOST.panelDrag=null; document.onmousemove=null; document.onmouseup=null; }; };
+    handle.addEventListener('touchstart',(e)=>{ if(onCtl(e)||panel.dataset.resizing||_inWsWin()) return; const tc=e.touches[0]; if(!tc)return; HOST.panelDrag={x:tc.clientX,y:tc.clientY,l:panel.offsetLeft,t:panel.offsetTop}; e.preventDefault();
+      const mv=(ev)=>{ const t2=ev.touches[0]; if(t2) move(t2.clientX,t2.clientY); };
+      const up=()=>{ HOST.panelDrag=null; document.removeEventListener('touchmove',mv); document.removeEventListener('touchend',up); };
+      document.addEventListener('touchmove',mv,{passive:false}); document.addEventListener('touchend',up); },{passive:false});
+    registerWindow(panel);   /* (#R47) any draggable panel also gets click-to-front + all-edge resize */
+  }
+  /* ================= (#R47) Window manager — the user: "前後位置が切り替わらない／触れたものを全面に／右下だけの
+     リサイズは不便／移動・リサイズのマークは要らない". One small system applied to every floating window+popup:
+       • bringToFront(el): clicking ANY managed window raises it above the others (capped below modals).
+       • addEdgeResize(el): resize from ANY edge or corner with NO visible handle (hit-tested border zone),
+         replacing the native bottom-right-only `resize:both` grab-mark.
+     makeDraggable auto-registers its panel; bigger windows (Atlas, Compare) also add edge-resize. ================= */
+  const __winReg=new Set();
+let __winZ=4300;
+  function bringToFront(el){ if(!el) return; try{ let mx=4300; __winReg.forEach(w=>{ if(w===el||!w.isConnected) return; const z=parseInt(w.style.zIndex,10)||0; if(z>mx&&z<6000) mx=z; }); __winZ=Math.min(5999,Math.max(__winZ,mx)+1); el.style.zIndex=String(__winZ); }catch(_){} }
+  function registerWindow(el){ if(!el||__winReg.has(el)) return; __winReg.add(el); try{ el.addEventListener('pointerdown',()=>bringToFront(el),true); }catch(_){ try{ el.addEventListener('mousedown',()=>bringToFront(el),true); }catch(__){} } }
+  function addEdgeResize(panel,opts){ opts=opts||{}; if(!panel||panel.dataset.edgeResize) return; panel.dataset.edgeResize='1';
+    const M=9, minW=(opts.min&&opts.min[0])||220, minH=(opts.min&&opts.min[1])||130;
+    const CUR={n:'ns-resize',s:'ns-resize',e:'ew-resize',w:'ew-resize',ne:'nesw-resize',sw:'nesw-resize',nw:'nwse-resize',se:'nwse-resize'};
+    const edgeAt=(cx,cy)=>{ const r=panel.getBoundingClientRect(); const x=cx-r.left,y=cy-r.top; if(x<0||y<0||x>r.width||y>r.height) return ''; let h='',v=''; if(x<=M)h='w'; else if(x>=r.width-M)h='e'; if(y<=M)v='n'; else if(y>=r.height-M)v='s'; return v+h; };
+    /* (#R79b) inside a workspace window the WINDOW handles resize — skip the panel's own edge-resize */
+    /* (#R79b) inside a workspace window the WINDOW handles resize — skip the panel's own edge-resize.
+       (#R130) ALSO skip when the panel is the Atlas SIDEBAR TAB (class `atl-tab`): in tab mode the Atlas panel is
+       pinned to width:100%!important inside #atlas-feed, so the invisible edge-resize border-zone let the user drag
+       (incl. left/right) and fought the forced width — the reported "サイドバー内Atlasに左右方向のリサイズ機構があり、
+       変なことになる". `atl-tab` is present only in tab mode (removed in ws-mode), so the floating Atlas window and the
+       Compare window keep edge-resize. */
+    const _inWsWin2=()=>{ try{ if(panel.classList&&panel.classList.contains('atl-tab')) return true; return !!(panel.parentElement&&panel.parentElement.classList&&panel.parentElement.classList.contains('ws-body')); }catch(_){ return false; } };   /* (#R153) same fix as _inWsWin: only the window's own content (direct .ws-body child) is exempt from edge-resize — in-map popups nested in the relocated #map-container resize normally */
+    panel.addEventListener('pointermove',(e)=>{ if(panel.dataset.resizing||_inWsWin2()) return; const d=edgeAt(e.clientX,e.clientY); panel.style.cursor=d?CUR[d]:''; });
+    panel.addEventListener('pointerleave',()=>{ if(!panel.dataset.resizing) panel.style.cursor=''; });
+    panel.addEventListener('pointerdown',(e)=>{ if(_inWsWin2()) return; if(e.target.closest&&e.target.closest('button,input,select,textarea,a,[role="button"],.atl-go,.atl-in')) return; const d=edgeAt(e.clientX,e.clientY); if(!d) return; e.preventDefault(); e.stopPropagation(); panel.dataset.resizing=d; bringToFront(panel);
+      const r=panel.getBoundingClientRect(), op=panel.offsetParent||document.documentElement, opr=op.getBoundingClientRect();
+      /* (#R48) ROOT CAUSE of the buggy resize: the Atlas panel is centred with transform:translateX(-50%) (from
+         left:50%). The old code pinned left to the VISUAL rect but LEFT THE TRANSFORM ON, so on grab the panel
+         jumped half its width and drifted while resizing. Neutralise the transform + bottom/right anchors first,
+         pin to the exact on-screen box, then read the transform-free offset. */
+      panel.style.setProperty('transform','none','important'); panel.style.setProperty('right','auto','important'); panel.style.setProperty('bottom','auto','important');
+      panel.style.setProperty('left',(r.left-opr.left)+'px','important'); panel.style.setProperty('top',(r.top-opr.top)+'px','important');
+      const sx=e.clientX, sy=e.clientY, sw=r.width, sh=r.height, sl=panel.offsetLeft, st=panel.offsetTop;
+      try{ panel.setPointerCapture&&panel.setPointerCapture(e.pointerId); }catch(_){}
+      const mv=(ev)=>{ let w=sw,h=sh,l=sl,t=st; const dx=ev.clientX-sx, dy=ev.clientY-sy;
+        if(d.indexOf('e')>=0) w=Math.max(minW,sw+dx); if(d.indexOf('s')>=0) h=Math.max(minH,sh+dy);
+        if(d.indexOf('w')>=0){ w=Math.max(minW,sw-dx); l=sl+(sw-w); } if(d.indexOf('n')>=0){ h=Math.max(minH,sh-dy); t=st+(sh-h); }
+        panel.style.setProperty('width',w+'px','important'); panel.style.setProperty('height',h+'px','important');
+        panel.style.setProperty('left',l+'px','important'); panel.style.setProperty('top',t+'px','important'); panel.setAttribute('data-dragged','1'); };
+      const up=(ev)=>{ delete panel.dataset.resizing; try{ panel.releasePointerCapture&&panel.releasePointerCapture(ev.pointerId); }catch(_){} document.removeEventListener('pointermove',mv); document.removeEventListener('pointerup',up); panel.style.cursor=''; };
+      document.addEventListener('pointermove',mv); document.addEventListener('pointerup',up); });
+    registerWindow(panel); }
+  return { addEdgeResize, bringToFront, makeDraggable, registerWindow };
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test",
     "test:security": "node --test tests/security-logic.mjs",
     "test:monitor": "node --test tests/monitor-logic.test.mjs",
-    "test:checks": "node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs tests/r149-checks.test.mjs tests/r150-checks.test.mjs tests/r151-checks.test.mjs tests/r152-checks.test.mjs tests/r153-checks.test.mjs tests/r154-checks.test.mjs tests/r155-checks.test.mjs tests/r156-checks.test.mjs tests/r157-checks.test.mjs tests/r158-checks.test.mjs tests/r159-checks.test.mjs tests/r160-checks.test.mjs tests/r161-checks.test.mjs tests/r162-checks.test.mjs tests/r163-checks.test.mjs tests/r164-checks.test.mjs tests/r165-checks.test.mjs tests/r166-checks.test.mjs tests/r167-checks.test.mjs tests/r168-checks.test.mjs",
+    "test:checks": "node --test tests/security-logic.mjs tests/monitor-logic.test.mjs tests/r147-checks.test.mjs tests/r149-checks.test.mjs tests/r150-checks.test.mjs tests/r151-checks.test.mjs tests/r152-checks.test.mjs tests/r153-checks.test.mjs tests/r154-checks.test.mjs tests/r155-checks.test.mjs tests/r156-checks.test.mjs tests/r157-checks.test.mjs tests/r158-checks.test.mjs tests/r159-checks.test.mjs tests/r160-checks.test.mjs tests/r161-checks.test.mjs tests/r162-checks.test.mjs tests/r163-checks.test.mjs tests/r164-checks.test.mjs tests/r165-checks.test.mjs tests/r166-checks.test.mjs tests/r167-checks.test.mjs tests/r168-checks.test.mjs tests/r169-checks.test.mjs",
     "test": "node scripts/static-checks.mjs && npm run test:checks && playwright test",
     "report": "playwright show-report"
   },

--- a/tests/r161-checks.test.mjs
+++ b/tests/r161-checks.test.mjs
@@ -213,8 +213,11 @@ test('#14 index.html loads the engine and uses it FIRST in analyzeContext', () =
   /* the legacy scorer must still be reachable as the fallback */
   /* line-ending tolerant: index.html is stored with CRLF */
   assert.ok(/if\(!subjectLoc\)\{\s+let best=null, bestScore=0;/.test(html), 'legacy gazetteer fallback removed');
-  /* de/ru/es used to render an undefined subject name */
-  assert.ok(html.includes('best.name[currentLang]||best.name.en||best.name.jp||null'), 'legacy name fallback missing');
+  /* de/ru/es used to render an undefined subject name.
+     (#R169) analyzeContext moved into js/news-context.js, where the closure read `currentLang`
+     became the host read `HOST.lang` — accept either spelling so the guard tracks the code. */
+  assert.ok(html.includes('best.name[currentLang]||best.name.en||best.name.jp||null')
+    || html.includes('best.name[HOST.lang]||best.name.en||best.name.jp||null'), 'legacy name fallback missing');
   /* admin-curated geo_pins still contribute */
   assert.ok(html.includes('window.IntMapNewsGeo.register(extra)'), 'geo_pins are not registered with the engine');
 });

--- a/tests/r165-checks.test.mjs
+++ b/tests/r165-checks.test.mjs
@@ -97,7 +97,42 @@ const RW = {
   commSearch:         { v: 'commSearch',         owners: ['community.js'] },
   communitySort:      { v: 'communitySort',      owners: ['community.js'] },
   replyingTo:         { v: 'replyingTo',         owners: ['community.js'] },
+  /* ── (#R169) the eighth split. Same rule: the module that OWNS the subject is the one allowed to
+     write that subject's state. Members whose getter already existed higher up (they were read-only
+     for earlier modules) get only the write half here, so `oneLinePair:false` for those six. ── */
+  satActive:          { v: 'satActive',          owners: ['satellite.js'] },
+  satAutoBackoff:     { v: 'satAutoBackoff',     owners: ['satellite.js'] },
+  satErrCount:        { v: 'satErrCount',        owners: ['satellite.js'] },
+  satLastGood:        { v: 'satLastGood',        owners: ['satellite.js'] },
+  searchMarker:       { v: 'searchMarker',       owners: ['search-geocode.js'] },
+  panelDrag:          { v: 'panelDrag',          owners: ['window-manager.js'] },
+  readerOpen:         { v: 'readerOpen',         owners: ['article-reader.js'] },
+  readerCurrent:      { v: 'readerCurrent',      owners: ['article-reader.js'] },
+  composeCat:         { v: 'composeCat',         owners: ['community-board.js'] },
+  composeEditId:      { v: 'composeEditId',      owners: ['community-board.js'] },
+  pendingImg:         { v: 'pendingImg',         owners: ['community-board.js'] },
+  /* the readout owns the cursor position, the elevation request sequence and its debounce timer */
+  _crLat:             { v: '_crLat',             owners: ['map-readout.js'] },
+  _crLng:             { v: '_crLng',             owners: ['map-readout.js'] },
+  _elevSeq:           { v: '_elevSeq',           owners: ['map-readout.js'] },
+  elevTimer:          { v: 'elevTimer',          owners: ['map-readout.js'] },
+  lastElev:           { v: 'lastElev',           owners: ['map-readout.js'] },
+  lastLayerVal:       { v: 'lastLayerVal',       owners: ['map-readout.js'] },
+  /* write halves only — the getter for each of these was already there for an earlier module */
+  commCaps:           { v: 'commCaps',           owners: ['community-board.js'], oneLinePair: false },
+  communityPosts:     { v: 'communityPosts',     owners: ['community-board.js'], oneLinePair: false },
+  geoDB:              { v: 'geoDB',              owners: ['news-context.js'],    oneLinePair: false },
+  isGridOn:           { v: 'isGridOn',           owners: ['map-readout.js'],     oneLinePair: false },
+  measureSnapClose:   { v: 'measureSnapClose',   owners: ['map-readout.js'],     oneLinePair: false },
+  newsFiltered:       { v: 'newsFiltered',       owners: ['news-feed.js'],       oneLinePair: false },
 };
+/* #R169 added a second writer to six members that already existed. */
+RW.satPanelDismissed.owners.push('satellite.js');
+RW.globalData.owners.push('news-feed.js');
+RW.newsFeatures.owners.push('news-feed.js');
+RW.renderedCount.owners.push('news-feed.js');
+RW.pendingPostLoc.owners.push('community-board.js');
+RW.toolMode.owners.push('map-readout.js');
 const RW_NAMES = Object.keys(RW);
 
 /* Closure values the Atlas kernel reads that are REASSIGNED at runtime → live getters, and never a
@@ -163,9 +198,13 @@ test('R165 #2 THE RW CONTRACT: the setter list is exactly the declared members, 
   //     (#R168) accept every write form, not just `=`: js/news-ui.js advances the lazy-batch counter
   //     with `HOST.renderedCount+=next.length`, which reads through the getter and writes through the
   //     setter exactly as a plain assignment would.
+  //     (#R169) accept a PREFIX increment too (`++HOST._elevSeq` in js/map-readout.js stamps the
+  //     elevation-request sequence). Until this round the postfix-only pattern would have let a
+  //     prefix write slip past check (d) as well — the "nothing writes a member it does not own"
+  //     guard — so the same widened pattern is used in both places.
   for (const [name, spec] of Object.entries(RW)) {
     for (const owner of spec.owners) {
-      assert.match(rd('js/' + owner), new RegExp(`HOST\\.${name}\\s*(?:=(?!=)|\\+\\+|--|[+\\-*/%&|^]=)`),
+      assert.match(rd('js/' + owner), new RegExp(`(?:\\+\\+|--)HOST\\.${name}\\b|HOST\\.${name}\\s*(?:=(?!=)|\\+\\+|--|[+\\-*/%&|^]=)`),
         `js/${owner} must write HOST.${name} somewhere — otherwise drop it from that member's owner list`);
     }
   }
@@ -174,7 +213,7 @@ test('R165 #2 THE RW CONTRACT: the setter list is exactly the declared members, 
   //     contract kept explicit for everyone else).
   for (const f of readdirSync(new URL('js/', root)).filter((x) => x.endsWith('.js'))) {
     const src = code(rd('js/' + f));
-    const writes = [...src.matchAll(/HOST\.([A-Za-z_$][\w$]*)\s*(?:=(?!=)|\+\+|--|[+\-*/%&|^]=)/g)].map((m) => m[1]);
+    const writes = [...src.matchAll(/(?:\+\+|--)HOST\.([A-Za-z_$][\w$]*)\b|HOST\.([A-Za-z_$][\w$]*)\s*(?:=(?!=)|\+\+|--|[+\-*/%&|^]=)/g)].map((m) => m[1] || m[2]);
     const bad = writes.filter((w) => !RW[w] || !RW[w].owners.includes(f));
     assert.deepEqual(bad, [], `js/${f} writes host member(s) it does not own: ${bad.join(', ')}`);
   }

--- a/tests/r167-checks.test.mjs
+++ b/tests/r167-checks.test.mjs
@@ -132,7 +132,11 @@ test('R167 #3 THE TABLE CONTRACT: js/tables.js is pure data that index.html neve
   //     with the code that reads them, the company ones into js/companies-ui.js, RADIUS_PRESETS into
   //     js/tool-panel.js. Which FILE rebinds a table is not what this contract is about — that it is
   //     rebound from window.IntMapTables exactly once, and never re-declared inline, is.
-  const consumers = ['index.html', 'js/countries-ui.js', 'js/companies-ui.js', 'js/tool-panel.js'].map((p) => [p, rd(p)]);
+  //     (#R169) the same again: the publisher/demonym gazetteers went into js/news-context.js with
+  //     analyzeContext, the satellite provider table into js/satellite.js, the news editions into
+  //     js/news-feed.js and the community categories into js/community-board.js.
+  const consumers = ['index.html', 'js/countries-ui.js', 'js/companies-ui.js', 'js/tool-panel.js',
+    'js/news-context.js', 'js/satellite.js', 'js/news-feed.js', 'js/community-board.js'].map((p) => [p, rd(p)]);
   const retAt = src.lastIndexOf('return {');
   const ret = src.slice(retAt, src.indexOf('};', retAt) + 2);
   for (const t of TABLES) {

--- a/tests/r169-checks.test.mjs
+++ b/tests/r169-checks.test.mjs
@@ -1,0 +1,308 @@
+// R169 source-level regression checks — the EIGHTH index.html split, plus the head-level defects
+// found while auditing the file.
+//
+// #R168 carved six SUBJECTS out of the core. What was left was one 6,894-line DOMContentLoaded
+// closure of 857 statements in which almost nothing is a self-contained block any more. #R169 cuts
+// it on a different axis: not "which statements sit together" but "which statements are pure
+// DECLARATIONS". 277 KB of the closure declares functions and tables and executes nothing; those
+// declarations can be lifted into a factory and instantiated anywhere after `map` exists, because a
+// declaration has no observable effect until something calls it. Every statement that actually RUNS
+// (the DOM wiring, the map.on() handlers, the boot sequence) stays exactly where it was, in its
+// original order — so this round cannot reorder a single side effect.
+//
+// The contract pinned here (tests/r169.spec.js proves the same things in a real browser):
+//   · each of the eleven files is loaded, declares exactly one factory, is instantiated exactly once
+//     and is named in the boot guard, so a file that fails to deploy cannot fail silently;
+//   · every exported name keeps ONE hoisted forwarding shim in index.html and is declared nowhere
+//     else there — call sites textually above the factory call still work, `this` and the argument
+//     list are preserved;
+//   · the eleven calls sit together, after the map is constructed, and nothing that runs during
+//     closure evaluation touches a moved name before them (checked transitively through the call
+//     graph, not just at the top level);
+//   · a factory body only DECLARES — proven statement by statement with a real parser;
+//   · no module reads a reassigned closure value as a bare identifier (the #R162 silent-loss shape).
+//
+// The RW contract (which module may WRITE which host member) lives in r165-checks.test.mjs.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import * as acorn from 'acorn';
+import { checkSplitScope } from '../scripts/check-split-scope.mjs';
+
+const root = new URL('../', import.meta.url);
+const rd = (p) => readFileSync(new URL(p, root), 'utf8');
+const html = rd('index.html');
+const lf = html.replace(/\r\n/g, '\n');   // index.html is CRLF in the working tree
+
+/* Blank comments + string/template literals so identifier scanning reads CODE only. */
+function code(src) {
+  let out = '', i = 0, inBlock = false;
+  while (i < src.length) {
+    const c = src[i], c2 = src[i + 1];
+    if (inBlock) { if (c === '*' && c2 === '/') { inBlock = false; out += '  '; i += 2; } else { out += c === '\n' ? '\n' : ' '; i++; } continue; }
+    if (c === '/' && c2 === '*') { inBlock = true; out += '  '; i += 2; continue; }
+    if (c === '/' && c2 === '/') { while (i < src.length && src[i] !== '\n') { out += ' '; i++; } continue; }
+    if (c === '"' || c === "'" || c === '`') {
+      const q = c; out += ' '; i++;
+      while (i < src.length) {
+        if (src[i] === '\\') { out += '  '; i += 2; continue; }
+        if (src[i] === q) { out += ' '; i++; break; }
+        out += src[i] === '\n' ? '\n' : ' '; i++;
+      }
+      continue;
+    }
+    out += c; i++;
+  }
+  return out;
+}
+
+/* factory -> { file, the const index.html binds it to, the names index.html keeps a shim for }.
+   The order of this object is the order the eleven calls must appear in — one block, right after
+   the #R168 block. */
+const MODULES = {
+  satellite:        { file: 'js/satellite.js', k: 'IM_SAT', exports: ['aiCaptureSatAt', 'satApply', 'satBuildTiles', 'satCaptureLabel', 'satChipHTML', 'satHasKey', 'satProviderById', 'satReady', 'satRefreshReadout', 'satRenderController', 'satRenderKeyInputs', 'satRevertToFallback', 'satSaveKeyInputs', 'satSelectProvider', 'satSetOpacity', 'satSetup', 'satStepDay', 'satToast'] },
+  aiCore:           { file: 'js/ai-core.js', k: 'IM_AI', exports: ['aiDev', 'aiEsc', 'aiFetchUsage', 'aiGate', 'aiLimitMsg', 'aiLoginMsg', 'aiParseJSON', 'aiReady', 'aiRenderSettings', 'aiReport', 'aiSaveSettings', 'aiSetBtnBusy', 'aiSyncFeatureButtons', 'aiToast', 'aiToday', 'aiUsesLeft', 'aiVisionReady', 'aiWaitMapIdle', 'askAI', 'askAIJSON', 'askAIJSONEnvelope'] },
+  placeLabels:      { file: 'js/place-labels.js', k: 'IM_LABELS', exports: ['applyLabelLang', 'buildGeoFC', 'ensureGeoLayers', 'ensurePlaceLabels', 'localizeGeoLabels', 'updateGeoLayers'] },
+  windowManager:    { file: 'js/window-manager.js', k: 'IM_WINMGR', exports: ['addEdgeResize', 'bringToFront', 'makeDraggable', 'registerWindow'] },
+  searchGeocode:    { file: 'js/search-geocode.js', k: 'IM_SEARCH', exports: ['doGeocode', 'localFuzzyPlaces'] },
+  newsContext:      { file: 'js/news-context.js', k: 'IM_NEWSCTX', exports: ['analyzeContext', 'rebuildGeoIndex'] },
+  newsFeed:         { file: 'js/news-feed.js', k: 'IM_NEWSFEED', exports: ['aiTranslateTitles', 'fetchData', 'loadNewsFromSupabase', 'startNews'] },
+  articleReader:    { file: 'js/article-reader.js', k: 'IM_READER', exports: ['openArticleInSidebar'] },
+  communityBoard:   { file: 'js/community-board.js', k: 'IM_COMMBOARD', exports: ['cmAddPost', 'cmEditPost', 'commCatLabel', 'imViewProfile', 'loadCommunity', 'openComposeModal', 'renderCommList', 'setupCommunityLayer', 'visibleCommunityPosts'] },
+  mapReadout:       { file: 'js/map-readout.js', k: 'IM_READOUT', exports: ['_demZoomForSpan', 'demElevAt', 'demElevBilinear', 'demZoomForMap', 'fetchBathymetry', 'fmtElevVal', 'fmtLL', 'handleMapClick', 'refreshGrid', 'renderCoordReadout', 'setGrid', 'showMeasureTip', 'updateCompass', 'updateCoord', 'updateLayerReadout', 'warmDEMTiles'] },
+  elevationProfile: { file: 'js/elevation-profile.js', k: 'IM_ELEVPROF', exports: ['_openProfilePanel'] },
+};
+const NAMES = Object.keys(MODULES);
+const rx = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const shimOf = (m, n) => `function ${n}(){ return ${MODULES[m].k}.${n}.apply(this,arguments); }`;
+const callOf = (m) => `const ${MODULES[m].k}=window.IntMapModules.${m}(map,IM_HOST);`;
+
+/* Closure values these modules read that are REASSIGNED at runtime → live host getters, never a
+   bare identifier inside a js/ file. A captured copy would silently go stale (the #R162 shape). */
+const LIVE = {
+  currentLang: 'lang', currentUser: 'user', currentMode: 'mode', currentMapType: 'mapType',
+  satActive: 'satActive', satErrCount: 'satErrCount', satAutoBackoff: 'satAutoBackoff',
+  satLastGood: 'satLastGood', satPanelDismissed: 'satPanelDismissed',
+  searchMarker: 'searchMarker', panelDrag: 'panelDrag', geoDB: 'geoDB',
+  globalData: 'globalData', newsFeatures: 'newsFeatures', newsFiltered: 'newsFiltered',
+  renderedCount: 'renderedCount', readerOpen: 'readerOpen', readerCurrent: 'readerCurrent',
+  communityPosts: 'communityPosts', commCaps: 'commCaps', composeCat: 'composeCat',
+  composeEditId: 'composeEditId', pendingImg: 'pendingImg', pendingPostLoc: 'pendingPostLoc',
+  isGridOn: 'isGridOn', toolMode: 'toolMode', measureSnapClose: 'measureSnapClose',
+  lastElev: 'lastElev', lastLayerVal: 'lastLayerVal', elevTimer: 'elevTimer',
+  _crLng: '_crLng', _crLat: '_crLat', _elevSeq: '_elevSeq',
+  geoLabelsOn: 'geoLabelsOn', namesOn: 'namesOn', userTheme: 'userTheme', newsLangs: 'newsLangs',
+};
+
+test('R169 #1 all eleven files are loaded and every factory is declared and instantiated once', () => {
+  for (const m of NAMES) {
+    const { file } = MODULES[m];
+    const src = rd(file);
+    assert.ok(html.includes(`<script src="${file}"></script>`), `index.html loads ${file}`);
+    assert.ok(src.includes('window.IntMapModules=window.IntMapModules||{};'),
+      `${file} extends IntMapModules without clobbering what earlier files put there`);
+    assert.ok(src.includes(`window.IntMapModules.${m}=function(map,HOST){`),
+      `${file} declares the ${m} factory taking (map,HOST)`);
+    assert.ok(!/<style>/.test(code(src)), `${file} must not carry CSS — the stylesheet stays in css/intmap.css`);
+    const calls = html.split(callOf(m)).length - 1;
+    assert.equal(calls, 1, `index.html must instantiate ${m} exactly once (found ${calls})`);
+    const defined = [...src.matchAll(/window\.IntMapModules\.(\w+)\s*=\s*function/g)].map((x) => x[1]);
+    assert.deepEqual(defined, [m], `${file} defines exactly one factory`);
+    assert.match(html, new RegExp(`'${m}'`), `the boot guard names the ${m} factory, so a missing file cannot hide`);
+  }
+});
+
+test('R169 #2 THE SHIM CONTRACT: every exported name is a hoisted forwarding declaration', () => {
+  for (const m of NAMES) {
+    const { file, exports } = MODULES[m];
+    const src = rd(file);
+
+    // (a) the module returns exactly the declared export list.
+    const retAt = src.lastIndexOf('return {');
+    const ret = src.slice(retAt, src.indexOf('};', retAt) + 2);
+    const returned = ret.replace(/^return \{|\};$/g, '').split(',').map((s) => s.trim()).filter(Boolean);
+    assert.deepEqual(returned, exports, `${file} must return exactly its declared exports`);
+
+    for (const n of exports) {
+      // (b) each one really is a function declared INSIDE the module — either a function
+      //     declaration or, for the handful that were written that way in index.html
+      //     (satProviderById, satHasKey …), a const bound to an arrow.
+      assert.match(src, new RegExp(`(?:^|\\n)\\s*(?:(?:async\\s+)?function ${rx(n)}\\(|const ${rx(n)}\\s*=\\s*(?:async\\s*)?\\()`),
+        `${file} declares ${n}`);
+
+      // (c) index.html keeps exactly one shim, and it is a hoisted function DECLARATION that
+      //     forwards receiver AND arguments. `const ${n}=…` would break every call site above the
+      //     factory (TDZ) and `(...a)=>` would silently drop `this`.
+      const shim = shimOf(m, n);
+      assert.equal(html.split(shim).length - 1, 1, `index.html holds exactly one shim for ${n}: ${shim}`);
+
+      // (d) and index.html no longer declares the real thing anywhere.
+      const inline = [...code(html).matchAll(new RegExp(`(?:^|[^.\\w$])(?:async\\s+function|function|const|let|var)\\s+${rx(n)}(?![\\w$])`, 'g'))];
+      assert.equal(inline.length, 1, `${n} must exist in index.html only as its shim (found ${inline.length} declarations)`);
+    }
+  }
+});
+
+test('R169 #3 POSITION: the eleven calls sit together after the map is built, before any eager use', () => {
+  const mapAssign = lf.indexOf('map=new maplibregl.Map({');
+  assert.ok(mapAssign > 0, 'index.html constructs the map exactly where expected');
+
+  const at = NAMES.map((m) => ({ m, i: lf.indexOf(callOf(m)) }));
+  for (const x of at) assert.ok(x.i > mapAssign, `${x.m} is instantiated AFTER the map is constructed`);
+  assert.deepEqual(at.slice().sort((a, b) => a.i - b.i).map((x) => x.m), NAMES, 'the eleven calls keep their declared order');
+
+  // The #R169 block must follow the #R168 block — both are declaration-only, but keeping them in
+  // one place is what makes "everything is instantiated here" a checkable statement.
+  const r168 = lf.indexOf('const IM_COMMUNITY=window.IntMapModules.community(map,IM_HOST);');
+  assert.ok(r168 > 0 && at[0].i > r168, 'the #R169 block sits directly after the #R168 block');
+
+  // Nothing may CALL a moved name while the closure is still evaluating and before the factories
+  // exist. Checked transitively: parse the closure, find every call that runs at closure-evaluation
+  // time (i.e. not inside a function body) BEFORE the first factory call, then follow the call graph
+  // of the functions those calls reach. A hit would be a temporal-dead-zone crash at boot.
+  const marker = lf.lastIndexOf("window.addEventListener('DOMContentLoaded'");
+  const open = lf.lastIndexOf('<script>', marker), close = lf.indexOf('</script>', marker);
+  const js = lf.slice(open + '<script>'.length, close);
+  const ast = acorn.parse(js, { ecmaVersion: 'latest', locations: true });
+  const fn = ast.body[0].expression.arguments[1];
+  const stmts = fn.body.body;
+  const firstCallLine = js.slice(0, js.indexOf(callOf(NAMES[0]))).split('\n').length;
+  const moved = new Set(NAMES.flatMap((m) => MODULES[m].exports));
+
+  const declaredBy = new Map();     // top-level name -> statement
+  for (const st of stmts) {
+    if (st.type === 'FunctionDeclaration' && st.id) declaredBy.set(st.id.name, st);
+    if (st.type === 'VariableDeclaration') for (const d of st.declarations) if (d.id.type === 'Identifier') declaredBy.set(d.id.name, st);
+  }
+  const callsIn = (node, immediateOnly) => {
+    const out = new Set();
+    (function w(n, inFn) {
+      if (!n || typeof n !== 'object') return;
+      if (Array.isArray(n)) return n.forEach((x) => w(x, inFn));
+      const nowIn = inFn || /Function/.test(n.type);
+      if (n.type === 'CallExpression' && n.callee.type === 'Identifier' && (!immediateOnly || !nowIn)) out.add(n.callee.name);
+      for (const k of Object.keys(n)) { if (k === 'loc' || k === 'start' || k === 'end' || k === 'type') continue; w(n[k], nowIn); }
+    })(node, false);
+    return out;
+  };
+  const hazards = [];
+  for (const st of stmts) {
+    if (st.loc.start.line >= firstCallLine) continue;
+    if (st.type === 'FunctionDeclaration' || st.type === 'ClassDeclaration') continue;
+    for (const rootName of callsIn(st, true)) {
+      const seen = new Set([rootName]), queue = [rootName];
+      while (queue.length) {
+        const c = queue.shift();
+        if (moved.has(c)) { hazards.push(`line ${st.loc.start.line}: ${rootName} … → ${c}`); queue.length = 0; break; }
+        const d = declaredBy.get(c);
+        if (!d) continue;
+        for (const nx of callsIn(d, false)) if (!seen.has(nx)) { seen.add(nx); queue.push(nx); }
+      }
+    }
+  }
+  assert.deepEqual(hazards, [], 'a moved name is reached by code that runs before the factories exist');
+});
+
+test('R169 #4 DECLARATION-ONLY: a factory body does nothing while it runs', () => {
+  // This is the property that makes calling all eleven early safe. A factory-level statement that
+  // EXECUTES would have its side effect moved with it; a factory-level initialiser that CALLS
+  // anything would read closure state at factory time — the #R167 dead-zone trap.
+  for (const m of NAMES) {
+    const src = rd(MODULES[m].file);
+    const ast = acorn.parse(src, { ecmaVersion: 'latest', locations: true });
+    let body = null;
+    for (const st of ast.body) {
+      if (st.type !== 'ExpressionStatement' || st.expression.type !== 'AssignmentExpression') continue;
+      const { left, right } = st.expression;
+      if (left.type === 'MemberExpression' && left.property.name === m && /Function/.test(right.type)) body = right.body.body;
+    }
+    assert.ok(body, `${MODULES[m].file}: found the ${m} factory body`);
+    const doers = body.filter((st) => st.type !== 'FunctionDeclaration' && st.type !== 'VariableDeclaration' && st.type !== 'ReturnStatement');
+    assert.deepEqual(doers.map((st) => `${st.type}@${st.loc.start.line}`), [],
+      `${MODULES[m].file} must only DECLARE at factory level — these statements would run: `);
+    assert.equal(body[body.length - 1].type, 'ReturnStatement', `${MODULES[m].file} ends with the export return`);
+
+    for (const st of body.filter((s) => s.type === 'VariableDeclaration')) {
+      for (const d of st.declarations) {
+        (function scan(n) {
+          if (!n || typeof n.type !== 'string') return;
+          if (/Function/.test(n.type)) return;
+          assert.ok(n.type !== 'CallExpression', `${MODULES[m].file}:${n.loc.start.line} — a factory-level initialiser must not call anything`);
+          for (const k of Object.keys(n)) {
+            if (k === 'type' || k === 'start' || k === 'end' || k === 'loc' || k === 'range') continue;
+            const v = n[k];
+            if (Array.isArray(v)) v.forEach((x) => x && typeof x.type === 'string' && scan(x));
+            else if (v && typeof v.type === 'string') scan(v);
+          }
+        })(d.init);
+      }
+    }
+  }
+});
+
+test('R169 #5 no module reads a live value as a bare identifier', () => {
+  for (const m of NAMES) {
+    const src = code(rd(MODULES[m].file));
+    for (const [name, prop] of Object.entries(LIVE)) {
+      const hits = (src.match(new RegExp(`(?<![.\\w$])${rx(name)}(?![\\w$])`, 'g')) || []).length;
+      assert.equal(hits, 0, `${MODULES[m].file} mentions ${name} as a bare identifier — it must use HOST.${prop} (${hits} hit(s))`);
+    }
+  }
+});
+
+test('R169 #6 every live member really is a getter over a really-reassigned variable', () => {
+  for (const [name, prop] of Object.entries(LIVE)) {
+    const asg = new RegExp(`(?:^|[^.\\w$=!<>+\\-*/%&|^])${rx(name)}\\s*=(?!=)`);
+    const decl = new RegExp(`(?:const|let|var)\\b[^;]*\\b${rx(name)}\\s*=`);
+    const reassigned = lf.split('\n').some((l) => asg.test(l) && !decl.test(l));
+    const setter = new RegExp(`set\\s+${rx(prop)}\\(v\\)\\{\\s*${rx(name)}=v;\\s*\\}`).test(lf);
+    assert.ok(reassigned || setter,
+      `${name} must be reassigned somewhere (in index.html, or through its IM_HOST setter) — otherwise it need not be a live member`);
+    assert.match(lf, new RegExp(`get\\s+${rx(prop)}\\(\\)\\{\\s*return\\s+${rx(name)};\\s*\\}`),
+      `IM_HOST.${prop} must be a live getter over ${name}`);
+  }
+});
+
+test('R169 #7 the parser-backed split-scope check still passes across all eleven new files', () => {
+  const problems = checkSplitScope();
+  assert.deepEqual(problems, [], 'split-scope problems:\n' + problems.map((p) => `${p.file}: ${p.msg}`).join('\n'));
+});
+
+test('R169 #8 index.html shrank and no module body came back inline', () => {
+  const lines = html.split('\n').length;
+  assert.ok(lines < 6_200, `index.html should be well under the pre-R169 7,690 lines; it is ${lines}`);
+  assert.ok(!/<style>[\s\S]{4000,}?<\/style>/.test(html), 'the stylesheet stays in css/intmap.css');
+  // A leftover in-page copy of a moved body would WIN over the module (a later function declaration
+  // overwrites an earlier one). Probe with a line from deep inside the biggest bodies, so the needle
+  // cannot accidentally match the one-line shim that legitimately carries the name.
+  const deep = {
+    'js/place-labels.js': "function _harvestOne(kind,sourceLayer,filter,cellDeg){",
+    'js/map-readout.js': "function buildGridFeatures(){",
+    'js/ai-core.js': "async function aiCallServerFull(prompt, system, imgs, opts){",
+    'js/satellite.js': "function satBuildTiles(p){",
+    'js/community-board.js': "function postCardHTML(post){",
+    'js/news-feed.js': "function feedUrls(){",
+  };
+  for (const [file, needle] of Object.entries(deep)) {
+    assert.ok(rd(file).includes(needle), `${file} really holds the moved body (${needle})`);
+    assert.ok(!lf.includes(needle), `index.html must not still carry ${file}'s body inline (${needle})`);
+  }
+});
+
+test('R169 #9 the head defects found while auditing index.html are fixed', () => {
+  // (a) a stray second </script> closed nothing — a leftover from an old edit that the browser
+  //     silently tolerates. One open <script> ⇒ one close. Counted on the markup only: an HTML
+  //     comment (the CSP note) and the document.write fallback both spell the word deliberately.
+  const markup = html.replace(/<!--[\s\S]*?-->/g, '');
+  assert.equal((markup.match(/<script\b/g) || []).length, (markup.match(/<\/script>/g) || []).length,
+    'index.html has as many </script> as <script> tags');
+  // (b) the MapLibre stylesheet was linked twice, byte-identical — a second request for a file the
+  //     browser already had.
+  const cssLinks = (html.match(/maplibre-gl@[\d.]+\/dist\/maplibre-gl\.css/g) || []).length;
+  assert.equal(cssLinks, 1, 'the MapLibre stylesheet is linked exactly once');
+  // (c) the anti-stale-version guard compares the build stamp it ships with against the newest one
+  //     this device has seen. A stamp that never advances makes the guard inert; both stamps were
+  //     last touched in #R121 / #R133.
+  assert.match(html, /window\.INTMAP_BUILD='2026-07-25-R169';/, 'INTMAP_BUILD is stamped for this round');
+  assert.match(html, /window\.__imBuild='R169';/, '__imBuild is stamped for this round');
+});

--- a/tests/r169-checks.test.mjs
+++ b/tests/r169-checks.test.mjs
@@ -291,11 +291,15 @@ test('R169 #8 index.html shrank and no module body came back inline', () => {
 
 test('R169 #9 the head defects found while auditing index.html are fixed', () => {
   // (a) a stray second </script> closed nothing — a leftover from an old edit that the browser
-  //     silently tolerates. One open <script> ⇒ one close. Counted on the markup only: an HTML
-  //     comment (the CSP note) and the document.write fallback both spell the word deliberately.
-  const markup = html.replace(/<!--[\s\S]*?-->/g, '');
-  assert.equal((markup.match(/<script\b/g) || []).length, (markup.match(/<\/script>/g) || []).length,
-    'index.html has as many </script> as <script> tags');
+  //     silently tolerates. One open <script> ⇒ one close. Tags INSIDE an HTML comment don't count
+  //     (the CSP note spells `<script src=evil-host>` on purpose); the ranges are computed and the
+  //     matches filtered by offset rather than stripped out of the string, because a single-pass
+  //     removal of a multi-character delimiter is exactly the "incomplete sanitization" shape.
+  const comments = [...html.matchAll(/<!--[\s\S]*?-->/g)].map((m) => [m.index, m.index + m[0].length]);
+  const outside = (i) => !comments.some(([a, b]) => i >= a && i < b);
+  const opens = [...html.matchAll(/<script\b/g)].filter((m) => outside(m.index)).length;
+  const closes = [...html.matchAll(/<\/script>/g)].filter((m) => outside(m.index)).length;
+  assert.equal(opens, closes, `index.html has as many </script> (${closes}) as <script> (${opens}) tags`);
   // (b) the MapLibre stylesheet was linked twice, byte-identical — a second request for a file the
   //     browser already had.
   const cssLinks = (html.match(/maplibre-gl@[\d.]+\/dist\/maplibre-gl\.css/g) || []).length;

--- a/tests/r169.spec.js
+++ b/tests/r169.spec.js
@@ -1,0 +1,244 @@
+// R169 behavioural checks in a real browser — the eighth index.html split.
+//
+// WHY a browser test: static analysis cannot see the #R162 failure shape. Soft dependencies here are
+// `typeof X!=='undefined'` inside try/catch, so a moved subject that lost a binding throws NOTHING —
+// a branch is skipped and the feature quietly disappears.
+//
+// What THIS round has to prove beyond "the globals exist":
+//   1. All eleven factories ran, and index.html's SHIMS really reach them. A shim that forwarded to
+//      the wrong object would not throw; it would just do nothing.
+//   2. The moved subjects still do their real work through those shims: the news pipeline builds a
+//      feed and locates every headline, the search box answers from the local gazetteer, the
+//      satellite controller renders, the place-label layers exist, the readout formats coordinates.
+//   3. WRITE-THROUGH for the new RW members. `HOST.x=v` on a getter-only object is a SILENT no-op, so
+//      "no error" proves nothing: each assertion below forces index.html's OWN code to re-derive from
+//      the bare closure variable afterwards (the grid toggle reads `isGridOn`, the lazy news batch
+//      reads `renderedCount`/`newsFiltered`).
+//   4. The host getters are LIVE: modules built while the UI was English follow a runtime switch.
+//
+// What is NOT claimed here, deliberately (#R167's rule: never pretend to prove what you cannot):
+//   · js/community-board.js. Its renderer is only reached through loadCommunity(), which awaits
+//     detectCommCaps() against Supabase — blocked by the hermetic policy — and the community feed has
+//     no button of its own (it opens from a community map pin, and with no posts there are no pins).
+//     Same conclusion #R168 reached for js/community.js. Source-level cover: r169-checks #1/#2/#5.
+//   · js/elevation-profile.js. _openProfilePanel() is reached only from the freehand Draw tool's
+//     "Elevation profile" action, which first samples a real terrain-RGB DEM over the network.
+//   · js/article-reader.js. Unreachable in the product since #R11 (see the file header) — there is no
+//     entry point to drive, and inventing one would be a product change, not a refactor.
+//   · The AI transport itself (aiCallServerFull): it needs the ai-proxy Edge Function. Only the parts
+//     that work offline — the config/quota surface on window.__ai — are exercised.
+import { test, expect } from '@playwright/test';
+import { installHermeticRouting, collectPageDiagnostics, isBenign } from './helpers/network.js';
+
+test.describe.configure({ mode: 'serial' });
+
+let page, diag;
+
+/* 45 fake headlines (> NEWS_BATCH=30) pre-seeded into the news cache, so the feed is deterministic
+   with no network AND large enough that a second lazy batch really has something to append. */
+const NEWS_SEED = {
+  ts: Date.now(),
+  lang: 'en',
+  data: Array.from({ length: 45 }, (_, i) => ({
+    title: `Tokyo test headline number ${i + 1}`,
+    link: `https://example.invalid/item-${i + 1}`,
+    publisher: 'Test Wire',
+    pubDate: new Date().toUTCString(),
+    description: `Test item ${i + 1} from Tokyo`,
+    /* fetchData()'s cache path hands these straight to the renderer, so the seed carries the
+       analysis the live path would compute. analyzeContext itself is exercised directly in #2b. */
+    analysis: { loc: [139.69, 35.69], name: 'Tokyo', country: 'JPN', type: 'city' },
+  })),
+};
+
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  await installHermeticRouting(context);
+  await context.addInitScript((seed) => {
+    try {
+      localStorage.setItem('intmap_ws4', JSON.stringify({ on: false }));
+      localStorage.setItem('intmap_news_cache', JSON.stringify(seed));
+    } catch { /* ignore */ }
+  }, NEWS_SEED);
+  page = await context.newPage();
+  diag = collectPageDiagnostics(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 45_000 });
+  await page.waitForFunction(() => !!window.__imap && !!document.getElementById('map'), null, { timeout: 45_000 });
+  await page.waitForTimeout(2500);
+});
+
+test.afterAll(async () => {
+  await page?.context()?.close();
+});
+
+test('R169 #1 all eleven files loaded and all eleven factories ran', async () => {
+  const res = await page.evaluate(() => ({
+    check: window.__imModuleCheck,
+    facs: ['satellite', 'aiCore', 'placeLabels', 'windowManager', 'searchGeocode', 'newsContext',
+      'newsFeed', 'articleReader', 'communityBoard', 'mapReadout', 'elevationProfile']
+      .filter((k) => typeof (window.IntMapModules || {})[k] !== 'function'),
+  }));
+  expect(res.check.missing, 'no required global is missing').toEqual([]);
+  expect(res.check.missingFactories, 'no factory is missing').toEqual([]);
+  expect(res.facs, 'every #R169 factory is a real function').toEqual([]);
+});
+
+test('R169 #2 THE NEWS PIPELINE: the moved fetch built a real feed', async () => {
+  // js/news-feed.js (loadNewsCache → fetchData → startNews) is reached only through index.html's
+  // shims. If either shim were dead the feed would stay on "Loading…".
+  const first = await page.evaluate(async () => {
+    // setMode() TOGGLES, so only click when the tab is not already active.
+    const nb = document.getElementById('btn-news');
+    if (nb && !nb.classList.contains('active')) { nb.click(); await new Promise((r) => setTimeout(r, 1400)); }
+    document.getElementById('newsfilter-all')?.click();
+    await new Promise((r) => setTimeout(r, 1200));
+    const feed = document.getElementById('live-news-feed');
+    return {
+      cards: feed.querySelectorAll('.news-item, .news-card').length,
+      text: (feed.innerText || '').slice(0, 80),
+    };
+  });
+  expect(first.cards, 'the first lazy batch (NEWS_BATCH=30) rendered').toBe(30);
+  expect(first.text).toContain('Tokyo test headline');
+});
+
+test('R169 #2b the moved locator resolves a headline to a real place', async () => {
+  // analyzeContext moved into js/news-context.js; index.html keeps the shim and publishes it as
+  // window._imAnalyzeContext. A dead shim would throw; a locator that lost its gazetteer (the #R162
+  // shape — geoDB read as a bare identifier) would return an unlocated result instead.
+  const a = await page.evaluate(() => {
+    try { return window._imAnalyzeContext('Heavy rain warning issued for Tokyo', 'Test Wire', 'https://example.invalid/x', ''); }
+    catch (e) { return { error: String(e) }; }
+  });
+  expect(a.error, 'the shim reached the module').toBeUndefined();
+  expect(Array.isArray(a.loc), 'the headline was located').toBe(true);
+  expect(a.loc[0]).toBeGreaterThan(135);
+  expect(a.loc[0]).toBeLessThan(145);
+  expect(String(a.name)).toMatch(/Tokyo|東京/);
+});
+
+test('R169 #3 WRITE-THROUGH: appendNewsBatch advances renderedCount past the first batch', async () => {
+  // renderedCount / newsFiltered live in index.html; js/news-feed.js replaces them through the host
+  // setters when startNews() re-derives the list. index.html's own scroll handler then compares
+  // `renderedCount<newsFiltered.length` off the closure to decide whether a second batch exists — so
+  // a silent no-op write would leave the feed stuck at 30 cards.
+  const res = await page.evaluate(async () => {
+    const feed = document.getElementById('live-news-feed');
+    const count = () => feed.querySelectorAll('.news-item, .news-card').length;
+    const before = count();
+    feed.scrollTop = feed.scrollHeight;
+    feed.dispatchEvent(new Event('scroll', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 900));
+    const links = [...feed.querySelectorAll('.news-item, .news-card')]
+      .map((c) => c.getAttribute('data-link') || c.querySelector('a')?.getAttribute('href') || c.innerText.slice(0, 60));
+    return { before, after: count(), unique: new Set(links).size };
+  });
+  expect(res.before).toBe(30);
+  expect(res.after, 'the second batch appended the remaining 15 of the 45 seeded items').toBe(45);
+  expect(res.unique, 'every card is distinct — the counters really advanced').toBe(45);
+});
+
+test('R169 #4 WRITE-THROUGH: the grid toggle round-trips through HOST.isGridOn', async () => {
+  // index.html keeps `toggleGrid(){ setGrid(!isGridOn); }` and reads the BARE closure variable;
+  // js/map-readout.js owns setGrid and writes HOST.isGridOn. If that write were a silent no-op the
+  // second click would compute !false again and turn the grid ON a second time instead of off.
+  const gridFeatures = () => page.evaluate(() => {
+    try { const s = window.__imap.getSource('grid-source'); return (s.serialize().data.features || []).length; }
+    catch { return -1; }
+  });
+  await page.evaluate(() => document.getElementById('btn-tool-grid').click());
+  await page.waitForTimeout(400);
+  const on = await gridFeatures();
+  await page.evaluate(() => document.getElementById('btn-tool-grid').click());
+  await page.waitForTimeout(400);
+  const off = await gridFeatures();
+  expect(on, 'the graticule was built by the moved buildGridFeatures()').toBeGreaterThan(0);
+  expect(off, 'the second click really turned it off — HOST.isGridOn was written through').toBe(0);
+  expect(await page.evaluate(() => document.getElementById('cb-grid').checked)).toBe(false);
+});
+
+test('R169 #5 the search box answers from the moved geocoder', async () => {
+  // preprocessNLQuery / localFuzzyPlaces / doGeocode all live in js/search-geocode.js now, and the
+  // input's Enter handler in index.html calls the shim. Nominatim and Open-Meteo are blocked by the
+  // hermetic policy, so anything that appears came from the LOCAL gazetteer path.
+  await page.fill('#ms-input', 'Tokyo');
+  await page.press('#ms-input', 'Enter');
+  await page.waitForFunction(() => document.querySelectorAll('#ms-results .ms-item').length > 0,
+    null, { timeout: 15_000 });
+  const items = await page.evaluate(() => [...document.querySelectorAll('#ms-results .ms-item')].map((d) => d.textContent));
+  expect(items.join(' | ')).toMatch(/Tokyo/i);
+});
+
+test('R169 #6 the satellite module built the controller and its debug surface is the real one', async () => {
+  const sat = await page.evaluate(() => {
+    const s = window.__sat;
+    if (!s) return { ok: false };
+    const esri = s.hasKey(s.providers.find((p) => p.id === 'esri'));
+    const tiles = s.build(s.providers.find((p) => p.id === 'esri'));
+    return { ok: true, providers: s.providers.length, esri, tiles, day: s.state.day };
+  });
+  expect(sat.ok, 'window.__sat exists (it captures the index.html shims)').toBe(true);
+  expect(sat.providers, 'the provider table reached the module').toBeGreaterThan(1);
+  expect(sat.esri, 'satHasKey() runs in the module and says the free provider is usable').toBe(true);
+  // satBuildTiles() really ran in the module and produced a tile template for the free provider
+  // (a paid provider with no saved key is the case that returns null).
+  expect(Array.isArray(sat.tiles) && sat.tiles.length > 0, 'satBuildTiles() returned tile URLs').toBe(true);
+  expect(String(sat.tiles[0])).toMatch(/^https?:\/\/.*\{z\}/);
+  expect(sat.day, 'satState reached the module').toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+  // satSetup() runs at style-load and renders the controller when the basemap is satellite.
+  await page.evaluate(() => { const b = document.getElementById('sat-controller'); if (b) b.style.display = 'block'; });
+  const html = await page.evaluate(() => {
+    try { window.__sat.render(); } catch { /* not exposed */ }
+    return (document.getElementById('sat-controller') || {}).innerHTML || '';
+  });
+  expect(html, 'satRenderController() filled the panel through the shim').toContain('satc-row');
+});
+
+test('R169 #7 the AI core surface is live and answers from the module', async () => {
+  const ai = await page.evaluate(() => {
+    const a = window.__ai;
+    if (!a) return { ok: false };
+    return { ok: true, cfg: !!a.config(), ready: typeof a.ready(), vision: typeof a.visionReady(),
+      parsed: a.parse('{"a":1}') };
+  });
+  expect(ai.ok, 'window.__ai exists (it captures the index.html shims)').toBe(true);
+  expect(ai.cfg).toBe(true);
+  expect(ai.ready, 'aiReady() ran in the module').toBe('boolean');
+  expect(ai.vision, 'aiVisionReady() ran in the module').toBe('boolean');
+  expect(ai.parsed, 'aiParseJSON() ran in the module').toEqual({ a: 1 });
+});
+
+test('R169 #8 the place-label and readout modules really touched the map', async () => {
+  const res = await page.evaluate(() => {
+    const m = window.__imap;
+    const ids = ['ofm-country', 'ofm-city', 'geo-sea'].filter((id) => !!m.getLayer(id));
+    const cr = document.getElementById('coord-readout');
+    return { ids, hasReadout: !!cr };
+  });
+  // ensurePlaceLabels() + ensureGeoLayers() are called from index.html's style-load path through
+  // their shims; the layers they add are the observable proof.
+  expect(res.ids, 'the moved label layers were added').toEqual(['ofm-country', 'ofm-city', 'geo-sea']);
+  expect(res.hasReadout).toBe(true);
+});
+
+test('R169 #9 LIVE getters: modules built in English follow a runtime language switch', async () => {
+  await page.evaluate(() => document.getElementById('lang-jp').click());
+  await page.waitForTimeout(2500);
+  const jp = await page.evaluate(() => {
+    let sat = '';
+    try { window.__sat.render(); sat = (document.getElementById('sat-controller') || {}).innerHTML || ''; } catch { /* ignore */ }
+    return { sat, feed: (document.getElementById('live-news-feed') || {}).innerText || '' };
+  });
+  // satRenderController() re-renders from HOST.lang. If the module had captured the language at
+  // factory time it would still be English here.
+  expect(jp.sat, 'the satellite controller re-rendered in Japanese').toMatch(/[ぁ-んァ-ン一-龯]/);
+  await page.evaluate(() => document.getElementById('lang-en').click());
+  await page.waitForTimeout(1500);
+  expect(jp.feed.length).toBeGreaterThan(0);
+});
+
+test('R169 #10 no IntMap-originated console error or uncaught exception during the exercise', async () => {
+  const bad = [...diag.pageErrors, ...diag.consoleErrors].filter((t) => !isBenign(t));
+  expect(bad, `unexpected page errors:\n${bad.join('\n')}`).toEqual([]);
+});


### PR DESCRIPTION
## What and why

`#R168` exhausted "subjects": the remaining 6,894-line `DOMContentLoaded` closure has no
self-contained group of statements left — the largest cluster my analyser finds spans
lines **1430..7420**, i.e. the whole file. So this round changes the axis.

Not *which statements sit together*, but **does this statement RUN, or does it only DECLARE?**

| kind | size | property |
|---|---|---|
| pure declarations (function decls, consts/lets initialised only by literals + functions) | **277 KB / 444 stmts** | nothing happens until something calls them |
| statements that execute (DOM wiring, `map.on()`, boot order, IIFEs) | 208 KB / 413 stmts | position and order are meaningful |

A declaration has no observable effect until it is called, so the eleven new factories can
all be instantiated together right after `map` exists — no temporal dead zone (the `#R167`
trap), no call-order question (the `#R166` care). **Every statement that actually runs stays
exactly where it was: this round reorders no side effect at all.** That is the safety argument.

## The eleven modules (192 KB)

`satellite.js` · `ai-core.js` · `place-labels.js` · `window-manager.js` · `search-geocode.js` ·
`news-context.js` · `news-feed.js` · `article-reader.js` · `community-board.js` ·
`map-readout.js` · `elevation-profile.js`

**index.html 7,691 → 5,744 lines / 659 → 504 KB** (−84% since `#R162`).
`IM_HOST` 201 → 253 members (read-write 29 → 52). 108 hoisting shims.

## Three real defects in `<head>`, found while auditing the file

1. a stray second `</script>` that closed nothing — a leftover the browser silently tolerates;
2. the MapLibre stylesheet `<link>`ed twice, byte-identical;
3. both build stamps frozen since `#R121`/`#R133`. `INTMAP_BUILD` is the baseline the `#R16`
   stale-cache guard compares against, so a stamp that never advances makes the guard inert.

## Found but deliberately NOT changed

The in-sidebar article reader has had **no entry point since `#R11`** ("revert Read→external"):
`openArticleInSidebar → fetchReadable → renderReader → IM_NEWS_UI.renderReaderMode` is all
live code that nothing calls. Deleting or re-wiring it is a product decision, not a
refactoring one, so it moved out unchanged with the finding recorded in
`js/article-reader.js` and DEV-NOTES R169.

## Docs (the second half of the instruction)

**Architecture.md**
- added a "how to read this" contract: §1–§18 describe the current state only; history is DEV-NOTES' job;
- corrected three stale numbers: §1 "~15,000 lines / 1.4 MB" (true at `#R165`), the §3 breakdown, and §14's boot check "~72 layer rows" → 143 measured (`npm run test:smoke` checks the same thing);
- removed **ten paragraphs of R117–R126 change-log** pasted into the AI section — covering routing, Compare, layers and UI, in the order R117→R119→R118→R120→R122→R123→R124→R125→R126→R121→R118. The durable part (`window.IntMapLayers`, the layer-data contract) moved to §7; the rest already exists in DEV-NOTES;
- collected the **eighteen `#Rxxx 補足` sections** that were wedged between §14 and §15 in arbitrary order into a new **§19, newest-first**. Verified line-by-line that nothing was lost.

**DEV-NOTES.md**
- documented that the file is two halves (newest-first R168→R86, then the original oldest-first journal) and marked the boundary — it was never written down anywhere;
- moved **R161b above R161** (the one real ordering break);
- recorded that **R114/R115/R116 have no entries at all** rather than inventing them.

## Tests

- `tests/r169-checks.test.mjs` (9) — parser-backed: declaration-only factories, the shim
  contract, and that **no statement running before the factory block can reach a moved name**,
  checked transitively through the call graph (direct-call-only would miss a one-hop path).
- `tests/r169.spec.js` (11) — real browser: news pipeline, both write-throughs
  (`renderedCount`/`newsFiltered`, `isGridOn`), search, satellite, AI surface, label layers,
  live getters, zero console errors. What cannot be proven offline is listed with reasons
  instead of asserted.
- `r165-checks` now counts `++HOST.x` as a write — a prefix increment was slipping past the
  "no module writes a member it does not own" guard (a hole since `#R165`).
- `npm test` green: static checks + 242 node + 162 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
