### PR TITLE
R225 fix: post-deploy smoke のテーブル数を 27 → 25 に（地政学レイヤーの削除ぶん）

### DIFF
--- a/tests/prod-smoke.spec.js
+++ b/tests/prod-smoke.spec.js
@@ -230,7 +230,11 @@ test('(#R167) prod deployed the DOM-only modules (legal / news timeline) and the
     const T = window.IntMapTables || {};
     return { n: Object.keys(T).length, gdp: T.GDP && T.GDP.USA, cap: T.CAPITAL && T.CAPITAL.JPN };
   });
-  expect(tables.n, 'js/tables.js deployed with all 27 tables').toBe(27);
+  /* (#R225) 27 → 25: `geoLayersDB` and `GEO_LABEL_JP` left with the nine geopolitics layers they
+     described (「レイヤー自体を削除してほしい」). The count is hard-coded ON PURPOSE — what it catches is a
+     PARTIAL deploy, which a «more than zero» test would not. ⚠ It is only run post-deploy (NEVER tier),
+     so nothing before the deploy can catch it drifting; move it in the same commit as the table. */
+  expect(tables.n, 'js/tables.js deployed with all 25 tables').toBe(25);
   expect(tables, 'the tables carry real values').toMatchObject({ gdp: 27361, cap: 'Tokyo' });
 });
 


### PR DESCRIPTION
本番デプロイは成功し、サイト自体は正常です。落ちたのは post-deploy smoke の期待値で、`js/tables.js` の輸出が `geoLayersDB` と `GEO_LABEL_JP` を失って **27 → 25** になったためです（実測で確認）。

⚠ この数は**意図的にハードコード**されています（「0より多い」では PARTIAL deploy を捕まえられない）。そして `prod-smoke` は **NEVER tier** で post-deploy にしか走らないので、デプロイ前の門では一切捕まりません——テーブルを増減させたら同じコミットでここも動かす、と注記しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)