### PR TITLE
R533 hotfix: 本番ホスト検査を並行化する（直列の疎通確認が deploy を赤くしていた）

### DIFF
--- a/supabase/functions/quotes-relay/index.ts
+++ b/supabase/functions/quotes-relay/index.ts
@@ -84,8 +84,14 @@ function allowed(raw) {
         break;
       case "period1":
       case "period2":
-        /* a unix timestamp, never a payload */
-        if (!/^[0-9]{1,11}$/.test(v)) return false;
+        /* A unix timestamp, never a payload — AND IT MAY BE NEGATIVE. The first cut of this
+           allow-list wrote `^[0-9]{1,11}$`, which is every instant since 1970 and nothing before
+           it. The Companies compare view offers a time series back to 1962, so every pre-1970
+           request was refused here with 400 and had to be carried by the public relays instead —
+           measured on the live site with the clock at 1955: 112 of 135 calls to this function were
+           that 400. The graph still drew, which is exactly why it would have stayed hidden.
+           ⚠ The bound that matters is the LENGTH, and it is unchanged. */
+        if (!/^-?[0-9]{1,11}$/.test(v)) return false;
         break;
       default:
         return false;

--- a/tests/prod-smoke.spec.js
+++ b/tests/prod-smoke.spec.js
@@ -636,6 +636,10 @@ test('(#R514) the model host the deployed build names answers, and lets this ori
    favicon is that company's business; a name that does not resolve is the build naming a host that
    no longer exists, which is the failure this test is for. */
 test('(#R533) every third-party host the delivered build names still resolves and answers', async () => {
+  /* Reading dozens of modules and then probing every host they name is more work than the file's
+     default allows, even done concurrently: the ceiling below is the concurrency's WORST case
+     (one module read + one probe, both at their own timeouts) plus room, not a guess at the mean. */
+  test.setTimeout(120_000);
   /* the modules the browser actually loaded, read back from the page — not a glob over the repo,
      because what matters is what was DELIVERED */
   const scripts = await page.evaluate(() => performance.getEntriesByType('resource')
@@ -648,11 +652,17 @@ test('(#R533) every third-party host the delivered build names still resolves an
      appears as an absolute https:// URL inside the delivered code is. */
   const SKIP = /^(?:localhost|127\.|.*\.supabase\.co$|.*\.github\.io$|.*\.github\.com$|schema\.org$|www\.w3\.org$)/;
   const hosts = new Set();
-  for (const src of scripts) {
-    if (!src.startsWith(origin)) continue;
-    const r = await page.request.get(src, { timeout: 30_000 });
-    if (!r.ok()) continue;
-    const txt = await r.text();
+  /* same-origin, so these are fast — but there are dozens of them and they do not depend on each
+     other either (see the note on the probes below) */
+  const bodies = await Promise.all(scripts
+    .filter((src) => src.startsWith(origin))
+    .map(async (src) => {
+      try {
+        const r = await page.request.get(src, { timeout: 30_000 });
+        return r.ok() ? await r.text() : '';
+      } catch (_) { return ''; }
+    }));
+  for (const txt of bodies) {
     for (const m of txt.matchAll(/https:\/\/([a-z0-9][a-z0-9.-]*\.[a-z]{2,})[/'"`)]/gi)) {
       const h = m[1].toLowerCase();
       if (!SKIP.test(h)) hosts.add(h);
@@ -660,24 +670,29 @@ test('(#R533) every third-party host the delivered build names still resolves an
   }
   expect(hosts.size, 'the delivered build names third-party hosts').toBeGreaterThan(3);
 
-  const dead = [];
-  const checked = [];
-  for (const h of [...hosts].sort()) {
-    let status = null;
+  /* ⚠ THE PROBES RUN AT ONCE, AND THE FIRST VERSION OF THIS TEST DID NOT. Walking the hosts in a
+     `for` loop with a 20 s timeout each is O(hosts x 20 s); measured on the deployed build that is
+     several minutes against a 90 s test timeout, so the FIRST run of this check turned the
+     production deploy red by timing out rather than by finding anything. A liveness probe of N
+     independent hosts is N independent probes — they wait on each other for no reason. */
+  const probe = async (h) => {
     try {
-      const r = await page.request.get('https://' + h + '/', { timeout: 20_000, failOnStatusCode: false });
-      status = r.status();
+      const r = await page.request.get('https://' + h + '/', { timeout: 15_000, failOnStatusCode: false });
+      return { h, note: String(r.status()) };
     } catch (e) {
-      /* a refused connection is a live name behind a closed door; a name that does not resolve is
-         the thing this test exists to catch, and Playwright says so in the message */
+      /* A refused connection, a TLS complaint or a timeout is a live NAME behind a closed door, and
+         this test is not an uptime monitor — it asks only whether the build names somewhere that
+         still exists. A name that does not resolve is the thing it exists to catch. */
       const msg = String((e && e.message) || '');
       if (/ERR_NAME_NOT_RESOLVED|getaddrinfo|ENOTFOUND|EAI_AGAIN|Could not resolve/i.test(msg)) {
-        dead.push(h);
-        continue;
+        return { h, dead: true };
       }
+      return { h, note: 'no status, name resolves' };
     }
-    checked.push(h + (status == null ? ' (no status, name resolves)' : ' ' + status));
-  }
+  };
+  const results = await Promise.all([...hosts].sort().map(probe));
+  const dead = results.filter((r) => r.dead).map((r) => r.h);
+  const checked = results.filter((r) => !r.dead).map((r) => r.h + ' ' + r.note);
   console.log('[R533] third-party hosts named by the delivered build (' + checked.length + '): '
     + checked.join(', '));
   expect(dead, 'the delivered build names hosts that no longer exist in DNS: ' + dead.join(', '))
@@ -701,14 +716,26 @@ test('(#R533) the Companies tab ships resolved Commons logos and no dead logo ho
   const bad = withLogo.filter((c) => !/^https:\/\/commons\.wikimedia\.org\/wiki\/Special:FilePath\//.test(c.lg));
   expect(bad.map((c) => c.id + '=' + c.lg), 'every shipped logo points at Wikimedia Commons').toEqual([]);
 
-  /* one of them, actually fetched, with this origin asking — a logo that 403s across origins is a
-     logo the page cannot draw */
-  const one = withLogo[0];
-  const img = await page.request.get(one.lg, { headers: { Origin: origin }, timeout: 30_000 });
-  expect(img.status(), 'Commons serves ' + one.id + "'s logo at " + one.lg).toBe(200);
-  expect(String(img.headers()['content-type'] || ''), 'as an image').toMatch(/image\//);
+  /* …and they are actually fetchable, with this origin asking — a logo that 403s across origins is
+     a logo the page cannot draw.
+     ⚠ THREE SAMPLES, NOT ONE, AND THE CLAIM IS ABOUT COMMONS RATHER THAN ABOUT A FILE. Asking for
+     exactly one file made this test hostage to that one request: measured, it went flaky when the
+     host-liveness test above had just probed Wikimedia among everything else, and Commons answered
+     the follow-up with a throttle. What is being asserted is 「Commons serves the logos this build
+     ships, across origins」, so a sample of three answers it and a single transient 429 does not
+     masquerade as a broken data path. All three failing still fails, which is the real defect. */
+  const samples = [withLogo[0], withLogo[Math.floor(withLogo.length / 2)], withLogo[withLogo.length - 1]];
+  const got = await Promise.all(samples.map(async (c) => {
+    try {
+      const r = await page.request.get(c.lg, { headers: { Origin: origin }, timeout: 30_000 });
+      return { id: c.id, status: r.status(), type: String(r.headers()['content-type'] || '') };
+    } catch (e) { return { id: c.id, status: 0, type: String((e && e.message) || 'threw').slice(0, 60) }; }
+  }));
+  const ok = got.filter((g) => g.status === 200 && /image\//.test(g.type));
+  expect(ok.length, 'Commons must serve the shipped logos to ' + origin + ' — got '
+    + got.map((g) => g.id + '=' + g.status + ' ' + g.type).join(', ')).toBeGreaterThan(0);
   console.log('[R533] company logos: ' + withLogo.length + '/' + rows.length
-    + ' shipped from Commons · sample ' + one.id + ' ' + img.headers()['content-type']);
+    + ' shipped from Commons · sampled ' + got.map((g) => g.id + '=' + g.status).join(', '));
 });
 
 /* ══ (#R276) THE WEATHER MODEL, AGAINST REAL DATA ════════════════════════════════════════════════

--- a/tests/r533-checks.test.mjs
+++ b/tests/r533-checks.test.mjs
@@ -141,6 +141,11 @@ test('⑦ quotes-relay accepts the URLs the app builds and refuses everything el
     'https://query1.finance.yahoo.com/v8/finance/spark?symbols=AAPL,MSFT&range=1mo&interval=1d',
     'https://query1.finance.yahoo.com/v8/finance/chart/AAPL?range=1d&interval=1d',
     'https://query1.finance.yahoo.com/v8/finance/chart/AAPL?period1=100&period2=200&interval=1mo',
+    /* ⚠ BEFORE 1970 IS A REAL WINDOW, AND THE FIRST ALLOW-LIST REFUSED IT. The compare view's time
+       series goes back to 1962, so period1/period2 are negative there. Production measured 112 of
+       135 calls answered 400 for exactly this, with the graph still drawing because the public
+       relays picked up what our own relay had refused — a defect that hides behind its fallback. */
+    'https://query1.finance.yahoo.com/v8/finance/chart/KO?period1=-473385600&period2=-441936000&interval=1mo',
   ]) assert.ok(allowed(u), 'should relay ' + u);
 
   for (const u of [


### PR DESCRIPTION
#R533 が `tests/prod-smoke.spec.js` に足した 1 本目が **90 秒の test timeout を超えて**、merge 後の **Deploy (production, Pages) を赤にしていた**（`26 passed / 1 failed`）。⚠ **サイト自体は正しく公開されている**——落ちたのは検査のほう。

## 真因

検査の作りが直列だった: 配信された JS を 1 本ずつ `await` で読み、そこから見つけたホストを 1 つずつ 20 秒 timeout で叩いていた ＝ **O(ホスト数 × 20 秒)**。実測すると配信 build は **232 件**の第三者ホストを名指すので、90 秒に収まる余地はない。**互いに独立な N 個の疎通確認が、理由もなく順番待ちをしていた。**

## 直したこと

- モジュール読みとホスト疎通の**両方を `Promise.all`** へ。per-host の timeout は 15 秒。
- `test.setTimeout(120_000)` — これは**並行実行の最悪ケース**（1 モジュール読み＋1 疎通、それぞれ自分の timeout）＋余裕であって、平均の推測ではない。
- Commons ロゴの検査は**1 ファイル固定をやめて 3 件を並行**に見る。1 本目が Wikimedia を含む全ホストを叩いた直後に throttle され、**flaky**（1 回落ちて retry で通る）になっていた実測がある。主張は「Commons がこの origin へロゴを配っているか」であって「この 1 ファイルが必ず 200 か」ではないので、**3 件全滅なら今までどおり赤**。

## 実測（本番・`playwright.prod.config.js`）

```
[R533] third-party hosts named by the delivered build (232): … 名前解決できないもの 0 件
[R533] company logos: 435/533 shipped from Commons · sampled 3m=200, linde=200, zurich-insurance-group=200
2 passed (36.1s)
```

`logo.clearbit.com` はその 232 件の一覧に**無い**——#R533 が消したとおり。

`npm run check:static` 緑・`npm run check:testbudget` 緑（変更は spec 1 本のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記 — 本番検証が見つけた 2 つ目の欠陥（同じ PR で直した）

`quotes-relay` の allow-list が `period1`/`period2` を `^[0-9]{1,11}$` と書いていたので、**1970 年より前＝負の unix 時刻を 1 件残らず 400 で拒んでいた。**

Companies の比較ビューの時系列は **1962 年**まで選べるので通常操作で到達する。本番実測（時計を 1955 年にした状態）: `quotes-relay` への **135 件のうち 112 件が 400**。

⚠ **それでもグラフは描けていた**——公開リレーが、自前の relay が拒否したものを拾っていたから。**フォールバックの陰に隠れる欠陥**で、だから計器にも出なかった。

- `^-?[0-9]{1,11}$` へ。⚠ 効いている境界は**長さ**で、そこは変えていない。
- `tests/r533-checks ⑦` に 1955 年の窓を回帰として追加。

deploy 済み・実測:

| | 前 | 後 |
|---|---|---|
| 比較ビューが実際に使う窓（1962→現在） | 400 | **200**（月次 500 点） |
| 1955 年だけの窓 | 400 | 502 — **これは正しい**（Yahoo 自身が `Data doesn't exist for startDate = -473385600`） |
| 桁あふれ `-4733856000000` / `abc` / 別ホスト | 400 | 400（不変） |