### PR TITLE
R173 follow-up: one click handler for aircraft, not two that cancel each other

### DIFF
--- a/js/data-layers.js
+++ b/js/data-layers.js
@@ -2554,14 +2554,7 @@ window.IntMapModules.dataLayers=function(map,HOST){
           map.on('mousemove',ly,(e)=>{ positionTooltip(e.point); });
           map.on('mouseleave',ly,()=>{ map.getCanvas().style.cursor=''; if(HOST.mapTooltipEl) HOST.mapTooltipEl.style.display='none'; });
         });
-        ['lyr-planes',PLANE3D_LYR,PLANE3D_POST].forEach(ly=>{
-          map.on('click',ly,(e)=>{ if(!e.features||!e.features.length) return;
-            try{ e.originalEvent&&(e.originalEvent.__imPlaneHit=true); }catch(_){}
-            const k=(e.features[0].properties||{}).icao24||'';
-            selectPlane(k===selectedPlane?null:k);
-            if(selectedPlane){ const el=ensureMapTooltip(); el.style.display='block';
-              el.innerHTML=trafficTooltipHTML('planes',e.features[0].properties); positionTooltip(e.point); } });
-        });
+
         /* The pick above, wired to the pointer: hovering a lifted aircraft shows the same tooltip and
            clicking it selects it, wherever on screen it is drawn. A click that hits neither the pick nor
            the footprint clears the selection — asked of the renderer rather than of a flag set by the layer
@@ -2582,13 +2575,26 @@ window.IntMapModules.dataLayers=function(map,HOST){
             try{ if(map.queryRenderedFeatures(e.point,{layers:[PLANE3D_LYR,PLANE3D_POST].filter(l=>map.getLayer(l))}).length) return; }catch(_){}
             if(HOST.mapTooltipEl) HOST.mapTooltipEl.style.display='none'; }
         }; map.on('mousemove',_planesHover); }
+        /* ONE click handler, deliberately. It began as two — a layer-scoped one for the renderer's own
+           footprint hit and a map-level one for the pick — and each of them TOGGLED, so a click that
+           satisfied both selected the aircraft and immediately deselected it. Caught on production with
+           41 real aircraft: the pick found the aeroplane, the click reported nothing selected. One
+           handler, one decision: the pick first (that is where the aeroplane is drawn), then the
+           renderer's footprint (the post and the flat glyph are real things to click at), else clear. */
         if(!_planesClear){ _planesClear=(e)=>{
-          const d=pickPlane(e.point);
-          if(d&&d.icao24){ selectPlane(d.icao24===selectedPlane?null:d.icao24); return; }
-          if(!selectedPlane) return;
-          try{ const ls=['lyr-planes',PLANE3D_LYR,PLANE3D_POST].filter(l=>map.getLayer(l));
-            if(ls.length&&map.queryRenderedFeatures(e.point,{layers:ls}).length) return; }catch(_){}
-          selectPlane(null); }; map.on('click',_planesClear); }
+          let d=pickPlane(e.point), props=null;
+          if(!d){ try{ const ls=['lyr-planes',PLANE3D_LYR,PLANE3D_POST].filter(l=>map.getLayer(l));
+              const f=ls.length?map.queryRenderedFeatures(e.point,{layers:ls}):[];
+              if(f&&f.length){ props=f[0].properties||{}; d=planesData.find(x=>x.icao24===(props.icao24||''))||null; } }catch(_){} }
+          if(d&&d.icao24){
+            selectPlane(d.icao24===selectedPlane?null:d.icao24);
+            if(selectedPlane){ const el=ensureMapTooltip(); el.style.display='block';
+              el.innerHTML=trafficTooltipHTML('planes',props||{ type:d.type, sel:1, callsign:d.callsign||'', icao24:d.icao24||'',
+                reg:d.reg||'', acType:d.acType||'', desc:d.desc||'', baroAlt:d.baroAlt, geoAlt:d.geoAlt, vel:d.vel,
+                heading:d.heading, vrate:d.vrate, squawk:d.squawk||'', onGround:!!d.onGround, lastContact:(d.lastContact||0) });
+              positionTooltip(e.point); }
+            return; }
+          if(selectedPlane) selectPlane(null); }; map.on('click',_planesClear); }
       }
     }
     function startTraffic(id){

--- a/tests/r173-checks.test.mjs
+++ b/tests/r173-checks.test.mjs
@@ -104,7 +104,9 @@ test('an aircraft can be picked where it is DRAWN, not where its shadow falls', 
   assert.match(INDEX, /projectAltitude\(ll,altM\)\{/, 'the engine can project a point that is up in the air');
   assert.match(INDEX, /t\.getMatrixForModel\(\{lng,lat\},\+altM\|\|0\)/, 'through the renderer’s own model matrix, so the globe is right too');
   assert.match(d, /map\.on\('mousemove',_planesHover\)/, 'hover uses it');
-  assert.match(d, /const d=pickPlane\(e\.point\);\r?\n\s+if\(d&&d\.icao24\)\{ selectPlane/, 'and so does the click');
+  assert.match(d, /let d=pickPlane\(e\.point\), props=null;/, 'and so does the click');
+  assert.ok(!/map\.on\('click',ly,/.test(d),
+    'ONE click handler: two of them each toggled, so a click that satisfied both selected and deselected in the same event');
 });
 
 test('the clicked aircraft draws the track this browser has actually observed', () => {

--- a/tests/r173.spec.js
+++ b/tests/r173.spec.js
@@ -223,4 +223,16 @@ test('a lifted aircraft can be hovered and clicked where it is drawn, and its tr
 
   await page.mouse.click(60, 700); await page.waitForTimeout(900);
   expect(await page.evaluate(() => window.IntMapPlanes3D.selected()), 'clicking away puts it back').toBeNull();
+
+  /* …and the aeroplane's FOOTPRINT — the post standing under it — selects it too. This is the case that
+     caught a real defect on production: the pick and the renderer's own footprint hit were two separate
+     click handlers and each of them TOGGLED, so a click that satisfied both selected the aircraft and
+     deselected it in the same event. One handler, one decision. */
+  const post = await page.evaluate(() => { const m = window.__imap;
+    /* the aircraft's own footprint: where the renderer answers a point query for it (its ground position) */
+    const f = m.queryRenderedFeatures({ layers: ['lyr-planes-3d'] }).find(x => (x.properties || {}).icao24 === 'ABC123');
+    const r = f.geometry.coordinates[0], c = r.reduce((a, p2) => [a[0] + p2[0], a[1] + p2[1]], [0, 0]);
+    const g = m.project([c[0] / r.length, c[1] / r.length]); return { x: Math.round(g.x), y: Math.round(g.y) }; });
+  await page.mouse.click(post.x, post.y); await page.waitForTimeout(1200);
+  expect(await page.evaluate(() => window.IntMapPlanes3D.selected()), 'the post under an aircraft selects it').toBe('ABC123');
 });


### PR DESCRIPTION
本番検証で見つけた実バグの修正です。

**症状**：本番（フランクフルト上空・実機 41機）で、ピックは機体を見つけ（`pickAt` が ICAO24 を返す）、
ホバーで読み出しも出るのに、**クリックしても選択されない**。

**真因**：クリックのハンドラが**2つ**あり、**どちらもトグルしていた**——
レンダラーの footprint 用のレイヤースコープのものと、ピック用の地図レベルのもの。
両方の条件を満たすクリックは、**同じイベントの中で選択して選択解除**していた。
スタブ1機のテストでは2つが重ならなかったので通っていた。

**修正**：ハンドラは1つ、判断も1回。ピック（＝機体が描かれている場所）を先に見て、
無ければレンダラーの footprint（支柱と平面グリフも実際に狙える対象）、どちらも無ければ選択解除。

**テスト**：`tests/r173.spec.js` は**両方**をクリックする（描かれている本体と、その真下の footprint）ので、
二重トグルが再発すれば必ず落ちる。`tests/r173-checks.test.mjs` にも「click ハンドラは1つ」を固定した。

`npm test` 全緑（静的・node 306件・Playwright 該当18件を実行）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)