### PR TITLE
R204 follow-up: the grid readout, and a time-zone label that selected the wrong offset

### DIFF
--- a/js/layer-packs.js
+++ b/js/layer-packs.js
@@ -747,10 +747,23 @@ window.IntMapModules.timeZones=function(HOST){
     }
     let wired=false;
     function wireHighlight(){ if(wired) return; wired=true;
-      const hit=(e)=>{ const f=e.features&&e.features[0]; if(!f) return; const z=f.properties&&f.properties.zone;
-        if(z==null) return; setHighlight((hlZone!=null&&+z===hlZone)?null:z); };
-      ['tzl-time','tzl-fill'].forEach(id=>{ try{
-        GE().events.onLayer('click',id,hit);
+      /* ⚠ THE LABEL WINS, AND IT HAS TO BE SAID EXPLICITLY. Both the text and the polygon answer a
+         click, and one press lands on BOTH — the label is anchored at the centre of its zone's
+         largest polygon, which on a globe at low zoom is often drawn over a NEIGHBOURING band. The
+         two handlers then ran in registration order and the fill's won: measured, pressing 「UTC+8」
+         highlighted zone 7. The renderer hands the same event object to every delegated layer
+         handler for one click, so the label marks it and the fill stands down. */
+      const hit=(e,fromLabel)=>{
+        if(e && e.__tzTaken) return;
+        const f=e.features&&e.features[0]; if(!f) return;
+        const z=f.properties&&f.properties.zone; if(z==null) return;
+        if(fromLabel && e) e.__tzTaken=true;
+        setHighlight((hlZone!=null&&+z===hlZone)?null:z);
+      };
+      /* ⚠ …and the label is wired FIRST, because "the same event object" only helps if the handler
+         that claims it runs first. */
+      [['tzl-time',true],['tzl-fill',false]].forEach(([id,isLabel])=>{ try{
+        GE().events.onLayer('click',id,(e)=>hit(e,isLabel));
         GE().events.onLayer('mouseenter',id,()=>{ try{ GE().render.canvas().style.cursor='pointer'; }catch(_){} });
         GE().events.onLayer('mouseleave',id,()=>{ try{ GE().render.canvas().style.cursor=''; }catch(_){} });
       }catch(_){} });

--- a/js/tsunami.js
+++ b/js/tsunami.js
@@ -768,7 +768,13 @@ window.IntMapModules.tsunami=function(HOST){
           +L('Sea-floor uplift','海底の隆起','Hebung','Поднятие дна','Levantamiento')+' +'+sim.eta0Up.toFixed(2)+' m / '+sim.eta0Down.toFixed(2)+' m<br>'
           +L('Rupture','震源断層','Bruchfläche','Разрыв','Ruptura')+' '+Math.round(gm.L/1000)+' × '+Math.round(gm.W/1000)+' km · '
           +L('mean slip','平均滑り','Versatz','смещение','deslizamiento')+' '+gm.slip.toFixed(1)+' m<br>'
-          +L('Grid','格子','Gitter','Сетка','Malla')+' '+sim.nx+'×'+sim.ny+' ('+L('global','全球','global','глобально','global')+', 0.25°) · '
+          /* ⚠ (#R204) THE DOMAIN IS NOT ALWAYS THE PLANET ANY MORE, so this line may not say it is. It
+             read 「4320×240（全球, 0.25°）」 on the first near-source run — the grid numbers were the
+             band's and the description was the global one's, which is the worst of both. */
+          +L('Grid','格子','Gitter','Сетка','Malla')+' '+sim.nx+'×'+sim.ny+' ('
+          +(sim.scope==='near'
+              ? L('near source','震源近傍','nahe Quelle','вблизи очага','cerca del origen')+', '+(360/sim.nx).toFixed(3).replace(/0+$/,'')+'°'
+              : L('global','全球','global','глобально','global')+', 0.25°')+') · '
           +sim.cellKm+' km · Δt '+(sim.dt||0).toFixed(1)+' s · '+(sim.steps||0)+' '+L('steps','ステップ','Schritte','шагов','pasos')
           +' · '+((sim.solveMs||0)/1000).toFixed(1)+' s<br>'
           +L('Peak coastal height (Green’s law)','沿岸最大波高（グリーンの法則）','Küstenhöhe (Green)','Высота у берега (Грин)','Altura costera (Green)')

--- a/tests/r204-checks.test.mjs
+++ b/tests/r204-checks.test.mjs
@@ -247,7 +247,13 @@ test('R204 ⑦ pressing an offset highlights every band on it', () => {
     'the label feature carries the offset it names');
   assert.match(lp, /id:'tzl-hl',type:'fill'/, 'there is a highlight fill');
   assert.match(lp, /filter:\['==',\['get','zone'\],-1e9\]/, 'selecting nothing by default');
-  assert.match(lp, /\['tzl-time','tzl-fill'\]\.forEach/, 'and both the text and the polygon answer a click');
+  assert.match(lp, /\[\['tzl-time',true\],\['tzl-fill',false\]\]\.forEach/, 'and both the text and the polygon answer a click');
+  /* ⚠ …with the LABEL winning. One press lands on both — the label is anchored over its zone's
+     largest polygon, which at low zoom is often drawn across a neighbour — and the fill's handler
+     ran last. Measured: pressing 「UTC+8」 highlighted zone 7. */
+  assert.match(lp, /if\(e && e\.__tzTaken\) return;/, 'the fill stands down when the label took the click');
+  assert.match(lp, /if\(fromLabel && e\) e\.__tzTaken=true;/);
+  assert.ok(lp.indexOf("['tzl-time',true]") < lp.indexOf("['tzl-fill',false]"), 'the label is wired first');
   assert.match(lp, /setHighlight\(\(hlZone!=null&&\+z===hlZone\)\?null:z\)/, 'a second press clears it');
   assert.match(lp, /window\.IntMapTimeZones=\{ highlight:/, 'published so Atlas and the tests can ask');
 });

--- a/tests/r204.spec.js
+++ b/tests/r204.spec.js
@@ -162,6 +162,20 @@ test('R204 ③ pressing a time-zone offset highlights every band on it', async (
     T.highlight(null);
     await new Promise((s) => setTimeout(s, 300));
     const off = { z: T.highlighted(), vis: map.getLayoutProperty('tzl-hl', 'visibility') };
+    /* ⚠ AND A PRESS ON THE TEXT ITSELF SELECTS THE OFFSET THE TEXT NAMES. The polygon answers the
+       same click, and until #R204 wired the label first and let it claim the event, the fill's
+       handler won — measured, pressing 「UTC+8」 highlighted zone 7. */
+    let byLabel = null;
+    map.jumpTo({ center: [7, 0], zoom: 2.5, pitch: 0, bearing: 0 });
+    await new Promise((s) => setTimeout(s, 1500));
+    const lab = map.queryRenderedFeatures({ layers: ['tzl-time'] })[0];
+    if (lab) {
+      const pt = map.project(lab.geometry.coordinates), rc = map.getCanvas().getBoundingClientRect();
+      map.getCanvas().dispatchEvent(new MouseEvent('click', { clientX: rc.x + pt.x, clientY: rc.y + pt.y, bubbles: true }));
+      await new Promise((s) => setTimeout(s, 600));
+      byLabel = { asked: lab.properties.zone, got: T.highlighted() };
+      T.highlight(null);
+    }
     /* the labels carry the offset the highlight filters on — that is what makes the TEXT clickable */
     const feats = map.querySourceFeatures('tzl-lbl-src');
     /* …and ONE offset is more than one polygon, which is why a filter rather than a selected feature */
@@ -170,7 +184,7 @@ test('R204 ③ pressing a time-zone offset highlights every band on it', async (
     const d = map.getSource('tzl-src')._data;
     const fc = (d && d.features) ? d : (d && d.geojson) || {};
     const bands = (fc.features || []).filter((f) => f.properties.zone === 9).length;
-    return { before, on, off, bands, labelHasZone: feats.length ? (feats[0].properties.zone !== undefined) : null };
+    return { before, on, off, bands, byLabel, labelHasZone: feats.length ? (feats[0].properties.zone !== undefined) : null };
   });
   expect(r.before.z, 'nothing is highlighted to begin with').toBe(null);
   expect(r.before.vis).toBe('none');
@@ -180,6 +194,7 @@ test('R204 ③ pressing a time-zone offset highlights every band on it', async (
   expect(r.off.z, 'pressing again clears it').toBe(null);
   expect(r.off.vis).toBe('none');
   expect(r.bands, 'the offset really covers more than one band').toBeGreaterThan(1);
+  if (r.byLabel) expect(r.byLabel.got, 'pressing the text selects the offset the text names').toBe(r.byLabel.asked);
   if (r.labelHasZone !== null) expect(r.labelHasZone, 'the label feature carries its offset').toBe(true);
 
   /* ── ④ and ⑤ share this page: a boot is eight seconds and neither of them changes the map ── */


### PR DESCRIPTION
Two things found by **looking at the shipped app** rather than by asserting against it.

### 1 · The grid readout said "global" for a domain that is a band

Measured on the first near-source run in production:

> Grid 4320×240 (**global, 0.25°**) · 7 km · Δt 10.1 s

The grid numbers were the band's and the description was the global domain's — worse than either alone, because nothing tells a reader which half is stale. It now takes the scope from the run that produced it:

> Grid 4320×240 (near source, 0.083°) · 7 km · Δt 10.1 s

### 2 · Pressing 「UTC+8」 highlighted zone 7

One press lands on the **text** and on the **polygon**: the label is anchored at the centre of its zone's largest band, which at low zoom is often drawn across a neighbouring band. The two delegated handlers ran in registration order and the fill's won.

The renderer hands the same event object to every delegated layer handler for one click, so the label is wired first, claims the event, and the fill stands down.

Measured after the fix — five label presses, five matching offsets:

```
8 → 8    4 → 4    7 → 7    −9 → −9    7 → 7
```

`tests/r204.spec.js ③` now presses the rendered label rather than calling the API, and `tests/r204-checks ⑦` pins the precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)