### PR TITLE
R211 deep: the POI test pinned minzoom 14 as a literal — write the claim it was guarding

### DIFF
--- a/tests/r186.spec.js
+++ b/tests/r186.spec.js
@@ -210,7 +210,16 @@ test('R186 POI: shop and facility names are their own layer and their own toggle
              sourceLayer: src && src['source-layer'], minzoom: src && src.minzoom,
              dot: G.layers.has('ofm-poi-dot') };
   });
-  expect(r).toMatchObject({ on: 'visible', off: 'none', sourceLayer: 'poi', minzoom: 14, dot: true });
+  /* ⚠ (#R211) THE CLAIM IS THE TOGGLE AND THE LAYER, NOT THE NUMBER 14. #R186 pinned `minzoom: 14`
+     as a literal beside the things this test is actually about, and #R211 lowered it to 12 on
+     instruction — 「あるズームで問答無用に全表示・全非表示になるのをやめる」, plus landmarks that a
+     person navigates by were not drawn at the zoom where they are looked for. The literal made a
+     deep shard red for a change the test has no opinion on. Written as the RELATION it was always
+     guarding: the layer exists, it is zoom-gated rather than always on, and it starts no LATER than
+     it used to. (The tier ladder that decides what appears when is asserted in tests/r211-checks.) */
+  expect(r).toMatchObject({ on: 'visible', off: 'none', sourceLayer: 'poi', dot: true });
+  expect(typeof r.minzoom, 'the POI labels are zoom-gated, not drawn at every zoom').toBe('number');
+  expect(r.minzoom, 'and they start no later than #R186 put them').toBeLessThanOrEqual(14);
 });
 
 test('R186 sea level: the number applies as it is typed, and 100 % is opaque', async ({ page }) => {


### PR DESCRIPTION
deep（マージ後の dispatch）で 9 件赤。うち **1 件は本物**で、これがその修正です。

`tests/r186.spec.js` の POI テストは `minzoom: 14` を**リテラルで固定**していました。#R211 は指示
（「あるズームで問答無用に全表示・全非表示になるのをやめる」＋人が探す倍率でランドマークが描かれていない）
で 12 に下げているので、**テストが意見を持っていない変更**でシャードが赤くなっていました。

主張は「店舗・施設名は**自分のレイヤーと自分のトグル**を持つ」であって 14 という数ではないので、
**関係**で書き直しました：レイヤーが在る／ズームで門がある（常時表示ではない）／**#R186 が置いた位置より
遅くならない**。どの段が何時現れるかは `tests/r211-checks.test.mjs` の梯子の表明が持っています。

残り 8 件の帰属は `chore/r211-deep-baseline`（R211 前の `148153d`）で同じ deep を回して確認中。
うち 5 件は #R210 が既に**環境**と帰属したもの（appendNewsBatch / r184-drone ④⑤ / r149 #9 / r173）。
`r174` と `r191` は**この木のローカルで緑**（2/2）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)