### PR TITLE
R263 追記: --baseline が新モデルを2回測っていた

### DIFF
--- a/scripts/seismic-validate.mjs
+++ b/scripts/seismic-validate.mjs
@@ -65,10 +65,18 @@ const browser = await chromium.launch();
 const page = await browser.newPage();
 page.on('pageerror', (e) => console.error('  page error: ' + e.message));
 await page.goto(base, { waitUntil: 'load' });
-await page.waitForFunction(() => window.IntMapLazy && window.IntMapEarth, null, { timeout: 60000 });
-if (BASELINE) await page.evaluate(() => { try { delete window.IntMapEarth; } catch (_) { window.IntMapEarth = undefined; } });
+/* only the loader is eager — js/earth-structure.js arrives with the seismic chunk (see below) */
+await page.waitForFunction(() => !!window.IntMapLazy, null, { timeout: 60000 });
 await page.evaluate(() => window.IntMapLazy.need('seismic'));
 await page.waitForFunction(() => !!window.IntMapSeismic, null, { timeout: 60000 });
+/* ⚠ THE ORDER HERE IS LOAD-BEARING AND IT WAS WRONG ONCE. js/earth-structure.js is imported by
+   js/seismic.js, not by src/main.js (the shell's line budget moved it there — see #R263), so it does
+   not exist until the seismic chunk has loaded and it is RE-CREATED by that import. Deleting it
+   before `need('seismic')` therefore did nothing at all, and --baseline silently measured the new
+   model twice. It is deleted AFTER the module is in memory; `refreshRegime()` and `buildSiteBank()`
+   both read `window.IntMapEarth` at CALL time, so removing it here is what the pre-#R263 model was. */
+if (BASELINE) await page.evaluate(() => { try { delete window.IntMapEarth; } catch (_) { window.IntMapEarth = undefined; } });
+await page.evaluate(() => JSON.stringify({ earth: typeof window.IntMapEarth }));
 
 const rows = [];
 for (const ev of events) {


### PR DESCRIPTION
#R263 でシェルの行数上限に当たって `js/earth-structure.js` の import を `src/main.js` から `js/seismic.js` へ移した。その結果このモジュールは boot 時には存在せず、seismic チャンクが読み込まれたときに**再生成される**。

`scripts/seismic-validate.mjs` の `--baseline` は `need('seismic')` の**前**に `delete window.IntMapEarth` していたので、削除は何の効果も持たず——**新モデルを2回測っていた**。

→ 削除は seismic が読み込まれた**後**に行う。`refreshRegime()` も `buildSiteBank()` も `window.IntMapEarth` を**呼び出し時に**読むので、そこで消せば #R263 以前のモデルになる。boot 待ちの条件からも `IntMapEarth` を外した（遅延ロードなので永遠に真にならず、60秒でタイムアウトしていた）。

⚠ **測り直した baseline は移設前に測った値と完全に一致した**（ln PGA −0.14/0.85・ln PGV +0.42/0.75・MMI +0.69/0.93・±0.5 29.5%・±1.0 59.9%）。移設前は eager import だったので当時の削除は正しく効いており、**PR #190 が報告した A/B はそのまま有効**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)