### PR TITLE
R207 follow-up: the post-deploy check slept instead of waiting for its condition

### DIFF
--- a/tests/prod-smoke.spec.js
+++ b/tests/prod-smoke.spec.js
@@ -358,8 +358,25 @@ test('(#R179) prod base map serves the pixels the display asks for', async ({ br
          asserted separately), so it selects it rather than inheriting it. Caught by running this file
          against LIVE production BEFORE merging the change: 16/16 green, and this is the one that
          would have gone red fifteen minutes after the deploy. */
+      /* ⚠ WAIT FOR THE CONDITION, NOT FOR A DURATION. The first version of this slept 3.5 s after the
+         click and went red on the post-deploy run while passing everywhere else: `applyTheme()` only
+         switches the basemap once the style is ready, and on a loaded runner against a cold CDN that
+         had not happened yet. What the assertions below need is a VISIBLE Carto layer, so that is
+         what is waited for — which is also faster on a warm run than any sleep long enough to be safe
+         on a cold one. */
       await p2.evaluate(() => document.getElementById('btn-view-map')?.click());
-      await p2.waitForTimeout(3500);
+      await p2.waitForFunction(() => {
+        try {
+          const m = window.__imap, st = m.getStyle();
+          return ['layer-light-nl', 'layer-dark-nl', 'layer-light', 'layer-dark'].some((id) => {
+            const lyr = (st.layers || []).find((l) => l.id === id);
+            if (!lyr) return false;
+            if ((m.getLayoutProperty(id, 'visibility') || 'visible') === 'none') return false;
+            return /cartocdn\.com/.test((((st.sources[lyr.source] || {}).tiles || [])[0]) || '');
+          });
+        } catch (_) { return false; }
+      }, null, { timeout: 45_000 }).catch(() => {});
+      await p2.waitForTimeout(2500);   /* let the visible layer actually request its tiles */
       const decision = await p2.evaluate(() => window.__imHiDPITiles);
       expect(decision, `the one HiDPI decision at dpr ${dsf}`).toBe(dsf >= 1.5);
       /* WHICH Carto requests are the map's is asked of the live style. The layer panel's preview


### PR DESCRIPTION
The R207 deploy went red on **one post-deploy test**, and the deploy itself was fine:

```
Build + verify:            success
Deploy to Pages:           success
Post-deploy smoke:         failure   (15 passed, 1 failed)
```

Production is live and correct — verified directly against the deployed URL:

```
[prod-smoke] basemap=satellite · terrain=off · bottom layer=layer-polar-cap
```

## What actually failed

`(#R179) prod base map serves the pixels the display asks for` finds the Carto base by looking for the **visible** base layer, which is no longer what a session opens on. R207 made it click Map first — and then wait **3.5 seconds**, which is the wrong kind of wait: `applyTheme()` only switches the basemap once the style is ready, and on a loaded runner against a cold CDN that had not happened yet. `seg` was null and all three retries agreed.

It passes locally against the *same* production URL, which is the signature of a timing assumption rather than a logic error — so the fix is to wait for the condition, not for a duration: a visible layer whose source is Carto, with a 45 s ceiling. That is correct on a cold runner and **faster** than the sleep on a warm one.

## Verified

Against live production, after the fix:

```
[prod-smoke] dpr 1 · style light_nolabels · base-map tiles 61 · @2x 0
[prod-smoke] dpr 2 · style light_nolabels · base-map tiles 61 · @2x 61
1 passed (24.1s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)