### PR TITLE
R207 follow-up: the build stamp said R205 on an R207 deploy, and nothing could tell

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ gtag('js', new Date());
    can finish booting in a hidden/background tab (rAF is throttled to zero there, `map.on('load')` never fires
    and nothing map-side can be verified). Never active for normal visitors. */
 if(/[?&]rafshim=1/.test(location.search)){ try{ window.requestAnimationFrame=function(cb){ return setTimeout(function(){ cb(performance.now()); },33); }; window.cancelAnimationFrame=clearTimeout; }catch(_){} }
-window.__imBuild='R205';   /* (#R121) build marker — bump when verifying that a reload really picked up the edited file (file:// reloads can serve a stale cache) */   /* (#R174) bump BOTH stamps together — tests/r169-checks.test.mjs requires them to name the same round, and both sat at R171 through #R172/#R173 */
+window.__imBuild='R207';   /* (#R121) build marker — bump when verifying that a reload really picked up the edited file (file:// reloads can serve a stale cache) */   /* (#R174) bump BOTH stamps together — tests/r169-checks.test.mjs requires them to name the same round, and both sat at R171 through #R172/#R173 */
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
@@ -50,7 +50,7 @@ window.__imBuild='R205';   /* (#R121) build marker — bump when verifying that 
      the NEWEST build ever loaded on this device. If a load ever serves an OLDER build than one already seen,
      we KNOW it's a stale copy → purge caches + hard-reload ONCE; if it's still old after that, surface a
      banner so it can never silently masquerade as the current app again. */
-  window.INTMAP_BUILD='2026-08-10-R205';   /* (#R174) …and it MUST be bumped every round: it was left at R171 through
+  window.INTMAP_BUILD='2026-08-11-R207';   /* (#R174) …and it MUST be bumped every round: it was left at R171 through
      #R172 and #R173, which means that for three rounds a device serving a stale cached copy looked current to the
      guard above. Caught by the production smoke test, which prints the live build id. */
   /* (#R29.1) Maintenance/security: capture the last ~25 runtime errors into a ring buffer so the Bug Report

--- a/tests/r207-checks.test.mjs
+++ b/tests/r207-checks.test.mjs
@@ -175,6 +175,32 @@ test('R207 ⑪ the space-approach caption is centred on the visible map and has 
     'it is a pill on the app surface, so it reads in light mode as well as dark');
 });
 
+/* ── ⑬ the build stamp names THIS round, not merely the same round twice ────────────────────────
+   MEASURED on the live site right after the R207 deploy: `[prod-smoke] live build = 2026-08-10-R205`.
+   R206 shipped with an R205 stamp and nothing noticed, because the only rule anyone had written was
+   "the two stamps agree with each other" (tests/r169-checks ⑧) — which two equally stale stamps
+   satisfy perfectly. #R174 had already lost three rounds to exactly this and answered it with a
+   comment saying it MUST be bumped; a comment is not a gate.
+
+   The stamp's job is to let the anti-stale guard (index.html ~line 50) and an incident responder tell
+   which build is live. A stamp that names an older round makes a CURRENT build look stale to the
+   guard and a stale one look plausible to a human — both directions wrong.
+
+   So it is derived from something that cannot be forgotten: DEV-NOTES.md's newest `## R<n>` heading
+   is written by the round itself (standing instruction 9 — prepend). If a round documents itself, it
+   cannot ship someone else's stamp. */
+test('R207 ⑬ the build stamp names the newest round in DEV-NOTES', () => {
+  const html = read('index.html');
+  const notes = read('DEV-NOTES.md');
+  const newest = Math.max(...[...notes.matchAll(/^## R(\d+) —/gm)].map((m) => +m[1]));
+  assert.ok(isFinite(newest) && newest > 0, 'DEV-NOTES.md has round headings to derive from');
+  const ib = /window\.INTMAP_BUILD='(\d{4}-\d{2}-\d{2})-R(\d+)';/.exec(html);
+  const mb = /window\.__imBuild='R(\d+)';/.exec(html);
+  assert.ok(ib && mb, 'both stamps are present and well-formed');
+  assert.equal(+ib[2], newest, `INTMAP_BUILD says R${ib[2]} but the newest documented round is R${newest}`);
+  assert.equal(+mb[1], newest, `__imBuild says R${mb[1]} but the newest documented round is R${newest}`);
+});
+
 /* ── ⑫ the test bill itself ────────────────────────────────────────────────────────────────────── */
 test('R207 ⑫ the deep tier no longer stands between a merge and the next one', () => {
   const y = read('.github/workflows/ci.yml');


### PR DESCRIPTION
Measured on the live site immediately after the R207 deploy:

```
[prod-smoke] live build = 2026-08-10-R205
```

**R206 shipped with an R205 stamp as well.** The only rule written anywhere is *'the two stamps name the same round'* (`tests/r169-checks` ⑧) — and two equally stale stamps satisfy that perfectly. #R174 already lost three rounds to this and answered it with a comment saying the stamp **must** be bumped every round. A comment is not a gate; that comment was sitting directly above the stale value.

## Why it is not cosmetic

The stamp feeds `index.html`'s anti-stale guard, which purges caches and hard-reloads when a load serves an **older** build than one already seen on that device. A stamp naming an older round makes a *current* build look stale to the guard, and makes a *genuinely* stale one look plausible to a human reading an incident report. Both directions are wrong, and `docs/INCIDENT-RESPONSE.md` points at this value as the answer to "what's live?".

## The fix

Derived from something a round cannot forget: **DEV-NOTES.md's newest `## R<n>` heading**, which the round writes about itself (standing instruction 9 — prepend). A round that documents itself can no longer ship someone else's stamp.

Both stamps bumped to R207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)