### PR TITLE
READMEのAI無料回数が3ラウンド古かった（30回 → 10回）

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Atlas can navigate the map, control layers, select and compare countries, activa
 
 It does not yet operate every feature reliably. Complex multi-step requests, current-information research, and newly added tools may fail or produce incomplete results.
 
-Built-in AI is currently free for logged-in users, with a limit of up to 30 uses per day. Most non-AI map features can be used without an account.
+Built-in AI is currently free for logged-in users, with a limit of up to 10 uses per day. Most non-AI map features can be used without an account.
 
 Atlas may make factual or operational mistakes. Important information should always be checked against its original source.
 


### PR DESCRIPTION
README の1行だけの修正です。

## 何が違っていたか

実装は **#R147 で 30→10 に戻して**いて、クライアント・サーバ両側にその記録があります:

```
js/app-body.js:588
  const AI_FREE_DAILY = 10;   /* #R40: 5→10; #R101: 10→30; #R147: 30→10 per request */

supabase/functions/ai-proxy/index.ts:90
  const PLAN_LIMITS = { free: 10, plus: 50, pro: 200, unlimited: 1_000_000 };
                                   /* (#R101) free 10→30/day; (#R147) 30→10/day */
```

README だけが #R101 時代の「up to **30** uses per day」のまま残っていました。

## なぜ直す価値があるか

アプリ本体（`js/ai-core.js`）は `HOST.AI_FREE_DAILY` を埋め込んで表示するので、**画面には正しく10と出ます**。つまり食い違っているのはドキュメント1箇所だけで、それがいちばん悪い形です — README を読んで来た人だけが3倍の期待を持って登録し、11回目で止まります。

## テストとの関係

`tests/r147-checks.test.mjs` はこの取り違えを既に見張っています:

```js
assert.ok(!/up to 30 uses per day/.test(html), 'no stale "30 uses per day" copy');
```

ただし対象が `appSource`（index.html + css + js + locales + src）なので、**README は範囲外**でした。今回スコープは広げていません — README は配布物ではなく GitHub 上の文書で、`appSource` に混ぜると「アプリのソースとは何か」という定義が濁るためです。

## 確認

- リポジトリ全体を検索し、他に古い数字が残っていないことを確認（`DEV-NOTES` / `ARCHIVE` は当時の記録なのでそのまま）
- `check:static` パス
- `test:checks` 1018/1018 パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
