### PR TITLE
R628 追記: 一文字だけ逃がすのは、入力ではなく呼び出し元についての主張

### DIFF
--- a/scripts/doc-facts.mjs
+++ b/scripts/doc-facts.mjs
@@ -1755,7 +1755,12 @@ if (RULE && RULE !== 'i18n-open-gap') {
   const itemsUnder = (body, sec) => {
     /* ⚠ NO `m` FLAG. With it `$` ends at the first line break, so the lazy body matched one line
        and every item reference below looked like an address into an empty section. */
-    const re = new RegExp('(?:^|\\n)#{1,6}[ \\t]+(?:§[ \\t]*)?' + sec.replace(/\./g, '\\.') + '(?=[.．、 \\t\\n])[^\\n]*\\n([\\s\\S]*?)(?=\\n#{1,6}[ \\t]|$)');
+    /* ⚠ ESCAPE THE WHOLE METACHARACTER SET, not just the dot. `sec` can only be digits, dots and
+       `A-1` shapes today — the pattern that produced it says so — but a needle that escapes one
+       character is a claim about its caller rather than about its input, and the next caller does
+       not read this line. (CodeQL js/incomplete-sanitization said the same thing.) */
+    const lit = sec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp('(?:^|\\n)#{1,6}[ \\t]+(?:§[ \\t]*)?' + lit + '(?=[.．、 \\t\\n])[^\\n]*\\n([\\s\\S]*?)(?=\\n#{1,6}[ \\t]|$)');
     const m = body.match(re);
     if (!m) return 0;
     return Math.max(0, ...[...m[1].matchAll(/^[ \t]*(\d+)\.[ \t]/gm)].map((x) => Number(x[1])));


### PR DESCRIPTION
#586 の auto-merge が、この 1 コミットより先に発火したので追いかける。

`section-refs` の `itemsUnder` が `sec.replace(/\./g, '\.')` で節番号を正規表現へ埋めていた。
いまの `sec` は数字とドットと `A-1` の形しか取り得ない——それを produce しているパターンが
そう言っている——が、**1 文字だけ逃がす記述は「この入力は安全だ」ではなく「いまの呼び出し元は
安全だ」と言っており、次の呼び出し元はこの行を読まない。**

CodeQL `js/incomplete-sanitization`（high）が #586 で同じことを指摘していた。メタ文字集合ごと逃がす。

検証: `npm run check:docs` 緑（`section-refs: 169 cross-document §-references, all resolving`）・
`tests/r628-checks.test.mjs` 8/8 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)