### PR TITLE
R210: what the deep tier caught, attributed rather than assumed

### DIFF
--- a/js/map-ui.js
+++ b/js/map-ui.js
@@ -453,7 +453,19 @@ window.IntMapModules.layerSidebar=function(HOST){
          `right:false`, and that still wins — the new case is the one where there is no saved answer
          at all. Mobile is unchanged (the panel is an overlay there, opened by the layer button). */
       { const ui=window._imSessionUI; const unanswered=!ui||typeof ui.right!=='boolean';
-        if(!isMob()&&(unanswered||ui.right===true)) open(); }
+        if(!isMob()&&(unanswered||ui.right===true)){
+          /* WARN (#R210) A FIRST VISIT OPENS IT WHEN THE APP IS IDLE, NOT WHILE IT IS STILL
+             BOOTING. open() runs reorganizeLayerPanel()+buildTiles() synchronously when the grid
+             has not been built yet, and on a first visit it never has — so opening here put a
+             full tile build in front of whatever boot was still doing. That is #R208's own
+             finding («譲り方が同優先度だと背景処理がアプリ起動と競走して勝つ»), and it showed up
+             as tests/r170's fresh-profile test failing on a GPU-less CI runner while passing
+             three times out of three locally. A RESTORED session is different: the grid was
+             pre-built by the idle callback above, so open() is cheap and immediate is right.
+             The 3 s timeout means the panel always appears, idle or not. */
+          if(unanswered&&'requestIdleCallback' in window) requestIdleCallback(()=>{ try{ open(); }catch(_){} },{timeout:3000});
+          else open();
+        } }
     } }catch(_){} },1500);   /* edge toggle available on boot in right mode (without auto-opening) */
     /* (#R104) rebuild the tile grid on a language change so the layer NAMES follow the new language immediately
        (the tiles are a copy of the classic dropdown, which updateI18n localizes — rebuild AFTER that). This was

--- a/tests/r176.spec.js
+++ b/tests/r176.spec.js
@@ -136,7 +136,18 @@ test('a levee drawn on flat ground creates a basin that holds water', async ({ p
     return { before, after, wet, leveeLayer: !!m.getLayer('tw-levee-line') };
   });
   expect(r.leveeLayer).toBe(true);
-  expect(r.before.basin, 'flat ground has no basin').toBeNull();
+  /* WARN (#R210) THIS USED TO BE `expect(r.before.basin).toBeNull()`, AND THAT WAS A PROPERTY OF
+     THE VIEWPORT, NOT OF THE GROUND. `open({refit:true})` fits the solver grid to the CURRENT view,
+     so the cells move whenever the map canvas changes width. #R210 took the left sidebar from 440 to
+     400 px; measured, the canvas went 840 -> 880 px, the fitted bounds widened, and a real 1.5 m
+     dip that the DEM has always contained near this point landed inside the sampled cells:
+     before.basin = {cells: 4, spillM 5.479 vs groundM 4.014}. The tool was not wrong — the
+     assertion was pinned to one screen width.
+     What this test is about is in its own title: the LEVEE makes a basin. So the precondition
+     states the same thing as a RELATION — before the line there is no rim worth speaking of
+     (< 2 m), after it there is one taller than the 4 m asserted below. */
+  const beforeRim = r.before.basin ? (r.before.basin.spillM - r.before.groundM) : 0;
+  expect(beforeRim, 'flat ground has no rim worth speaking of').toBeLessThan(2);
   expect(r.after.basin, 'drawing the line made one').not.toBeNull();
   // the rim is the ground plus the crest the user asked for
   expect(r.after.basin.spillM - r.after.groundM).toBeGreaterThan(4);

--- a/tests/r195-checks.test.mjs
+++ b/tests/r195-checks.test.mjs
@@ -59,8 +59,10 @@ test('R195 ①: both sidebars are recorded, and every route out of them records 
      and that only the no-saved-answer case opens. Pinning the old expression would have made that
      instruction unimplementable, so the assertion is on the two behaviours, not on the source line. */
   assert.match(mapUi, /typeof ui\.right!=='boolean'/, 'boot distinguishes "no saved answer" from a saved one');
-  assert.match(mapUi, /if\(!isMob\(\)&&\(unanswered\|\|ui\.right===true\)\) open\(\);/,
+  assert.match(mapUi, /if\(!isMob\(\)&&\(unanswered\|\|ui\.right===true\)\)\{/,
     'a saved right:false still boots closed; only an unanswered first visit opens');
+  /* (#R210 follow-up) the unanswered case waits for idle so the tile build does not race boot */
+  assert.match(mapUi, /if\(unanswered&&'requestIdleCallback' in window\)/, 'and it opens on idle');
 });
 
 /* ── ② the dynamic image is parameterised by the engine, not by latitude ──────────────────────── */

--- a/tests/r210-checks.test.mjs
+++ b/tests/r210-checks.test.mjs
@@ -95,4 +95,9 @@ test('R210 ⑥: the test seat opts out of the first-visit panel on purpose', () 
   assert.match(seed, /"lsrOpen":false/, 'the seeded session answers the layer-panel question');
   const ui = rd('js/map-ui.js');
   assert.match(ui, /typeof ui\.right!=='boolean'/, 'and the app is what distinguishes "no answer" from an answer');
+  /* WARN (#R210 follow-up) …and the first-visit open must not race the boot: open() builds the
+     whole tile grid synchronously the first time, so on an unanswered session it waits for idle.
+     A RESTORED session still opens immediately (its grid was pre-built by the idle callback). */
+  assert.match(ui, /if\(unanswered&&'requestIdleCallback' in window\) requestIdleCallback/,
+    'a first visit opens the panel on idle, with a timeout so it always appears');
 });


### PR DESCRIPTION
The deep tier does not run on a PR, so R210 merged without it. Dispatched on main afterwards, it came back with 7 reds. **Every one of them was attributed by comparison before anything was changed** (#R195's lesson: a red on CI is not "pre-existing" because you would like it to be).

## Method

Deep was dispatched a second time on a branch pinned at `0009bc2` (main before R210), and the failing specs were also run locally in a worktree at that commit — **repeat-each, both trees**, which is #R166's rule.

| red | pre-R210 | R210 | verdict |
|---|---|---|---|
| `r169 #3` / `r168 #7` appendNewsBatch write-through | fails | fails | environment |
| `r184-drone ④` 2.4 GHz through the Alps | fails | fails | environment (Overpass) |
| `r184-drone ⑤` OSM restricted areas | fails | — | environment |
| `r149 #9` image drop into Atlas | — | passes locally 1/1 | environment |
| `r173` lifted aircraft click + track | — | passes locally 1/1 | environment |
| `r170` fresh desktop profile | — | passes locally 3/3 | **timing, and R210 made it worse — fixed** |
| `r176` levee on flat ground | **passes 3/3** | **fails 3/3** | **caused by R210 — fixed** |

## The one real regression, measured

`r176` asserted `before.basin === null` — "flat ground has no basin". That is a property of the **viewport**, not of the ground: `TW.open({refit:true})` fits the solver grid to the current view. R210 took the left sidebar from 440 to 400 px, and the instrumented probe says exactly what followed:

```
pre-R210   canvas 840 px   bounds 139.74790..139.95210   before.basin = null
R210       canvas 880 px   bounds 139.74303..139.95697   before.basin = {cells: 4, groundM 4.014, spillM 5.479}
```

A real **1.5 m** dip the DEM has always contained moved inside the sampled cells. The tool is not wrong. The assertion is now the **relation** the test's own title is about — before the line there is no rim worth speaking of (< 2 m), after it there is one taller than the 4 m already asserted below. ⚠ Verified **on both trees** so it is not tuned to this change.

## The timing one, and why it was worth fixing rather than retrying

`open()` runs `reorganizeLayerPanel()` + `buildTiles()` **synchronously** when the grid has not been built — and on a first visit it never has. So R210's first-visit open put a full tile build in front of whatever boot was still doing, which is #R208's own finding («譲り方が同優先度だと背景処理がアプリ起動と競走して勝つ»). An unanswered session now opens the panel on `requestIdleCallback` with a 3 s timeout, so it always appears and no longer races the boot — **and that removes a real boot cost for every first-time user, not just for the test.** A restored session still opens immediately: its grid was pre-built by the idle callback above it.

`npm test` green (checks + browser). `tests/r195-checks` and `tests/r210-checks` updated to state the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)