### PR TITLE
R190 follow-up: the build stamps, and a tsunami button that cannot outlive its answer

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ gtag('js', new Date());
    can finish booting in a hidden/background tab (rAF is throttled to zero there, `map.on('load')` never fires
    and nothing map-side can be verified). Never active for normal visitors. */
 if(/[?&]rafshim=1/.test(location.search)){ try{ window.requestAnimationFrame=function(cb){ return setTimeout(function(){ cb(performance.now()); },33); }; window.cancelAnimationFrame=clearTimeout; }catch(_){} }
-window.__imBuild='R189';   /* (#R121) build marker — bump when verifying that a reload really picked up the edited file (file:// reloads can serve a stale cache) */   /* (#R174) bump BOTH stamps together — tests/r169-checks.test.mjs requires them to name the same round, and both sat at R171 through #R172/#R173 */
+window.__imBuild='R190';   /* (#R121) build marker — bump when verifying that a reload really picked up the edited file (file:// reloads can serve a stale cache) */   /* (#R174) bump BOTH stamps together — tests/r169-checks.test.mjs requires them to name the same round, and both sat at R171 through #R172/#R173 */
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
@@ -50,7 +50,7 @@ window.__imBuild='R189';   /* (#R121) build marker — bump when verifying that 
      the NEWEST build ever loaded on this device. If a load ever serves an OLDER build than one already seen,
      we KNOW it's a stale copy → purge caches + hard-reload ONCE; if it's still old after that, surface a
      banner so it can never silently masquerade as the current app again. */
-  window.INTMAP_BUILD='2026-08-03-R189';   /* (#R174) …and it MUST be bumped every round: it was left at R171 through
+  window.INTMAP_BUILD='2026-08-05-R190';   /* (#R174) …and it MUST be bumped every round: it was left at R171 through
      #R172 and #R173, which means that for three rounds a device serving a stale cached copy looked current to the
      guard above. Caught by the production smoke test, which prints the live build id. */
   /* (#R29.1) Maintenance/security: capture the last ~25 runtime errors into a ring buffer so the Bug Report

--- a/js/app-body.js
+++ b/js/app-body.js
@@ -2174,8 +2174,16 @@ window.addEventListener('DOMContentLoaded', () => { const _imAppBoot = () => {
         /* concurrently, not after: this is the whole speed-up */
         try{ window.__imFireDefaultLayers&&window.__imFireDefaultLayers(); }catch(_){}
         window.__imBoot.set(88,'layers-fired');
+        /* ⚠ (#R190) THE ENDING NAMES ARE A CONTRACT, NOT A LABEL. tests/r186 asserts that exactly ONE
+           of `idle` / `timeout` / `no-renderer` is recorded — "a launch screen that lifts without
+           saying why is the failure mode", in its own words. The first draft here invented
+           `idle-timeout` and `layers-timeout`, which are outside that vocabulary, so on a runner slow
+           enough to take an escape the screen lifted correctly and the test found NO ending at all
+           (measured in CI: layers painted at 9,290 ms, escape at 12,134 ms, zero recognised endings).
+           It passed elsewhere only because those runners reached `idle` first — a latent flake.
+           Which escape fired is still said, in the console, where a diagnosis is read. */
         let ended=false;
-        const go=(why)=>{ if(ended) return; ended=true; try{ window.__imBoot.done(why||'ready'); }catch(_){} };
+        const go=(why)=>{ if(ended) return; ended=true; try{ window.__imBoot.done(why||'idle'); }catch(_){} };
         /* "the default layers are actually painting" — asked of the renderer, never of a checkbox
            (#R170: `isStyleLoaded()` is not "may I add layers", and a ticked box is not a drawn layer). */
         const _pending=()=>{ let n=0; try{
@@ -2192,8 +2200,8 @@ window.addEventListener('DOMContentLoaded', () => { const _imAppBoot = () => {
           const left=_pending();
           try{ window.__imBoot.set(left?92:97,'layers'); }catch(_){}
           if(!left){ try{ GE().events.once('idle',()=>go('idle')); }catch(_){ go('idle'); }
-            setTimeout(()=>go('idle-timeout'),2500); return; }
-          if(++waits>28){ console.warn('[boot] default layers still not on the map after ~14 s — revealing anyway'); go('layers-timeout'); return; }
+            setTimeout(()=>{ if(!ended) console.warn('[boot] the layers are painted but the map did not go idle within 2.5 s — revealing anyway'); go('timeout'); },2500); return; }
+          if(++waits>28){ console.warn('[boot] default layers still not on the map after ~14 s — revealing anyway'); go('timeout'); return; }
           setTimeout(settle,500); };
         try{ GE().events.once('idle',settle); }catch(_){ setTimeout(settle,900); }
         setTimeout(settle,4000);

--- a/js/seismic.js
+++ b/js/seismic.js
@@ -885,16 +885,24 @@ window.IntMapModules.seismic=function(HOST){
        Two halves: ask at every zoom that might be warm (the field's own level first — its warm grid
        covers the epicentre), and warm one tile on open/pick so the answer exists before it is needed.
        `_tsuShown` below re-renders the panel exactly once, when the availability flips. */
-    let _tsuShown=null, _tsuWarm=null;
+    let _tsuShown=null, _tsuWarm=null, _epiElev=null;
+    /* ⚠ (#R190) …AND THE ANSWER IS REMEMBERED, because the tile it came from does not stay.
+       Measured on production: the button rendered for an offshore M9.0 and a screening call a moment
+       later returned null — the DEM LRU had evicted the tile under the epicentre while the field
+       build warmed a thousand others. A button that is visible and does nothing is worse than no
+       button. The sea floor under a fixed point does not change, so the first real reading for THIS
+       epicentre is kept and re-used; moving the epicentre clears it (see the key). */
     function _epiSeaDepth(){
       if(!epi) return null;
+      const k=epi[0].toFixed(4)+'/'+epi[1].toFixed(4);
+      if(_epiElev&&_epiElev.k===k) return _epiElev.v;
       const zs=[]; if(fld&&fld.z) zs.push(fld.z);
       [8,7,6,5].forEach(z=>{ if(zs.indexOf(z)<0) zs.push(z); });
       for(const z of zs){
         let e=null; try{ e=demElevBilinear(epi[0],epi[1],z); if(e==null) e=demElevAt(epi[0],epi[1],null,z); }catch(_){}
-        if(e!=null&&isFinite(e)) return e;
+        if(e!=null&&isFinite(e)){ _epiElev={k,v:e}; return e; }
       }
-      return null;
+      return null;   /* not known YET — never cached, so a warmed tile can still answer later */
     }
     /* one tile, so "is the epicentre at sea?" is answerable without waiting for a whole field */
     function warmEpi(){ if(!epi) return; const k=epi[0].toFixed(2)+'/'+epi[1].toFixed(2);

--- a/tests/r190-checks.test.mjs
+++ b/tests/r190-checks.test.mjs
@@ -205,6 +205,11 @@ test('R190 seismic: frequency-dependent Q, a slope measured at the DEM’s own s
   assert.match(src, /function _epiSeaDepth\(\)\{/, 'the depth is asked for at every zoom that might be warm');
   assert.match(src, /if\(fld&&fld\.z\) zs\.push\(fld\.z\);/, 'the field’s own level first — its warm grid covers the epicentre');
   assert.match(src, /function warmEpi\(\)\{/, 'and one tile is warmed so the answer exists before it is needed');
+  /* ⚠ measured on production: the button rendered and a screening call a moment later returned null,
+     because the DEM LRU had evicted that tile while the field build warmed a thousand others. */
+  assert.match(src, /if\(_epiElev&&_epiElev\.k===k\) return _epiElev\.v;/, 'a known sea depth is remembered…');
+  assert.match(src, /\{ _epiElev=\{k,v:e\}; return e; \}/, '…keyed on the epicentre, so moving it re-reads');
+  assert.doesNotMatch(src, /_epiElev=\{k,v:null\}/, 'and "not known yet" is never cached as an answer');
   assert.match(src, /_tsuShown=!!tsunamiCase\(\);/, 'render records what it drew…');
   assert.match(src, /if\(opened&&_t!==_tsuShown\)\{ _tsuShown=_t; render\(\); \}/,
     '…so the panel re-renders exactly once, when the availability flips');

--- a/tests/r190-checks.test.mjs
+++ b/tests/r190-checks.test.mjs
@@ -127,7 +127,7 @@ test('R190 flight sim: the view\'s tilt becomes the aeroplane\'s flight path', (
 /* ── 6 · the launch screen ───────────────────────────────────────────────────────────────────── */
 test('R190 boot: the default layers are fired at style-ready, and the screen waits for them', () => {
   const body = read('js/app-body.js');
-  const m = /window\.__imBoot\.set\(80,'style'\);([\s\S]{0,2200}?)setTimeout\(settle,4000\);/.exec(body);
+  const m = /window\.__imBoot\.set\(80,'style'\);([\s\S]{0,3600}?)setTimeout\(settle,4000\);/.exec(body);
   assert.ok(m, 'the launch-screen block must still be one readable sequence');
   assert.ok(m[1].indexOf('__imFireDefaultLayers') < m[1].indexOf('GE().events.once(\'idle\',settle)'),
     'the layers are asked for BEFORE the first idle, so the downloads overlap');
@@ -135,6 +135,15 @@ test('R190 boot: the default layers are fired at style-ready, and the screen wai
     'and the screen lifts on layers that are really on the map, not on ticked boxes');
   const dl = read('js/data-layers.js');
   assert.match(dl, /window\.__imLayerPainted=check;/, 'answered by the existing reconciler, not a second id table');
+  /* ⚠ the ending NAMES are tests/r186's contract: exactly one of idle / timeout / no-renderer, because
+     "a launch screen that lifts without saying why is the failure mode". Inventing `idle-timeout` and
+     `layers-timeout` made a slow runner record NO recognised ending (measured in CI: layers at
+     9,290 ms, escape at 12,134 ms). Which escape fired is said in the console instead. */
+  for (const bad of ['idle-timeout', 'layers-timeout']) {
+    assert.ok(!body.includes(`go('${bad}')`), `${bad} is outside the ending vocabulary r186 pins`);
+  }
+  assert.match(body, /const go=\(why\)=>\{ if\(ended\) return; ended=true; try\{ window\.__imBoot\.done\(why\|\|'idle'\)/,
+    'and the default ending is one of them');
 });
 
 /* ── 7 · the seismic simulator ───────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Two things found by verifying the R190 deploy on the live site rather than
assuming it.

### 1 · Both build stamps still read R189
The code is R190 but `window.INTMAP_BUILD` was `2026-08-03-R189`. That string is
what the stale-cache guard compares, what Sentry tags a release with, and what the
Bug Report tool attaches — a stale stamp makes an out-of-date cached copy look
current, which is exactly the defect #R174 recorded when it sat at R171 for three
rounds. `tests/r169 #9` caught the paired marker (`window.__imBuild`) as soon as
only one of the two moved, which is what that assertion is for.

### 2 · The tsunami button could outlive its own screening
Measured on production: the button rendered for an offshore M9.0 and a screening
call a moment later returned `null` — the DEM LRU had evicted the tile under the
epicentre while the field build warmed a thousand others. A visible button whose
click does nothing is worse than no button.

The sea floor under a fixed point does not change, so the first real reading for
that epicentre is remembered and re-used; moving the epicentre re-reads (the cache
is keyed on it), and "not known yet" is never cached, so a tile that arrives later
can still answer.

515 unit checks green; static checks pass; `tests/r176 ⑤` (the seismic contract)
passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)