### PR TITLE
R405 追記: cron を触る migration は cron.job を直接 UPDATE できない（CI は緑・本番で permission denied）

### DIFF
--- a/supabase/migrations/20260824220000_r405_news_feeds.sql
+++ b/supabase/migrations/20260824220000_r405_news_feeds.sql
@@ -150,20 +150,24 @@ begin
     return;
   end if;
 
-  for j in select jobid, jobname, command from cron.job
-            where jobname in ('news-ingest-translate', 'news-ingest-summarise') loop
+  for j in select jobid, jobname, command from cron.job where jobname = 'news-ingest-translate' loop
     newcmd := replace(j.command, '"stages":["translate"]', '"stages":["summarise"]');
-    if newcmd <> j.command then
-      perform cron.alter_job(j.jobid, command := newcmd);
-      touched := touched + 1;
+    if newcmd = j.command then
+      raise notice 'news-ingest-translate does not carry a ["translate"] stage list — leaving it alone';
+      continue;
     end if;
-    if j.jobname = 'news-ingest-translate' then
-      perform cron.alter_job(j.jobid, schedule := '13 * * * *');
-      update cron.job set jobname = 'news-ingest-summarise' where jobid = j.jobid;
-    end if;
+    /* ⚠⚠⚠ **`update cron.job` ではなく `cron.schedule`。** 実測 (2026-08-24): Management API の
+       login role は `cron.job` に直接 UPDATE できず、`permission denied for table job` で
+       **migration ごとロールバックする**（適用は 1 トランザクションなので、部分適用はしない）。
+       `cron.schedule` は同名の job を置き換えるので、名前を変える操作もこれで書ける。
+       ⚠ **command は値として渡すだけ**——秘密 (`x-news-ingest-secret`) は DB の外へ出ないし、
+         この migration が書き直すのは**段の一覧の文字列だけ**である。 */
+    perform cron.schedule('news-ingest-summarise', '13 * * * *', newcmd);
+    perform cron.unschedule(j.jobid);
+    touched := touched + 1;
   end loop;
 
   if touched = 0 then
-    raise notice 'no news-ingest-translate job carried a ["translate"] stage list — nothing to repoint';
+    raise notice 'no news-ingest-translate job to repoint — already done, or pg_cron holds no such job';
   end if;
 end $$;

--- a/tests/r405-checks.test.mjs
+++ b/tests/r405-checks.test.mjs
@@ -27,6 +27,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readLF } from '../scripts/eol.mjs';
@@ -428,4 +429,34 @@ test('⑮ a stored summary whose cited outlet is no longer a member is not shown
      ⚠ ブラウザ側の証拠は `tests/r405.spec.js` ①。ここはその静的な裏取りである。 */
   assert.doesNotMatch(list, /card\.querySelector\('\.btn-read'\)\.onclick/,
     'decorate() が外しうる要素に、取れた確認なしで onclick を代入している');
+});
+
+/* ── ⑯ cron は API から動かせる書き方で書く ──────────────────────────────
+   ⚠⚠⚠ **実測 (2026-08-24・本番)**: migration を Management API から適用する経路
+   (`supabase db query --file … --linked`) の login role は `cron.job` に**直接
+   UPDATE できない** —— `permission denied for table job` で **migration ごと
+   ロールバックする**。適用は 1 トランザクションなので部分適用にはならないが、
+   「CI では緑・本番では 1 行も入らない」という形になる（CI に pg_cron は無いので、
+   その do-block は `to_regclass` で自分を飛ばして通ってしまう）。
+   ⇒ cron を触る migration は `cron.schedule` / `cron.unschedule` /
+     `cron.alter_job` だけを使う。⚠ #R404 の migration も同じ規則で書かれている。
+   ⚠ この検査は「本番で通るか」を測れない——測れるのは**通らないと分かっている書き方を
+     していないこと**である。そこは正直に言っておく。 */
+test('⑯ cron を触る migration は cron.job を直接 UPDATE しない（API の role には権限が無い）', () => {
+  const dir = path.join(ROOT, "supabase", "migrations");
+  const offenders = [];
+  for (const f of fs.readdirSync(dir).filter((n) => n.endsWith(".sql"))) {
+    /* ⚠ **散文に当たらせない。** stripSqlComments が外すのは行コメントだけなので、
+       この規則の理由を説明したブロックコメントの中の «update cron.job» に検査が答えて
+       しまう（このリポジトリで 13 回目の形）。⇒ ブロックコメントも先に外す。 */
+    const sql = stripSqlComments(readLF(path.join(dir, f))).replace(/\/\*[\s\S]*?\*\//g, " ");
+    /* `update cron.job …` と `insert into cron.job …` / `delete from cron.job …` */
+    if (/\b(?:update|delete\s+from|insert\s+into)\s+cron\.job\b/i.test(sql)) offenders.push(f);
+  }
+  assert.deepEqual(offenders, [],
+    "cron.job を直接書き換える migration は本番で permission denied になる: " + offenders.join(", "));
+  /* このラウンドの migration が、実際に使ってよい関数のほうを呼んでいること。 */
+  const mine = stripSqlComments(rd(MIGRATION)).replace(/\/\*[\s\S]*?\*\//g, " ");
+  assert.match(mine, /perform\s+cron\.schedule\(/, "cron.schedule を呼んでいない");
+  assert.match(mine, /perform\s+cron\.unschedule\(/, "古い job を外していない");
 });


### PR DESCRIPTION
## 何が起きたか

#R405 の migration を**本番へ適用したら落ちた** —— CI は緑だったのに:

```
ERROR: 42501: permission denied for table job
CONTEXT: SQL statement "update cron.job set jobname = 'news-ingest-summarise' where jobid = j.jobid"
```

Management API 経由の適用（`supabase db query --file … --linked`・DB パスワード不要の経路）の
login role は `cron.job` に**直接 UPDATE できない**。適用は 1 トランザクションなので
**部分適用にはならず**、本番は 1 行も動いていない状態でロールバックした。

⚠⚠⚠ **CI が緑だったのは、CI に pg_cron が無いから** —— その do-block は
`to_regclass('cron.job') is null` で自分を飛ばして通る。つまり
**「CI では緑・本番では 1 行も入らない」**という形だった。

## 直したもの

- migration の cron ブロックを `cron.schedule` / `cron.unschedule` に書き換えた。
  `cron.schedule` は同名の job を置き換えるので、**名前を変える操作もこれで書ける**。
  ⚠ command は**値として渡すだけ**なので、`x-news-ingest-secret` は DB の外へ出ないし、
  この migration が書き直すのは**段の一覧の文字列だけ**である。
- `tests/r405-checks.test.mjs ⑯` —— **どの migration も `cron.job` を直接
  UPDATE / INSERT / DELETE しない**。⚠ **3 通りに変異させて赤を実測**した。
  ⚠ 最初の版は**自分の説明コメントの中の «update cron.job» に答えて**赤くなった
  （このリポジトリで 13 回目の形）。⇒ ブロックコメントも先に外す。

## 本番の状態（書き換えた版を適用したあと・実測）

```
feeds_total        38   /  feeds_enabled 36
bloomberg_direct    5   /  bloomberg_google_on 0
cnn_still_enabled true       ← 無効化していない。last_error に実測を記録しただけ
cron: news-ingest-summarise @ 13 * * * *  |  news-ingest-tick @ */20 * * * *
```

`supabase migration repair --status applied 20260824220000` も実行済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
