### PR TITLE
R220 追記: 縁取りは作ったのに一度も表示されていなかった／場の矢印が natural size で海を覆っていた／海流にも onRestyle

### DIFF
--- a/js/ocean-currents.js
+++ b/js/ocean-currents.js
@@ -49,7 +49,7 @@ window.IntMapModules.oceanCurrents=function(HOST){
        World-data layer uses. If world-packs has not registered, this module does not build. */
     const W=(window.IntMapWorld&&window.IntMapWorld._ui)||null;
     if(!W) return { state:()=>({on:false,err:'world-packs not loaded'}) };
-    const { makePanel, ensureHead, row, esc, whenDrawable, setVis, L } = W;
+    const { makePanel, ensureHead, row, esc, whenDrawable, setVis, onRestyle, L } = W;
 
     /* ══ ⚠⚠ (#R220) 「クオリティがゴミ。」 — WHAT WAS ACTUALLY ON SCREEN ═══════════════════════════
        #R219 got the DATA right (bundled, fixed, measured — see the file header) and then drew it as
@@ -80,11 +80,17 @@ window.IntMapModules.oceanCurrents=function(HOST){
        muddy over the satellite ocean, and #2f7fe0 is within a few per cent of the sea it is drawn on. */
     const COL_WARM='#ff5b41', COL_COLD='#38b6ff', COL_NEUTRAL='#c9d1d9';
     const COL_CASE='rgba(2,16,28,0.82)';   /* the casing every mark shares */
+    /* ⚠ (#R220) ONE LIST, and everything that switches the layer reads it. The first version of this
+       round updated the PANEL's list and left `setVis([FLOW,LINE,HEAD,LBL], …)` in `draw()` and
+       `toggle()` — measured on the built site: `oc-glow`, `oc-case`, `oc-head-case` and `oc-flow-case`
+       all `visibility:'none'`, i.e. every casing this round exists to add was built and never shown,
+       and the plate looked exactly as thin as it had before. */
+    const ALL=[FLOWC,FLOW,GLOW,CASE,LINE,HEADC,HEAD,LBL];
 
     let on=false, doc=null, state='idle', err=null, picked=null;
 
     const panel=makePanel('oc-panel',()=>'🌊 '+L('Ocean currents','海流','Meeresströmungen','Морские течения','Corrientes marinas'),'wp-dl-currents',
-      { legendId:'wpcurrents', layers:()=>[FLOWC,FLOW,GLOW,CASE,LINE,HEADC,HEAD,LBL],
+      { legendId:'wpcurrents', layers:()=>ALL.slice(),
         names:()=>({en:'🌊 Ocean currents',jp:'🌊 海流（暖流・寒流）',de:'🌊 Meeresströmungen',ru:'🌊 Морские течения',es:'🌊 Corrientes marinas'}) });
 
     /* ── the arrowhead, drawn once and registered as an image ─────────────────────────────────────
@@ -155,20 +161,25 @@ window.IntMapModules.oceanCurrents=function(HOST){
            placement pass and are what stop the field from disappearing into the sea. The casing must
            `icon-allow-overlap:true` and `icon-ignore-placement:true` — if it took part in collision
            it would sometimes win the slot its own arrow lost, and the map would show naked shadows. */
-        const FLOW_LAYOUT=(k)=>({visibility:'none',
+        /* ⚠ THE ZOOM EXPRESSION IS THE OUTERMOST ONE (#R196's rule), so the SPEED rides on the stop
+           OUTPUTS. Measured: writing `['*', speed, zoomRamp]` is accepted-looking and rejected, and a
+           rejected layout leaves the icons at their natural 48 px — which is what a first version of
+           this round did, and the whole ocean went dark under them. */
+        const FLOW_SIZE=(k)=>['interpolate',['linear'],['zoom'],
+          0,SPEED_SZ(0.26*k), 3,SPEED_SZ(0.34*k), 6,SPEED_SZ(0.46*k), 9,SPEED_SZ(0.58*k)];
+        const FLOW_LAYOUT=()=>({visibility:'none',
           'icon-image':'oc-dart-img',
-          'icon-size':SPEED_SZ(k?1:1),
           'icon-rotate':['-',['get','b'],90],
           'icon-rotation-alignment':'map','icon-padding':1});
         if(!GE().layers.has(FLOWC)) GE().layers.add({id:FLOWC,type:'symbol',source:FSRC,
-          layout:Object.assign(FLOW_LAYOUT(),{ 'icon-size':SPEED_SZ(1),
+          layout:Object.assign(FLOW_LAYOUT(),{ 'icon-size':FLOW_SIZE(1),
             'icon-allow-overlap':true,'icon-ignore-placement':true }),
           paint:{'icon-color':COL_CASE,
-            'icon-opacity':['interpolate',['linear'],['zoom'],0,0.5,4,0.62,8,0.7],
-            'icon-halo-color':COL_CASE,'icon-halo-width':2.2,'icon-halo-blur':0.6,
-            'icon-translate':[0,0]}});
+            'icon-opacity':['interpolate',['linear'],['zoom'],0,0.34,4,0.44,8,0.52],
+            'icon-halo-color':COL_CASE,'icon-halo-width':1.2,'icon-halo-blur':0.5}});
         if(!GE().layers.has(FLOW)) GE().layers.add({id:FLOW,type:'symbol',source:FSRC,
-          layout:Object.assign(FLOW_LAYOUT(),{ 'icon-allow-overlap':false,'icon-ignore-placement':false }),
+          layout:Object.assign(FLOW_LAYOUT(),{ 'icon-size':FLOW_SIZE(1),
+            'icon-allow-overlap':false,'icon-ignore-placement':false }),
           paint:{'icon-color':SPEED_COL,
             'icon-opacity':['interpolate',['linear'],['zoom'],0,0.85,4,0.95,8,1]}});
         /* ② the named currents, over the field — glow, casing, colour, in that order */
@@ -201,6 +212,12 @@ window.IntMapModules.oceanCurrents=function(HOST){
         return true;
       }catch(_){ return false; } }
 
+    /* ⚠ (#R220) A RESTYLE DROPS EVERY ADDED LAYER. The basemap swap, a theme change and a style
+       reload all take the eight layers away, and this module had no `onRestyle` at all — so the plate
+       vanished until the reader toggled it off and on again. Redrawn from the document already in
+       hand: no request, no wait. (#R219 found and closed the same hole in the tide shading.) */
+    onRestyle(()=>{ if(on&&doc) whenDrawable(()=>{ if(ensureLayers()) draw(); }); });
+
     /* ── the file, once ───────────────────────────────────────────────────────────────────────────
        ⚠ NOT ON THE BOOT PATH. 146 kB is nothing next to the layer being useful, and everything about
        nothing next to a layer nobody switched on — so it is fetched on the first toggle and kept. */
@@ -232,7 +249,7 @@ window.IntMapModules.oceanCurrents=function(HOST){
       whenDrawable(()=>{ if(!ensureLayers()) return;
         try{ GE().layers.setSourceData(SRC,{type:'FeatureCollection',features:named}); }catch(_){}
         try{ GE().layers.setSourceData(FSRC,{type:'FeatureCollection',features:flow}); }catch(_){}
-        setVis([FLOW,LINE,HEAD,LBL],on);
+        setVis(ALL,on);
         panel.claim(); }); }
 
     /* ── the window ─────────────────────────────────────────────────────────────────────────────── */
@@ -288,7 +305,7 @@ window.IntMapModules.oceanCurrents=function(HOST){
 
     function toggle(v){
       on=!!v;
-      if(!on){ panel.hide(); setVis([FLOW,LINE,HEAD,LBL],false); picked=null; return; }
+      if(!on){ panel.hide(); setVis(ALL,false); picked=null; return; }
       render();
       whenDrawable(()=>{ ensureLayers(); if(doc){ draw(); } else load(); });
     }

--- a/js/world-packs.js
+++ b/js/world-packs.js
@@ -1794,7 +1794,10 @@ window.IntMapModules.worldPacks=function(HOST){
        project and the second of `uncheckRow`, and the #R212 report 「ポップアップ消してもレイヤー
        選択状態」 was caused by exactly that kind of duplication getting out of step. So they are
        handed over rather than re-declared. Nothing here is new behaviour; it is the same functions. */
-    const _ui={ makePanel, uncheckRow, ensureHead, row, esc, usdShort, usdExact, nowYear, onYear, whenDrawable, setVis, L };
+    /* (#R220) …and `onRestyle`, because a style reload drops every added layer and the ocean-current
+       plate — the only member of this family that lives in its own file — had no way to hear about
+       it. #R219 found the same hole in the tide shading; this closes it for the sixth layer too. */
+    const _ui={ makePanel, uncheckRow, ensureHead, row, esc, usdShort, usdExact, nowYear, onYear, whenDrawable, setVis, onRestyle, L };
     return Object.assign({ _ui, state:()=>({ trade:STATE.trade&&STATE.trade(), energy:STATE.energy&&STATE.energy(),
       alerts:STATE.alerts&&STATE.alerts(), tides:STATE.tides&&STATE.tides(), crops:STATE.crops&&STATE.crops(),
       year:nowYear() }) }, STATE);

--- a/tests/r213-checks.test.mjs
+++ b/tests/r213-checks.test.mjs
@@ -285,7 +285,9 @@ test('R213 ⑧: revenue carries its own currency, and the ranking says what it c
   assert.doesNotMatch(iw, /new maplibregl\.Popup|GE\(\)\.ui\.popup/, 'there is no second, separate popup');
   /* it borrows the layer-family toolkit instead of carrying a second copy */
   assert.match(iw, /window\.IntMapWorld && window\.IntMapWorld\._ui/, 'the panel/row toolkit is handed over by js/world-packs.js');
-  assert.match(read('js/world-packs.js'), /const _ui=\{ makePanel, uncheckRow, ensureHead, row, esc, usdShort, usdExact, nowYear, onYear, whenDrawable, setVis, L \};/,
+  /* (#R220) …plus `onRestyle`: a style reload drops every added layer, and the current plate — the
+     one member of this family in its own file — had no way to hear about it. */
+  assert.match(read('js/world-packs.js'), /const _ui=\{ makePanel, uncheckRow, ensureHead, row, esc, usdShort, usdExact, nowYear, onYear, whenDrawable, setVis, onRestyle, L \};/,
     'and world-packs publishes exactly that toolkit');
   /* the module is imported after world-packs, which is what makes the line above true at boot */
   const main = read('src/main.js');

--- a/tests/r220-checks.test.mjs
+++ b/tests/r220-checks.test.mjs
@@ -72,8 +72,13 @@ test('r220 ③ every mark on the current plate has a casing under it', () => {
   /* the casing must not take part in collision, or it wins slots its own arrow loses */
   const flowc = OCEAN.slice(OCEAN.indexOf('layers.add({id:FLOWC'), OCEAN.indexOf('layers.add({id:FLOW,'));
   assert.match(flowc, /'icon-allow-overlap':true,'icon-ignore-placement':true/, 'the field casing ignores placement');
-  assert.ok(OCEAN.includes("layers:()=>[FLOWC,FLOW,GLOW,CASE,LINE,HEADC,HEAD,LBL]"),
-    'and the panel drives all eight layers');
+  /* ⚠ ONE list, read by the panel AND by every setVis — the first version of this round updated the
+     panel and left `setVis([FLOW,LINE,HEAD,LBL])` behind, so every casing was built and never shown. */
+  assert.match(OCEAN, /const ALL=\[FLOWC,FLOW,GLOW,CASE,LINE,HEADC,HEAD,LBL\];/, 'there is one list');
+  assert.ok(OCEAN.includes('layers:()=>ALL.slice()'), 'the panel reads it');
+  assert.equal((OCEAN.match(/setVis\(ALL,/g) || []).length, 2, 'and so does every setVis');
+  assert.ok(!/setVis\(\[FLOW,LINE,HEAD,LBL\]/.test(OCEAN.replace(/\/\*[\s\S]*?\*\//g, '')),
+    'no partial list survives in the program (the note that records it may name it)');
 });
 
 /* ══ ④ WORDS ════════════════════════════════════════════════════════════════════════════════ */


### PR DESCRIPTION
本番反映後に**実際に描かれた画素**で確認したところ、#R220 本体で3件の欠陥を自分で入れていたので直します。

1. ⚠ **この回で足したケーシング4枚は、作られたまま一度も可視になっていなかった。**
   パネルのレイヤー一覧は更新したのに、`draw()` と `toggle()` の
   `setVis([FLOW,LINE,HEAD,LBL], …)` が古いままだった。実測（ビルド済みサイト）:
   `oc-glow` / `oc-case` / `oc-head-case` / `oc-flow-case` がすべて `visibility:'none'`。
   つまり「縁取りを足した」と書いたものが1つも画面に出ていなかった。
   → リストは `ALL` 1つにして、パネルも `setVis` も同じものを読む。

2. ⚠ **場の矢印が natural size (48 px) で描かれ、海を暗く埋めていた。**
   `icon-size` に速度の式をそのまま入れたためズーム式が最外側でなくなり、
   レイアウトが拒否されていた（#R196 が記録している罠と同じ形）。
   → ズーム式を外側にし、速度は stop の出力へ。

3. **海流に `onRestyle` が無かった** ので、ベースマップ／テーマ／スタイル再読込のたびに
   8枚が黙って消えていた。`world-packs` の `_ui` に `onRestyle` を公開して購読。
   （#R219 が潮汐の塗りで塞いだのと同じ穴。）

`npm test` 緑（checks 876 / browser 48）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)