### PR TITLE
fix(ci): the TLE refresh cannot push to main — it opens a pull request

### DIFF
--- a/.github/workflows/tle-refresh.yml
+++ b/.github/workflows/tle-refresh.yml
@@ -5,11 +5,17 @@
 # outcome the brief rules out (「何も表示されないのは論外」). The app therefore ships a real element
 # set of its own (data/tle/), and this job is what stops that copy from going stale: it rebuilds it
 # from CelesTrak — or, when CelesTrak cannot be reached, from SatNOGS DB, which mirrors the same
-# Space-Track / CelesTrak elements — and commits it only when the file actually changed.
+# Space-Track / CelesTrak elements.
 #
 # Element sets are re-issued on a roughly two-hour timescale for low orbits, but a snapshot is a
 # FALLBACK, not the live path: twice a day keeps its worst case at ~12 h old, which SGP4 propagates
 # to a few kilometres for LEO, and the layer states the age of the elements it used either way.
+#
+# ⚠ IT OPENS A PULL REQUEST RATHER THAN PUSHING. `main` carries a ruleset requiring a pull request
+# with NO bypass actors, so `github-actions[bot]` cannot push to it either — a job that committed
+# straight to main would have failed on every run that actually had an update, which is every run
+# that mattered. Checked with `gh api repos/.../rulesets`: rules = deletion, pull_request,
+# required_status_checks, non_fast_forward; bypass_actors = [].
 name: TLE snapshot
 
 on:
@@ -19,6 +25,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: tle-snapshot
@@ -34,16 +41,28 @@ jobs:
           node-version: 20
       - name: Rebuild data/tle from the live sources
         run: node scripts/build-tle-snapshot.mjs
-      - name: Commit only if the catalogue actually moved
+      - name: Open a pull request when the catalogue actually moved
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet -- data/tle; then
-            echo "catalogue unchanged — nothing to commit"
+            echo "catalogue unchanged — nothing to propose"
             exit 0
           fi
+          BRANCH="data/tle-refresh"
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
           git add data/tle
           git commit -m "data: refresh the bundled satellite catalogue
 
-          Rebuilt by .github/workflows/tle-refresh.yml (#R185)."
-          git push
+          Rebuilt by .github/workflows/tle-refresh.yml (#R185). Source and object count are in
+          data/tle/catalogue.json."
+          git push --force origin "$BRANCH"
+          if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')" ]; then
+            gh pr create --base main --head "$BRANCH" \
+              --title "data: refresh the bundled satellite catalogue" \
+              --body "$(node -e 'const m=require("./data/tle/catalogue.json");console.log(`Rebuilt by the scheduled \`TLE snapshot\` workflow.\n\n| | |\n|---|---|\n| source | ${m.source} |\n| objects | ${m.objects} |\n| newest epoch | ${m.newestEpoch} |\n| median element age | ${m.medianElementAgeHours} h |\n\nThis is the copy the live-satellite layer falls back to when CelesTrak cannot be reached (#R185). Real element sets, propagated by SGP4 in real time; the app reports their age.`)')"
+          else
+            echo "an open pull request already tracks this branch — it now carries the newer catalogue"
+          fi

--- a/Architecture.md
+++ b/Architecture.md
@@ -1327,6 +1327,9 @@ js/
                                     SGP4 自身の半長軸が決める遠地点 a(1+e) の1.5倍を超えたら捨てる
                                     （IMP-8 は本物の270,956km で1.04倍＝残る）。80km未満は再突入。
                                     捨てた数は `state().diverged`。26KB
+                                    同梱カタログの更新は `.github/workflows/tle-refresh.yml`（1日2回）。
+                                    ⚠ **main へは push できない**（ruleset が pull_request 必須・
+                                    bypass_actors 空＝`github-actions[bot]` も対象）ので**PRを開く**。
   satellite-detail.js               (#R184) **人工衛星の詳細カード `IntMapSatPanel`**。航空機カードの `.acp-*` を
                                     そのまま使う（第2のUI語彙を作らない）。軌道種別は**フィードのラベルではなく
                                     周期・離心率・傾斜角から導く**。遠地点／近地点は平均運動と離心率から


### PR DESCRIPTION
`main` carries a ruleset requiring a pull request with **no bypass actors**, so `github-actions[bot]` cannot push to it either:

```
gh api repos/rwmqx7dwb5-arch/IntMap/rulesets/19133498
  rules         deletion, pull_request, required_status_checks, non_fast_forward
  bypass_actors []
```

The scheduled `TLE snapshot` job shipped in #73 committed straight to `main`, so it would have failed on **every run that actually had a newer catalogue** — which is every run that mattered — and it would have failed quietly, on a schedule nobody watches. That would have left the shipped fallback catalogue slowly ageing while looking maintained.

It now pushes a branch and opens (or updates) a pull request, with the source, object count and element age read out of `data/tle/catalogue.json` for the body.

I hit the same rule myself pushing the build stamp, which is how it was noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)