### PR TITLE
Add global ChatGPT handoff inbox

### DIFF
--- a/.claude/rules/gpt-handoff.md
+++ b/.claude/rules/gpt-handoff.md
@@ -5,21 +5,26 @@ This rule is permanent for IntMap.
 ## Ownership
 
 - ChatGPT is the semantic editor of the local `GPT-HANDOFF/HANDOFF.md` file.
-- The user develops requirements over time by talking to ChatGPT. ChatGPT may merge, rewrite, reorder, split, or remove requirement text as the user's intent develops.
+- The user may develop requirements either in the local Work session or in any ordinary ChatGPT chat.
+- Ordinary-chat implementation intent is staged through the owner-only GitHub inbox described by `CHATGPT-HANDOFF.md`; `scripts/handoff-inbox.mjs` imports it into the local HANDOFF.
 - Claude **must not** directly edit, rewrite, reorganize, simplify, add to, or delete requirement text in `GPT-HANDOFF/HANDOFF.md`.
-- Claude must not duplicate the handoff into a second planning/specification document.
-- The machine state maintained by `scripts/handoff.mjs` is not a second semantic communication channel; it contains only completion/verification state.
+- Claude must not treat GitHub issue #225 as a specification source. The local HANDOFF is the only semantic GPT → Claude channel.
+- The machine state maintained by `scripts/handoff.mjs` and `scripts/handoff-inbox.mjs` is status/synchronization metadata, not a second semantic communication channel.
 
 ## At the beginning of implementation work
 
 1. Run `node scripts/handoff.mjs init` if the handoff workspace does not yet exist.
-2. Run `node scripts/handoff.mjs prepare` before implementation.
-   - This synchronizes task state.
+2. Run `node scripts/handoff-inbox.mjs pull`.
+   - This imports new structured events from IntMap issue #225 into the canonical local HANDOFF.
+   - Only events authored by GitHub user `rwmqx7dwb5-arch` are trusted.
+   - Already imported events are idempotent, and task IDs already archived after user verification are not resurrected.
+3. Run `node scripts/handoff.mjs prepare` before implementation.
+   - This synchronizes completion state.
    - A task whose current specification was completed by Claude **and** verified by the user is automatically archived and removed from the active HANDOFF by the deterministic bridge script.
    - Claude itself must not perform that deletion manually.
-3. Read the active tasks from the canonical HANDOFF path reported by the script. The script deliberately resolves the user's main IntMap working copy (`~/OneDrive/IntMap`) when available, so parallel Claude worktrees all read the same GPT-authored handoff.
-4. Unless the user's current message explicitly narrows, replaces, or tells Claude to ignore the handoff, active HANDOFF tasks are the session-specific implementation requirements.
-5. If there are no active handoff tasks, follow the user's direct request normally.
+4. Read the active tasks from the canonical HANDOFF path reported by the script. The scripts deliberately resolve the user's main IntMap working copy (`~/OneDrive/IntMap`) when available, so parallel Claude worktrees all read the same GPT-authored handoff.
+5. Unless the user's current message explicitly narrows, replaces, or tells Claude to ignore the handoff, active HANDOFF tasks are the session-specific implementation requirements.
+6. If there are no active handoff tasks, follow the user's direct request normally.
 
 The user's explicit current instruction always outranks the handoff when they conflict.
 
@@ -52,6 +57,6 @@ Claude completion and user verification are separate states:
 
 - `GPT-HANDOFF/` is intentionally local and ignored by Git. Never commit, push, reset, clean, or overwrite it as part of normal repository work.
 - A modified or present local handoff is expected working state, not unrelated source-code dirt.
-- The completion state and archive live outside the repository under the user's home directory (`~/.intmap-handoff`) so all worktrees share the same state and routine approvals do not dirty Git.
-- Do not add handoff contents to `DEV-NOTES.md`, `Architecture.md`, issues, PR bodies, or another persistent document merely to preserve them. Git history is for product changes; the handoff is disposable implementation input.
-- The handoff bridge itself (`scripts/handoff.mjs`, this rule, launcher/config files) is normal tracked project infrastructure and follows the standard IntMap workflow when changed.
+- Completion, verification, archive, and inbox-import cursors live outside the repository under `~/.intmap-handoff`, so all worktrees share state and routine approvals do not dirty Git.
+- Issue #225 is an intake event log for ChatGPT only; do not copy its raw history into product documentation.
+- The handoff bridge itself (`scripts/handoff.mjs`, `scripts/handoff-inbox.mjs`, this rule, launcher/config files) is normal tracked project infrastructure and follows the standard IntMap workflow when changed.

--- a/.github/workflows/handoff-self-test.yml
+++ b/.github/workflows/handoff-self-test.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - 'scripts/handoff.mjs'
+      - 'scripts/handoff-inbox.mjs'
+      - 'CHATGPT-HANDOFF.md'
       - 'HANDOFF-REVIEW.cmd'
       - '.claude/rules/gpt-handoff.md'
       - '.claude/settings.json'
@@ -23,3 +25,4 @@ jobs:
         with:
           node-version: '20'
       - run: node scripts/handoff.mjs self-test
+      - run: node scripts/handoff-inbox.mjs self-test

--- a/CHATGPT-HANDOFF.md
+++ b/CHATGPT-HANDOFF.md
@@ -1,0 +1,68 @@
+# IntMap ChatGPT global handoff protocol
+
+This file defines how **any ChatGPT chat** should capture IntMap implementation intent without requiring the user to work inside a particular Project.
+
+Canonical cross-chat inbox: GitHub issue **#225 — `[SYSTEM] GPT Handoff Inbox`** in `rwmqx7dwb5-arch/IntMap`.
+
+## When to capture
+
+Capture when the user expresses an implementation/change intent for IntMap, even conversationally, for example:
+
+- “これ実装したい”
+- “さっきのやつ入れたい”
+- “Windy見てたらこれも欲しくなった”
+- “前話してたあれを実装したい”
+- “やっぱり前の案をこう変えたい”
+
+Do **not** enqueue a task when the user is only asking a factual question, discussing an idea hypothetically, or asking for an opinion without indicating that IntMap should actually be changed.
+
+## Vague references
+
+For references such as “前話してたあれ”, “さっきの”, “前の案”:
+
+1. Use the current conversation first.
+2. If the referent is not present, retrieve the user's prior conversation context/memory before asking them to repeat it.
+3. Inspect active inbox events when useful to identify an existing task ID.
+4. Resolve the intended concrete requirement and preserve the user's latest decision over older versions.
+5. If retrieval still leaves more than one materially plausible referent, ask one concise clarification rather than guessing.
+
+The user should not have to remember task IDs or say “add this to HANDOFF”.
+
+## Writing to the inbox
+
+Use the connected GitHub account and add a comment to issue #225. Only comments authored by `rwmqx7dwb5-arch` are imported locally.
+
+For a new task, generate a stable ID ending in at least three digits, preferably `IM-YYYYMMDD-NNN`. For a continuation/change to an existing active task, reuse that task's ID and publish the **full current replacement task**, not a fragmentary patch.
+
+Upsert comment:
+
+```text
+<!-- INTMAP-HANDOFF-EVENT v=1 action=upsert task=IM-20260821-001 -->
+<!-- HANDOFF:TASK id="IM-20260821-001" -->
+## IM-20260821-001 — Short title
+
+### Requirements
+- Concrete current requirements, merged with the user's prior decisions.
+
+### Done when
+- Observable acceptance criteria.
+<!-- HANDOFF:END id="IM-20260821-001" -->
+<!-- INTMAP-HANDOFF-EVENT-END -->
+```
+
+If the user explicitly abandons an active not-yet-verified task, publish:
+
+```text
+<!-- INTMAP-HANDOFF-EVENT v=1 action=cancel task=IM-20260821-001 -->
+<!-- INTMAP-HANDOFF-EVENT-END -->
+```
+
+Do not put secrets, credentials, private data, or raw conversation transcripts in the public issue. Convert the user's intent into the minimum implementation specification needed by Claude.
+
+## Local import and Claude boundary
+
+`scripts/handoff-inbox.mjs pull` imports only new trusted events into `GPT-HANDOFF/HANDOFF.md`. It keeps a per-task comment cursor outside the repository, so repeatedly pulling does not overwrite later local Work edits unless a newer ordinary-chat event for that same task arrives.
+
+Claude never reads issue #225 as requirements. Claude first pulls the inbox, then reads the local HANDOFF. Therefore the local `HANDOFF.md` remains the only semantic GPT → Claude communication file.
+
+Fully user-verified task IDs are archived locally; old issue events cannot resurrect them. If a completed idea genuinely needs new work later, create a new task ID.

--- a/HANDOFF-REVIEW.cmd
+++ b/HANDOFF-REVIEW.cmd
@@ -7,5 +7,11 @@ if errorlevel 1 (
   pause
   exit /b 1
 )
+node scripts\handoff-inbox.mjs pull
+if errorlevel 1 (
+  echo.
+  echo Could not sync the global GPT inbox. Existing local tasks are unchanged.
+  pause
+)
 node scripts\handoff.mjs ui
 if errorlevel 1 pause

--- a/scripts/handoff-inbox.mjs
+++ b/scripts/handoff-inbox.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
+const REPOSITORY = 'rwmqx7dwb5-arch/IntMap';
+const ISSUE_NUMBER = 225;
+const TRUSTED_AUTHOR = 'rwmqx7dwb5-arch';
+const VALID_ID = /^[A-Za-z][A-Za-z0-9_-]*-\d{3,}$/;
+const TASK_RE = /<!--\s*HANDOFF:TASK\s+id="([A-Za-z0-9_-]+)"\s*-->\s*([\s\S]*?)<!--\s*HANDOFF:END\s+id="\1"\s*-->/g;
+const EVENT_RE = /<!--\s*INTMAP-HANDOFF-EVENT\s+v=1\s+action=(upsert|cancel)\s+task=([A-Za-z0-9_-]+)\s*-->\s*([\s\S]*?)<!--\s*INTMAP-HANDOFF-EVENT-END\s*-->/g;
+
+function canonicalRepoRoot() {
+  if (process.env.INTMAP_CANONICAL_REPO) return path.resolve(process.env.INTMAP_CANONICAL_REPO);
+  const oneDrive = path.join(os.homedir(), 'OneDrive', 'IntMap');
+  if (existsSync(path.join(oneDrive, 'CLAUDE.md'))) return oneDrive;
+  return REPO_ROOT;
+}
+
+function makeContext(overrides = {}) {
+  const repoRoot = overrides.repoRoot || canonicalRepoRoot();
+  const handoffDir = overrides.handoffDir || process.env.INTMAP_HANDOFF_DIR || path.join(repoRoot, 'GPT-HANDOFF');
+  const stateDir = overrides.stateDir || process.env.INTMAP_HANDOFF_STATE_DIR || path.join(os.homedir(), '.intmap-handoff');
+  return {
+    repoRoot,
+    handoffDir,
+    handoffFile: path.join(handoffDir, 'HANDOFF.md'),
+    stateDir,
+    archiveFile: path.join(stateDir, 'archive.md'),
+    inboxStateFile: path.join(stateDir, 'inbox-state.json'),
+  };
+}
+
+async function writeAtomic(file, content) {
+  await mkdir(path.dirname(file), { recursive: true });
+  const temp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(temp, content, 'utf8');
+  try {
+    const { rename } = await import('node:fs/promises');
+    await rename(temp, file);
+  } catch (error) {
+    await rm(temp, { force: true });
+    throw error;
+  }
+}
+
+function ensureHandoffInitialized(ctx) {
+  if (existsSync(ctx.handoffFile)) return;
+  const result = spawnSync(process.execPath, [path.join(ctx.repoRoot, 'scripts', 'handoff.mjs'), 'init'], {
+    cwd: ctx.repoRoot,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      INTMAP_HANDOFF_DIR: ctx.handoffDir,
+      INTMAP_HANDOFF_STATE_DIR: ctx.stateDir,
+      INTMAP_CANONICAL_REPO: ctx.repoRoot,
+    },
+  });
+  if (result.status !== 0 || !existsSync(ctx.handoffFile)) {
+    throw new Error('Could not initialize the local HANDOFF workspace.');
+  }
+}
+
+async function readInboxState(ctx) {
+  await mkdir(ctx.stateDir, { recursive: true });
+  if (!existsSync(ctx.inboxStateFile)) return { version: 1, applied: {} };
+  const parsed = JSON.parse(await readFile(ctx.inboxStateFile, 'utf8'));
+  if (!parsed || parsed.version !== 1 || typeof parsed.applied !== 'object' || !parsed.applied) {
+    throw new Error(`Unsupported inbox state: ${ctx.inboxStateFile}`);
+  }
+  return parsed;
+}
+
+function archivedTaskIds(text) {
+  const ids = new Set();
+  TASK_RE.lastIndex = 0;
+  let match;
+  while ((match = TASK_RE.exec(text || ''))) ids.add(match[1]);
+  return ids;
+}
+
+function taskRanges(document) {
+  const out = new Map();
+  TASK_RE.lastIndex = 0;
+  let match;
+  while ((match = TASK_RE.exec(document))) {
+    out.set(match[1], { start: match.index, end: match.index + match[0].length, raw: match[0] });
+  }
+  return out;
+}
+
+function parseCommentEvents(comment) {
+  if (comment?.user?.login !== TRUSTED_AUTHOR) return [];
+  const body = String(comment?.body || '');
+  const events = [];
+  EVENT_RE.lastIndex = 0;
+  let match;
+  while ((match = EVENT_RE.exec(body))) {
+    const [, action, taskId, payload] = match;
+    if (!VALID_ID.test(taskId)) continue;
+    if (action === 'cancel') {
+      events.push({ action, taskId, commentId: Number(comment.id), rawTask: null });
+      continue;
+    }
+    const tasks = [...payload.matchAll(new RegExp(TASK_RE.source, 'g'))];
+    if (tasks.length !== 1 || tasks[0][1] !== taskId) continue;
+    events.push({ action, taskId, commentId: Number(comment.id), rawTask: tasks[0][0].trim() });
+  }
+  return events;
+}
+
+async function fetchAllComments() {
+  const [owner, repo] = REPOSITORY.split('/');
+  const all = [];
+  for (let page = 1; page <= 50; page += 1) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/issues/${ISSUE_NUMBER}/comments?per_page=100&page=${page}`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'IntMap-handoff-inbox',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (!response.ok) throw new Error(`GitHub inbox fetch failed: HTTP ${response.status}`);
+    const pageItems = await response.json();
+    if (!Array.isArray(pageItems)) throw new Error('GitHub inbox returned an unexpected payload.');
+    all.push(...pageItems);
+    if (pageItems.length < 100) break;
+  }
+  return all;
+}
+
+async function applyComments(ctx, comments, { quiet = false } = {}) {
+  ensureHandoffInitialized(ctx);
+  const [document, state, archive] = await Promise.all([
+    readFile(ctx.handoffFile, 'utf8'),
+    readInboxState(ctx),
+    existsSync(ctx.archiveFile) ? readFile(ctx.archiveFile, 'utf8') : Promise.resolve(''),
+  ]);
+
+  const archived = archivedTaskIds(archive);
+  const events = comments
+    .flatMap(parseCommentEvents)
+    .filter((event) => Number.isFinite(event.commentId))
+    .sort((a, b) => a.commentId - b.commentId);
+
+  let nextDocument = document;
+  let appliedCount = 0;
+  let ignoredArchived = 0;
+
+  for (const event of events) {
+    const lastApplied = Number(state.applied[event.taskId] || 0);
+    if (event.commentId <= lastApplied) continue;
+
+    if (archived.has(event.taskId)) {
+      state.applied[event.taskId] = event.commentId;
+      ignoredArchived += 1;
+      continue;
+    }
+
+    const ranges = taskRanges(nextDocument);
+    const existing = ranges.get(event.taskId);
+
+    if (event.action === 'cancel') {
+      if (existing) {
+        nextDocument = `${nextDocument.slice(0, existing.start)}${nextDocument.slice(existing.end)}`
+          .replace(/\n{4,}/g, '\n\n\n')
+          .trimEnd() + '\n';
+      }
+    } else if (existing) {
+      nextDocument = `${nextDocument.slice(0, existing.start)}${event.rawTask}${nextDocument.slice(existing.end)}`;
+    } else {
+      nextDocument = `${nextDocument.trimEnd()}\n\n${event.rawTask}\n`;
+    }
+
+    state.applied[event.taskId] = event.commentId;
+    appliedCount += 1;
+  }
+
+  if (nextDocument !== document) await writeAtomic(ctx.handoffFile, nextDocument);
+  await writeAtomic(ctx.inboxStateFile, `${JSON.stringify(state, null, 2)}\n`);
+
+  if (!quiet) {
+    console.log(`Global GPT inbox: ${appliedCount} new event(s) applied from IntMap issue #${ISSUE_NUMBER}.`);
+    if (ignoredArchived) console.log(`Ignored ${ignoredArchived} event(s) for already user-verified task IDs.`);
+    console.log(`Local handoff: ${ctx.handoffFile}`);
+  }
+  return { appliedCount, ignoredArchived, document: nextDocument, state };
+}
+
+async function pull(ctx) {
+  const comments = await fetchAllComments();
+  return applyComments(ctx, comments);
+}
+
+async function selfTest() {
+  const temp = await mkdtemp(path.join(os.tmpdir(), 'intmap-handoff-inbox-'));
+  const ctx = makeContext({
+    repoRoot: REPO_ROOT,
+    handoffDir: path.join(temp, 'handoff'),
+    stateDir: path.join(temp, 'state'),
+  });
+  await mkdir(ctx.handoffDir, { recursive: true });
+  await mkdir(ctx.stateDir, { recursive: true });
+  await writeFile(ctx.handoffFile, '# Test\n\n<!-- HANDOFF:TASK id="IM-20260821-001" -->\n## IM-20260821-001 — Local draft\n\n### Requirements\n- local\n\n### Done when\n- local\n<!-- HANDOFF:END id="IM-20260821-001" -->\n', 'utf8');
+
+  const event = (id, body, user = TRUSTED_AUTHOR) => ({ id, user: { login: user }, body });
+  const upsert = (taskId, title, detail) => `<!-- INTMAP-HANDOFF-EVENT v=1 action=upsert task=${taskId} -->\n<!-- HANDOFF:TASK id="${taskId}" -->\n## ${taskId} — ${title}\n\n### Requirements\n- ${detail}\n\n### Done when\n- done\n<!-- HANDOFF:END id="${taskId}" -->\n<!-- INTMAP-HANDOFF-EVENT-END -->`;
+  const cancel = (taskId) => `<!-- INTMAP-HANDOFF-EVENT v=1 action=cancel task=${taskId} -->\n<!-- INTMAP-HANDOFF-EVENT-END -->`;
+
+  const comments = [
+    event(10, upsert('IM-20260821-001', 'Blocked attacker', 'bad'), 'someone-else'),
+    event(11, upsert('IM-20260821-001', 'Global replacement', 'new requirement')),
+    event(12, upsert('IM-20260821-002', 'Second task', 'second requirement')),
+  ];
+
+  const first = await applyComments(ctx, comments, { quiet: true });
+  if (first.appliedCount !== 2) throw new Error(`self-test: expected 2 applied events, got ${first.appliedCount}`);
+  if (!first.document.includes('Global replacement') || first.document.includes('Blocked attacker')) {
+    throw new Error('self-test: trusted-author replacement failed');
+  }
+  if (!first.document.includes('Second task')) throw new Error('self-test: new task append failed');
+
+  const second = await applyComments(ctx, comments, { quiet: true });
+  if (second.appliedCount !== 0) throw new Error('self-test: inbox import is not idempotent');
+
+  const third = await applyComments(ctx, [...comments, event(13, cancel('IM-20260821-002'))], { quiet: true });
+  if (third.document.includes('Second task')) throw new Error('self-test: cancel did not remove task');
+
+  await writeFile(ctx.archiveFile, '\n<!-- HANDOFF:TASK id="IM-20260821-003" -->\narchived\n<!-- HANDOFF:END id="IM-20260821-003" -->\n', 'utf8');
+  const fourth = await applyComments(ctx, [...comments, event(13, cancel('IM-20260821-002')), event(14, upsert('IM-20260821-003', 'Should stay archived', 'no resurrection'))], { quiet: true });
+  if (fourth.document.includes('Should stay archived')) throw new Error('self-test: archived task was resurrected');
+
+  await rm(temp, { recursive: true, force: true });
+  console.log('handoff-inbox self-test passed');
+}
+
+const command = process.argv[2] || 'pull';
+const ctx = makeContext();
+
+try {
+  if (command === 'pull') await pull(ctx);
+  else if (command === 'self-test') await selfTest();
+  else throw new Error('Usage: node scripts/handoff-inbox.mjs [pull|self-test]');
+} catch (error) {
+  console.error(`handoff-inbox: ${error.message}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Extends the existing GPT → Claude handoff so IntMap implementation intent can be captured from ordinary ChatGPT chats, not only the local Work session.

- Adds owner-only GitHub issue #225 as the cross-chat intake event log.
- Adds `scripts/handoff-inbox.mjs` to import only new trusted upsert/cancel events into the local `GPT-HANDOFF/HANDOFF.md`.
- Keeps local Work edits safe with per-task comment cursors; an old inbox event is never re-applied over later local edits.
- Prevents completed/user-verified task IDs from being resurrected.
- Documents how ChatGPT should resolve vague references such as “前話してたあれを実装したい”: current chat → prior conversation context/memory → active inbox; ask only if the referent remains materially ambiguous.
- Claude automatically pulls the global inbox before `handoff.mjs prepare`, while still treating the local HANDOFF as the only semantic GPT → Claude specification.
- The one-click review launcher also syncs the inbox first.
- Adds only a tiny self-test to the existing handoff test job; normal `npm test` budget is unchanged.