### PR TITLE
R203 follow-up: the opening centre is a fact to read, not a literal to pin

### DIFF
--- a/js/app-body.js
+++ b/js/app-body.js
@@ -737,6 +737,13 @@ window.addEventListener('DOMContentLoaded', () => { const _imAppBoot = () => {
      reads the `window.__imSatProto` flag this sets — see the file header. `_hiDPITiles` is the one
      value it needs from this scope and is handed over explicitly (scripts/check-split-scope.mjs). */
   try{ window.IntMapModules.satProto(IM_HOST); }catch(_){}
+  /* (#R203) …and the centre is COMPUTED ONCE AND PUBLISHED. A test cannot re-derive it — it moves
+     0.25° a minute, so "boot, then compute what the centre should be" is off by however long the
+     boot took — and tests/r180-cesium pinned the literal 10 and went red the moment this stopped
+     being a literal. What a test can do is read what the app decided, which is a fact rather than a
+     re-derivation (the rule #R202 wrote down after r185's altitude floor). */
+  const _openingCentre=OpeningView.openingCentre(OpeningView.openingClockMs(),[10,20]);
+  try{ window.__imOpeningCentre=_openingCentre.slice(); }catch(_){}
   try{
     /* (#R178) even the primary view is built through the contract. It could not be while the engine
        was created inside this map's own 'load' handler; js/geo-engine.js is imported before anything
@@ -813,7 +820,7 @@ window.addEventListener('DOMContentLoaded', () => { const _imAppBoot = () => {
          product at full alpha. js/opening-view.js keeps this centre whenever the Sun is at least 12°
          above it and rotates to the sub-solar longitude when it is not. Same latitude, same zoom, and
          a hash, a search or one drag overrides it immediately. */
-      center:OpeningView.openingCentre(OpeningView.openingClockMs(),[10,20]), zoom:1.7, minZoom:0, maxZoom:(isMobile()?18:19),
+      center:_openingCentre, zoom:1.7, minZoom:0, maxZoom:(isMobile()?18:19),
       style:{ version:8, glyphs:'https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf',
         sources:{ 'bl':{type:'raster',tiles:carto('light_all'),tileSize:256},'bln':{type:'raster',tiles:carto('light_nolabels'),tileSize:256},'bd':{type:'raster',tiles:carto('dark_all'),tileSize:256},'bdn':{type:'raster',tiles:carto('dark_nolabels'),tileSize:256},'sat-labels':{type:'raster',tiles:['https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}','https://services.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}'],tileSize:256},'satellite':{type:'raster',tiles:(window.__imSatProto?['imapsat://{z}/{y}/{x}']:['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}','https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}']),tileSize:256,maxzoom:19,attribution:'Imagery © Esri, Maxar, Earthstar Geographics'},'tool-source':{type:'geojson',data:{type:'FeatureCollection',features:[]}},'grid-source':{type:'geojson',data:{type:'FeatureCollection',features:[]}} },
         /* ══ (#R191) A TILE SHOULD ARRIVE, NOT APPEAR ═══════════════════════════════════════════════

--- a/tests/r180-cesium.spec.js
+++ b/tests/r180-cesium.spec.js
@@ -120,8 +120,18 @@ test('R180 ③: the startup view puts the eye where MapLibre puts it, and the ro
     return { z: E.camera.getZoom(), c: E.camera.getCenter(), eye: E.camera.eye() };
   });
   expect(boot.z, 'the app boots at zoom 1.7').toBeCloseTo(1.7, 3);
-  expect(boot.c.lng).toBeCloseTo(10, 4);
-  expect(boot.c.lat).toBeCloseTo(20, 4);
+  /* ⚠ (#R203) THE LONGITUDE IS NOT A LITERAL ANY MORE, AND PINNING IT AS ONE IS WHAT BROKE THIS.
+     js/opening-view.js opens on the daylit hemisphere — the sub-solar longitude whenever the Sun is
+     under 12° over 10°E — so the boot centre now depends on the clock, and it moves 0.25° a MINUTE.
+     A test cannot re-derive it after the fact (the boot itself takes seconds). What this test is
+     about is that CESIUM PUTS THE EYE WHERE MapLibre PUTS IT, so it reads the centre the app
+     decided and checks Cesium honoured it — the same rule as #R202's altitude floor: read the
+     number from the app, never write it down a second time. */
+  const want = await page.evaluate(() => window.__imOpeningCentre);
+  expect(Array.isArray(want), 'the app publishes the centre it opened at').toBe(true);
+  expect(boot.c.lng, 'Cesium boots at the centre the app chose').toBeCloseTo(want[0], 4);
+  expect(boot.c.lat).toBeCloseTo(want[1], 4);
+  expect(want[1], 'and the opening latitude is still 20').toBeCloseTo(20, 4);
   /* #R178 measured MapLibre's eye at globe z1.7 as 24,422 km. Cesium is asked for the same
      view through the same contract; if the mapping were wrong this would be out by megametres,
      which is exactly the failure mode #R176/#R177 spent two rounds on. 1 % is a generous band

--- a/tests/r203-checks.test.mjs
+++ b/tests/r203-checks.test.mjs
@@ -58,8 +58,12 @@ test('R203 ①b the sub-solar point agrees with the almanac at the solstices and
 
 test('R203 ①c the map is created at that centre, and js/opening-view.js is its only owner', () => {
   const body = rd('js/app-body.js');
-  assert.match(body, /center:OpeningView\.openingCentre\(OpeningView\.openingClockMs\(\),\[10,20\]\)/,
-    'the view is created at the computed opening centre');
+  assert.match(body, /const _openingCentre=OpeningView\.openingCentre\(OpeningView\.openingClockMs\(\),\[10,20\]\)/,
+    'the opening centre is computed once');
+  assert.match(body, /center:_openingCentre,/, 'and the view is created at it');
+  /* ⚠ published, so a test READS what the app decided instead of re-deriving a number that moves
+     0.25° a minute — which is what took tests/r180-cesium red on the first post-merge run. */
+  assert.match(body, /window\.__imOpeningCentre=_openingCentre/, 'and published for the tests');
   assert.match(body, /import \{ OpeningView \} from '\.\/opening-view\.js'/);
   /* nothing else may re-derive the Sun's position for this purpose */
   assert.doesNotMatch(body, /280\.460 \+ 0\.9856474/, 'the solar series lives in js/opening-view.js only');

--- a/tests/r203.spec.js
+++ b/tests/r203.spec.js
@@ -8,6 +8,7 @@
  *  leaves the camera where it found it.
  * ==========================================================================*/
 import { test, expect } from '@playwright/test';
+import { OpeningView } from '../js/opening-view.js';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -58,16 +59,18 @@ async function canvasStats(p) {
    asserts the consequence rather than the mechanism: whenever the suite runs, the Sun is up over
    the centre and the planet is not black. */
 test('R203 ① the app does not open on a black planet, at whatever hour the suite runs', async () => {
-  const c = await page.evaluate(() => {
-    const cc = window.IntMapGeoEngine.camera.getCenter();
-    return { lng: cc.lng, lat: cc.lat };
-  });
-  const elev = await page.evaluate(async ({ lat, lng }) => {
-    const m = await import('/js/opening-view.js').catch(() => null);
-    if (m) return m.solarElevation(Date.now(), lat, lng);
-    return null;
-  }, c).catch(() => null);
-  if (elev != null) expect(elev, 'the Sun stands over the opening centre').toBeGreaterThan(6);
+  /* ⚠ THE MODULE IS BUNDLED, SO A TEST CANNOT `import('/js/opening-view.js')` FROM THE PAGE — the
+     first version of this check did, caught the rejection, and SKIPPED ITSELF, which is the silent
+     pass this repository keeps warning about. The app publishes what it decided instead. */
+  const chosen = await page.evaluate(() => window.__imOpeningCentre);
+  expect(Array.isArray(chosen), 'the app published the centre it opened at').toBe(true);
+  expect(chosen[1], 'at the latitude it always has').toBeCloseTo(20, 4);
+  /* the property, evaluated HERE rather than in the page: the Sun is up over what the app chose.
+     ⚠ NOT compared against `camera.getCenter()` — on a desktop the sidebar sets camera PADDING, so
+     the reported centre is the centre of the padded view and is tens of degrees away from the one
+     the view was created at. Measured while writing this: published 176.748, reported 89.107. */
+  expect(OpeningView.solarElevation(Date.now(), chosen[1], chosen[0]),
+    'the Sun stands over the opening centre').toBeGreaterThan(OpeningView.MIN_ELEV_DEG - 1);
 
   const s = await canvasStats(page);
   expect(s.err, 'the canvas could be read').toBeUndefined();


### PR DESCRIPTION
The first post-merge **deep** run went red on `tests/r180-cesium ③`, and **it is mine**.

That test asserted `boot.c.lng ≈ 10` — the default centre as a **literal** — and #R203 made the opening longitude follow the Sun, so it moves **0.25° a minute**. This is exactly the class of defect the round already fixed once (`tests/r202-checks ③i` pinned the intensity mesh at the value 448 and broke on the very instruction to make it finer): a test that writes the number down a second time breaks on the next change in the direction it exists to protect.

A test cannot re-derive this one either — the boot itself takes seconds, and seconds are degrees. So `js/app-body.js` computes the centre **once** and publishes it as `window.__imOpeningCentre`; the tests read what the app decided. `r180-cesium ③`'s subject is unchanged: Cesium must put the eye where MapLibre puts it, at whatever centre the app opened at.

**⚠ It also caught a check of my own that was silently skipping.** `tests/r203 ①` tried to `import('/js/opening-view.js')` from the page to get the solar elevation. The module is **bundled**, so the import rejected, the `.catch(() => null)` swallowed it, and the assertion never ran. The elevation is computed in the spec's own Node context now, from the published centre.

**⚠ And it must not be compared against `camera.getCenter()`**: on a desktop the sidebar sets camera *padding*, so the reported centre is the centre of the padded view. Measured on one boot: published **176.748**, reported **89.107**.

The other deep failure, `r186.spec.js:228`, is the ADS-B rate-limit flake #R201 attributed on both trees and #R202 recorded.

## Verification

- `npm run check:static` — pass
- `npm run test:checks` — **648/648**
- `npm test` (core tier) — **181 passed, 3.6 min**
- `tests/r180-cesium.spec.js` — **10/10 green locally** (was 1 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)